### PR TITLE
Search for libraries in executable needs to be aware of symlinks

### DIFF
--- a/bin/git-cola
+++ b/bin/git-cola
@@ -24,8 +24,8 @@ def cola_init():
     """Provides access to the cola modules"""
     # Try to detect where it is run from and set prefix and the search path.
     # It is assumed that the user installed Cola using the --prefix= option
-    prefix = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
+    prefix = os.path.dirname(os.path.dirname(
+        os.path.realpath(os.path.abspath(__file__))))
     # Look for modules in the source or install trees
     cola_mod = os.path.join(prefix, 'cola', '__init__.py')
     if os.path.exists(cola_mod):


### PR DESCRIPTION
Currently git-cola uses os.path.dirname(os.path.abspath(**file**)) to find where it put its libraries. That fails when "git-cola" in PATH is a symlink to the real location, because it truncates the path relative to the link rather than the true location of the file, resulting in adding a nonsensical location to sys.path and failing to import cola.app. It needs to use os.path.realpath to resolve any link before manipulating the path.
