### PR TITLE
Fix exception when creating a branch with default parameters in create branch dialog

### DIFF
--- a/cola/widgets/createbranch.py
+++ b/cola/widgets/createbranch.py
@@ -48,6 +48,7 @@ class CreateThread(QtCore.QThread):
         track = self.opts.track
         model = self.opts.model
         results = []
+        status = 0
 
         if track and '/' in revision:
             remote = revision.split('/', 1)[0]


### PR DESCRIPTION
Use of uninitialized variable when creating branch with all defaults.
