### PR TITLE
Better branch color change heuristic

### DIFF
--- a/cola/dag/view.py
+++ b/cola/dag/view.py
@@ -849,15 +849,15 @@ class Edge(QtGui.QGraphicsItem):
         rect = QtCore.QRectF(self.source_pt, QtCore.QSizeF(width, height))
         self.bound = rect.normalized()
 
-        # Choose a new color for branchy edges
-        if self.line.length() > GraphView.y_off:
+        # Choose a new color for new branch edges
+        if self.source.x() < self.dest.x():
             color = EdgeColor.next()
-        else:
+            line = Qt.SolidLine
+        elif self.source.x() != self.dest.x():
             color = EdgeColor.current()
-
-        if self.source.x() != self.dest.x():
             line = Qt.SolidLine
         else:
+            color = EdgeColor.current()
             line = Qt.DotLine
 
         self.pen = QtGui.QPen(color, 1.0, line, Qt.SquareCap, Qt.BevelJoin)
@@ -1529,7 +1529,7 @@ class GraphView(QtGui.QGraphicsView, ViewerMixin):
             except KeyError:
                 # TODO - Handle truncated history viewing
                 pass
-            for parent in commit.parents:
+            for parent in reversed(commit.parents):
                 try:
                     parent_item = self.items[parent.sha1]
                 except KeyError:


### PR DESCRIPTION
I think this is the one we've been looking for.  It maintains branch colors,
and changes main lineage to match the branch color once the branch is
merged back in.  It also doesn't change colors every time a branch is
merged in which means you can merge back many times from the same
branch and it will remain the same color, making it easier to follow that
the merge backs are always coming from a particular (even long running
branch).  Try it out on the faceroll repo and you'll see what I mean.

---8<---

This makes our edge colors a bit less schitzophrenic by only switching
the edge color when a new branch is detected, rather than also when the
branch is merged in.  This makes the history a bit easier to follow.

It also prevents the colors from changing when multple merges are
integrated from the same lineage (such as when changes are being
continually merged in from a stable branch, the stable branch will
maintain it's edge color through repeated merge-backs, and all the
merge-back edges will be the same color as the stable branch).

Signed-off-by: Uri Okrent uokrent@gmail.com
