### PR TITLE
Wrap commit messages at 72 chars

### DIFF
--- a/cola/widgets/commitmsg.py
+++ b/cola/widgets/commitmsg.py
@@ -393,6 +393,10 @@ class CommitMessageTextEdit(HintedTextEdit):
 
         self.installEventFilter(self)
 
+        self.setLineWrapMode(QtGui.QTextEdit.FixedColumnWidth)
+        self.setLineWrapColumnOrWidth(72)
+        self.setWordWrapMode(QtGui.QTextOption.WordWrap)
+
     def eventFilter(self, obj, event):
         if event.type() == QtCore.QEvent.FocusIn:
             height = QtGui.QFontMetrics(self.font()).height() * 3


### PR DESCRIPTION
It is a fairly accepted guideline that commit messages should wrap at 72 chars.

Possible improvements :
- Same kind of thing for the commit title, which shouldn't exceed 50-60 characters.
- Wrap at 72 chars AND not at widget width.
- Get the '72' magic number out of a config file.
