### PR TITLE
status: preserve horizontal scroll across updates

### DIFF
--- a/cola/widgets/status.py
+++ b/cola/widgets/status.py
@@ -68,6 +68,7 @@ class StatusTreeWidget(QtGui.QTreeWidget):
         self.setAnimated(True)
         self.setRootIsDecorated(False)
         self.setIndentation(0)
+        self.setAutoScroll(False)
 
         self.add_item(N_('Staged'), hide=True)
         self.add_item(N_('Unmerged'), hide=True)


### PR DESCRIPTION
When a file name is too long, a horizontal scroll bar appears in the status widget. As the selection is updated, `QTreeView` tries to put the first column back in 'full view' and thus resets the scroll bar horizontal position to `0` [(source)](http://doc.qt.digia.com/4.6/qabstractitemview.html#autoScroll-prop)

This commit disables that behaviour.
`setAutoScroll(..)` is available as early as in Qt 4.0.
