### PR TITLE
Better name for desktop entry

### DIFF
--- a/share/applications/git-cola.desktop
+++ b/share/applications/git-cola.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=Cola Git GUI
+Name=Git Cola
 Comment=A highly caffeinated git GUI
 Exec=git-cola --prompt
 Icon=/usr/share/git-cola/icons/git.svg


### PR DESCRIPTION
The project is called 'git-cola', not 'cola-git'. And as it is a desktop
entry, it's obvious it must be a GUI.
