### PR TITLE
fix exception when changing font

### DIFF
--- a/cola/widgets/prefs.py
+++ b/cola/widgets/prefs.py
@@ -220,11 +220,11 @@ class SettingsFormWidget(FormWidget):
         font = self.fixed_font.currentFont()
         font.setPointSize(size)
         cmds.do(SetConfig, self.model,
-                'user', FONTDIFF, unicode(font.toString()))
+                'user', prefs.FONTDIFF, unicode(font.toString()))
 
     def current_font_changed(self, font):
         cmds.do(SetConfig, self.model,
-                'user', FONTDIFF, unicode(font.toString()))
+                'user', prefs.FONTDIFF, unicode(font.toString()))
 
 
 class PreferencesView(standard.Dialog):


### PR DESCRIPTION
FONTDIFF is found in the cola.models.prefs module, but it was being
accessed as a global name, resulting in a NameError exception.  Make the
code refer to it using prefs.FONTDIFF instead.

Signed-off-by: Daniel Harding dharding@living180.net
