### PR TITLE
dag: Add modified files list to dag

### DIFF
--- a/cola/gitcmds.py
+++ b/cola/gitcmds.py
@@ -227,15 +227,18 @@ def common_diff_opts(config=config):
     return opts
 
 
-def sha1_diff(git, sha1):
-    return git.diff(sha1+'^!', **common_diff_opts())[STDOUT]
+def sha1_diff(git, sha1, file_name=None):
+    if file_name == None:
+        return git.diff(sha1+'^!', **common_diff_opts())[STDOUT]
+    else:
+        return git.diff(sha1+'^!', file_name,  **common_diff_opts())[STDOUT]
 
 
-def diff_info(sha1, git=git):
+def diff_info(sha1, file_name=None, git=git):
     decoded = log(git, '-1', sha1, '--', pretty='format:%b').strip()
     if decoded:
         decoded += '\n\n'
-    return decoded + sha1_diff(git, sha1)
+    return decoded + sha1_diff(git, sha1, file_name)
 
 
 def diff_helper(commit=None,

--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -26,6 +26,7 @@ from cola.widgets.standard import MainWindow
 from cola.widgets.standard import TreeWidget
 from cola.widgets.diff import COMMITS_SELECTED
 from cola.widgets.diff import DiffWidget
+from cola.widgets.file import FileWidget
 
 
 def git_dag(model, args=None):
@@ -362,6 +363,7 @@ class DAGView(MainWindow):
 
         self.treewidget = CommitTreeWidget(notifier, self)
         self.diffwidget = DiffWidget(notifier, self)
+        self.filewidget = FileWidget(notifier, self)
         self.graphview = GraphView(notifier, self)
 
         self.controls_layout = QtGui.QHBoxLayout()
@@ -377,6 +379,9 @@ class DAGView(MainWindow):
         self.log_dock.setWidget(self.treewidget)
         log_dock_titlebar = self.log_dock.titleBarWidget()
         log_dock_titlebar.add_corner_widget(self.controls_widget)
+
+        self.file_dock = qtutils.create_dock(N_('File'), self)
+        self.file_dock.setWidget(self.filewidget)
 
         self.diff_dock = qtutils.create_dock(N_('Diff'), self)
         self.diff_dock.setWidget(self.diffwidget)
@@ -407,6 +412,7 @@ class DAGView(MainWindow):
         self.view_menu.addAction(self.log_dock.toggleViewAction())
         self.view_menu.addAction(self.graphview_dock.toggleViewAction())
         self.view_menu.addAction(self.diff_dock.toggleViewAction())
+        self.view_menu.addAction(self.file_dock.toggleViewAction())
         self.view_menu.addSeparator()
         self.view_menu.addAction(self.lock_layout_action)
 
@@ -418,6 +424,7 @@ class DAGView(MainWindow):
         bottom = Qt.BottomDockWidgetArea
         self.addDockWidget(left, self.log_dock)
         self.addDockWidget(right, self.graphview_dock)
+        self.addDockWidget(right, self.file_dock)
         self.addDockWidget(bottom, self.diff_dock)
 
         # Update fields affected by model

--- a/cola/widgets/file.py
+++ b/cola/widgets/file.py
@@ -1,0 +1,68 @@
+from PyQt4 import QtCore
+from PyQt4 import QtGui
+from PyQt4.QtCore import Qt, SIGNAL
+
+from cola.i18n import N_
+from cola.git import git
+from cola.git import STDOUT
+from cola.widgets.standard import TreeWidget
+from cola.widgets.diff import COMMITS_SELECTED
+from cola.widgets.diff import FILES_SELECTED
+
+class FileWidget(TreeWidget):
+
+    def __init__(self, notifier, parent):
+        TreeWidget.__init__(self, parent)
+        self.notifier = notifier
+        self.setHeaderLabels([N_('File Name'), N_('Addition'), N_('Deletion')])
+        notifier.add_observer(COMMITS_SELECTED, self.commits_selected)
+
+        self.connect(self, SIGNAL('itemSelectionChanged()'),
+                     self.selection_changed)
+
+
+    def selection_changed(self):
+        items = self.selected_items()
+        self.notifier.notify_observers(FILES_SELECTED,
+                                       [i.file_name for i in items])
+
+    def commits_selected(self, commits):
+        if len(commits) != 1:
+            return
+        commit = commits[0]
+        sha1 = commit.sha1
+        files_log = git.show(sha1, "--numstat", "--oneline")[STDOUT].splitlines()[1:]
+        self.list_files(files_log)
+
+    def list_files(self, files_log):
+        files = []
+        for f in files_log:
+            file = FileTreeWidgetItem(f)
+            files.append(file)
+        self.clear()
+        self.insertTopLevelItems(0, files)
+
+    def adjust_columns(self):
+        width = self.width()-20
+        zero = width*2/3
+        onetwo = width/6
+        self.setColumnWidth(0, zero)
+        self.setColumnWidth(1, onetwo)
+        self.setColumnWidth(2, onetwo)
+
+    def show(self):
+        self.adjust_columns()
+
+    def resizeEvent(self, e):
+        self.adjust_columns()
+
+
+class FileTreeWidgetItem(QtGui.QTreeWidgetItem):
+
+    def __init__(self, file_log, parent=None):
+        QtGui.QTreeWidgetItem.__init__(self, parent)
+        texts = file_log.split("\t")
+        self.file_name = texts[2]
+        self.setText(0, self.file_name) # file name
+        self.setText(1, texts[0]) # addition
+        self.setText(2, texts[1]) # deletion

--- a/po/git-cola.pot
+++ b/po/git-cola.pot
@@ -2042,3 +2042,15 @@ msgstr ""
 #: cola/widgets/status.py:646 cola/widgets/status.py:662
 msgid "No files selected for checkout from HEAD."
 msgstr ""
+
+#: cola/widgets/file.py:17
+msgid "File Name"
+msgstr ""
+
+#: cola/widgets/file.py:17
+msgid "Addition"
+msgstr ""
+
+#: cola/widgets/file.py:17
+msgid "Deletion"
+msgstr ""


### PR DESCRIPTION
Currently the diff viewer in dag lists all changes within a commit. There is no way to refine the diff to a single file. This is problematic for a commit which have many files modified.

Add a file widget to dag. It will display the list of modified files when a commit selected. Selecting a file in the list will make the diff viewer display the diff for that file only.

Suggested-By: @systemovich via github.com in #217

I'm not really familiar with python, so feel free to give feedback. 

In diff.py, I assigned the sha1 to the object when intercepting commits selected event. I need that sha1 when doing the file diff. I don't like that approach, but I can't think off any better solution. Passing it off from the FileWidget means I need to store the sha1 in FIleWidget, or put it in FileTreeWidgetItem (putting same sha1 in all file entries) If you have a better idea, let me know.
