### PR TITLE
ssh-askpass: Set window type to dialog

### DIFF
--- a/share/git-cola/bin/ssh-askpass
+++ b/share/git-cola/bin/ssh-askpass
@@ -61,6 +61,10 @@ proc finish {} {
 }
 
 wm title . "OpenSSH"
+set OS [lindex $tcl_platform(os) 0]
+if { $OS == "Linux" } {
+	wm attribute . "-type" "dialog"
+}
 tk::PlaceWindow .
 vwait rc
 exit $rc


### PR DESCRIPTION
On i3 window manager, ssh-askpass window is created as
full/top level window instead of floating window by default.
i3 sets dialog, utility, toolbar and splash windows to floating.

Changes ssh-askpass window type to dialog

Reported-By: aszkid via github.com in #207

Signed-off-by: Minarto Margoliono lie.r.min.g@gmail.com
