### PR TITLE
Add support for session management of window managers

### DIFF
--- a/cola/settings.py
+++ b/cola/settings.py
@@ -31,6 +31,8 @@ class Settings(object):
     bookmarks = property(lambda self: mklist(self.values['bookmarks']))
     gui_state = property(lambda self: mkdict(self.values['gui_state']))
     recent = property(lambda self: mklist(self.values['recent']))
+    session = property(lambda self: self.values['session'], 
+                       lambda self, new_value: self.values.update(session=new_value))
 
     def __init__(self, verify=git.is_git_worktree):
         """Load existing settings if they exist"""
@@ -38,6 +40,7 @@ class Settings(object):
                 'bookmarks': [],
                 'gui_state': {},
                 'recent': [],
+                'session': None,
         }
         self.verify = verify
         self.load()


### PR DESCRIPTION
Window managers can restart applications that were running when
the user logged off. This commit saves the current repository path
to the settings file if window manager requests the saving of the state.

On next startup the saved repository is loaded (if git-cola is started
in a directory without a repository).
