### PR TITLE
git: fix command windows popping up on Windows

### DIFF
--- a/cola/git.py
+++ b/cola/git.py
@@ -165,6 +165,7 @@ class Git(object):
         extra = {}
         if sys.platform == 'win32':
             command = map(replace_carot, command)
+            extra['shell'] = True
 
         # Start the process
         # Guard against thread-unsafe .git/index.lock files


### PR DESCRIPTION
Prior to commit 1109aeb4, the `Git.execute` method passed `shell=True` to `core.run_command` on Windows systems.  That commit stopped passing the `shell` parameter to `core.run_command`, with the result that every time `Git.execute` was called on Windows, a command shell window would flash on the screen.  This commit restores the pre- 1109aeb4 behavior.

Tested on Windows 7 using Python 2.7.6 and Python 3.3.5.
