### PR TITLE
Make fork() work on Windows under Python 3

### DIFF
--- a/cola/core.py
+++ b/cola/core.py
@@ -165,7 +165,11 @@ def _fork_win32(args, cwd=None):
         sh_exe = _win32_abspath('sh') or 'sh'
         argv = [sh_exe, '-c', cmdstr]
 
-    argv = [encode(arg) for arg in args]
+    if PY3:
+        # see comment in start_command()
+        argv = [decode(arg) for arg in args]
+    else:
+        argv = [encode(arg) for arg in args]
     DETACHED_PROCESS = 0x00000008 # Amazing!
     return subprocess.Popen(argv, cwd=cwd, creationflags=DETACHED_PROCESS).pid
 


### PR DESCRIPTION
Use the same approach in `_fork_win32()` that was used in commit ee990fbc for `start_command()`.
