### PR TITLE
Don't pass shell=True to core.run_command()

### DIFF
--- a/cola/core.py
+++ b/cola/core.py
@@ -90,11 +90,12 @@ def readline(fh, encoding=None):
 
 
 @interruptable
-def start_command(cmd, cwd=None, shell=False, add_env=None,
+def start_command(cmd, cwd=None, add_env=None,
                   universal_newlines=False,
                   stdin=subprocess.PIPE,
                   stdout=subprocess.PIPE,
-                  stderr=subprocess.PIPE):
+                  stderr=subprocess.PIPE,
+                  **extra):
     """Start the given command, and return a subprocess object.
 
     This provides a simpler interface to the subprocess module.
@@ -116,8 +117,8 @@ def start_command(cmd, cwd=None, shell=False, add_env=None,
     else:
         cmd = [encode(c) for c in cmd]
     return subprocess.Popen(cmd, bufsize=1, stdin=stdin, stdout=stdout,
-                            stderr=stderr, cwd=cwd, shell=shell, env=env,
-                            universal_newlines=universal_newlines)
+                            stderr=stderr, cwd=cwd, env=env,
+                            universal_newlines=universal_newlines, **extra)
 
 
 @interruptable

--- a/cola/git.py
+++ b/cola/git.py
@@ -164,8 +164,14 @@ class Git(object):
 
         extra = {}
         if sys.platform == 'win32':
-            command = map(replace_carot, command)
-            extra['shell'] = True
+            # If git-cola is invoked on Windows using "start pythonw git-cola",
+            # a console window will briefly flash on the screen each time
+            # git-cola invokes git, which is very annoying.  The code below
+            # prevents this by ensuring that any window will be hidden.
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags = subprocess.STARTF_USESHOWWINDOW
+            startupinfo.wShowWindow = subprocess.SW_HIDE
+            extra['startupinfo'] = startupinfo
 
         # Start the process
         # Guard against thread-unsafe .git/index.lock files
@@ -235,20 +241,6 @@ class Git(object):
                         "Ensure that 'git' is in your $PATH, or specify the "
                         "path to 'git' using the --git-path argument.")
             sys.exit(1)
-
-
-def replace_carot(cmd_arg):
-    """
-    Guard against the windows command shell.
-
-    In the Windows shell, a carat character (^) may be used for
-    line continuation.  To guard against this, escape the carat
-    by using two of them.
-
-    http://technet.microsoft.com/en-us/library/cc723564.aspx
-
-    """
-    return cmd_arg.replace('^', '^^')
 
 
 @memoize


### PR DESCRIPTION
On Windows, the `Git.execute()` method was passing `shell=True` to the `core.run_command()` function.  This was to avoid a console window briefly popping up on the screen each time git-cola invoked git, which could happen if git-cola was invoked using `start pythonw git-cola`.  But, using `shell=True` is generally undesirable.  This change stops passing `shell=True` and instead creates a `STARTUPINFO` structure and configures it to ensure that any child process window is hidden.

Because the Windows shell is no longer being invoked, the `replace_carot` function is no longer needed and is removed.
