### PR TITLE
Fix stdout()/stderr() helpers for Python 3

### DIFF
--- a/cola/core.py
+++ b/cola/core.py
@@ -225,11 +225,17 @@ def xopen(path, mode='r', encoding=None):
 
 
 def stdout(msg):
-    sys.stdout.write(encode(msg) + '\n')
+    msg = msg + '\n'
+    if not PY3:
+        msg = encode(msg, sys.stdout.encoding)
+    sys.stdout.write(msg)
 
 
 def stderr(msg):
-    sys.stderr.write(encode(msg) + '\n')
+    msg = msg + '\n'
+    if not PY3:
+        msg = encode(msg, sys.stderr.encoding)
+    sys.stderr.write(msg)
 
 
 @interruptable


### PR DESCRIPTION
On Python 3, the `core.stdout()` and `core.stderr()` helper functions were attempting to concatenate the message encoded as a bytestring with a unicode string containing a newline, which raises a `TypeError`.  Fix this by concatenating the newline first, and then only encoding the result if on Python 2, since Python 3 wants unicode strings anyway.
