### PR TITLE
recent: improve name of button 'Expand' 'Collapse'

### DIFF
--- a/cola/widgets/recent.py
+++ b/cola/widgets/recent.py
@@ -61,11 +61,11 @@ class RecentFileDialog(standard.Dialog):
         self.tree.setModel(self.tree_model)
 
         self.expand_button = QtGui.QPushButton()
-        self.expand_button.setText(N_('Expand'))
+        self.expand_button.setText(N_('Expand all'))
         self.expand_button.setIcon(qtutils.open_icon())
 
         self.collapse_button = QtGui.QPushButton()
-        self.collapse_button.setText(N_('Collapse'))
+        self.collapse_button.setText(N_('Collapse all'))
         self.collapse_button.setIcon(qtutils.dir_close_icon())
 
         self.edit_button = QtGui.QPushButton()


### PR DESCRIPTION
Currently the buttons to expand/collapse all items on the list is simply
named as Expand/Collapse, it is quite(?) ambiguous in English and much
more ambiguous if the translator directly translates it(ex.展開/折疊)
without patching the 'all' meaning on it(ex.全部展開/全部折疊）
Simply patch the source language should be a good idea.

Signed-off-by: Ｖ字龍(Vdragon) pika1021@gmail.com
