### PR TITLE
Makefile: generate pot under po/ instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ tags:
 	$(FIND) . -name '*.py' -print0 | xargs -0 $(CTAGS) -f tags
 
 pot:
-	$(PYTHON) setup.py build_pot -N -d .
+	$(PYTHON) setup.py build_pot -N -d po
 
 mo:
 	$(PYTHON) setup.py build_mo -f


### PR DESCRIPTION
If there's no reason to put pot under root dir we should overwrite the
orignal pot file.

Signed-off-by: Ｖ字龍(Vdragon) pika1021@gmail.com
