### PR TITLE
widgets: fix msgmerge warnings

### DIFF
--- a/cola/widgets/browse.py
+++ b/cola/widgets/browse.py
@@ -77,7 +77,7 @@ class Browser(standard.Widget):
         msg += N_('Branch: %s') % branch
         self.setToolTip(msg)
 
-        title = N_('%s: %s - Browse') % (self.model.project, branch)
+        title = N_('%(project)s: %(branch)s - Browse') % dict(project=self.model.project, branch=branch)
         if self.mode == self.model.mode_amend:
             title += ' (%s)' % N_('Amending')
         self.setWindowTitle(title)

--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -488,7 +488,7 @@ class GitDAG(MainWindow):
     def update_window_title(self):
         project = self.model.project
         if self.dag.ref:
-            self.setWindowTitle(N_('%s: %s - DAG') % (project, self.dag.ref))
+            self.setWindowTitle(N_('%(project)s: %(ref)s - DAG') % dict(project=project, ref=self.dag.ref))
         else:
             self.setWindowTitle(project + N_(' - DAG'))
 


### PR DESCRIPTION
Just to make msgmerge happy, though.
It should also slightly make those strings translator-friendly-er.
I'm not familiar with Python so it may require some review and
codingstyle tune.
Signed-off-by: Ｖ字龍(Vdragon) pika1021@gmail.com
