### PR TITLE
browse: let parenthesis to be translatable

### DIFF
--- a/cola/widgets/browse.py
+++ b/cola/widgets/browse.py
@@ -79,7 +79,7 @@ class Browser(standard.Widget):
 
         title = N_('%s: %s - Browse') % (self.model.project, branch)
         if self.mode == self.model.mode_amend:
-            title += ' (%s)' % N_('Amending')
+            title += ' %s' % N_('(Amending)')
         self.setWindowTitle(title)
 
 


### PR DESCRIPTION
Move the parenthesis into the gettext string and let the translator
determine the correct one.
For example, double-width parenthesis "（）" instead of ones in ASCII are
used in zh_TW locale.

Signed-off-by: Ｖ字龍(Vdragon) pika1021@gmail.com
