### PR TITLE
setup.py: install *.rst files instead of *.txt, trying to fix #279

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def cola_data_files():
         _app_path('share/git-cola/icons', '*.png'),
         _app_path('share/git-cola/icons', '*.svg'),
         _app_path('share/applications', '*.desktop'),
-        _app_path('share/doc/git-cola', '*.txt'),
+        _app_path('share/doc/git-cola', '*.rst'),
         _app_path('share/doc/git-cola', '*.html'),
         _package('cola'),
         _package('cola.models'),


### PR DESCRIPTION
It seems that since commit 8e0d3bb5 txt documents are rewrited using
restructured text, but setup.py wasn't updated to install them.

This commit updates setup.py to install files with rst extension
instead.

Signed-off-by: Ｖ字龍(Vdragon) pika1021@gmail.com
