### PR TITLE
Bookmark: Fix empty name when path has trailing slash

### DIFF
--- a/cola/widgets/bookmarks.py
+++ b/cola/widgets/bookmarks.py
@@ -310,5 +310,6 @@ class BookmarksTreeWidgetItem(QtGui.QTreeWidgetItem):
         QtGui.QTreeWidgetItem.__init__(self)
         self.path = path
         self.setIcon(0, icon)
-        self.setText(0, os.path.basename(path))
+        normpath = os.path.normpath(path)
+        self.setText(0, os.path.basename(normpath))
         self.setToolTip(0, path)


### PR DESCRIPTION
Normalize the path / remove redundant separator before trying to get the
folder name.

Issue Number: #288 
Reported-by: Vdragon
Signed-off-by: Minarto Margoliono lie.r.min.g@gmail.com
