### PR TITLE
tag: Display error message when creating tag with invalid name (fix issue: #286)

### DIFF
--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -1140,13 +1140,7 @@ class Tag(Command):
         Interaction.log_status(status, log_msg, err)
         if status == 0:
             self.model.update_status()
-            return True
-        else:
-            Interaction.critical(
-                    N_('Error: could not create tag "%s"') % self.name,
-                    (N_('git tag returned exit code %s') % status) +
-                    ((output+err) and ('\n\n' + output + err) or ''))
-            return False
+        return (status, output, err)
 
 
 class Unstage(Command):

--- a/cola/widgets/createtag.py
+++ b/cola/widgets/createtag.py
@@ -152,9 +152,16 @@ class CreateTag(standard.Dialog):
                                     icon=qtutils.save_icon())):
             return
 
-        if (cmds.do(cmds.Tag, tag_name, revision,
-                sign=sign_tag, message=tag_msg)):
+        status, output, err = cmds.do(cmds.Tag, tag_name, revision,
+                                      sign=sign_tag, message=tag_msg)
+
+        if status == 0:
             information(N_('Tag Created'),
                         N_('Created a new tag named "%s"') % tag_name,
                         details=tag_msg or None)
             self.accept()
+        else:
+            critical(N_('Error: could not create tag "%s"') % tag_name,
+                    (N_('git tag returned exit code %s') % status) +
+                    ((output+err) and ('\n\n' + output + err) or ''))
+


### PR DESCRIPTION
When an invalid name is supplied during tag creation, there was no error
displayed to the user. It would always say "Created a new tag named [tag
name]" even though no tag is actually created.

This change will display error message instead of tag creation message
when git tag command fails.

Reported-by: Ｖ字龍(Vdragon) pika1021@gmail.com
Signed-off-by: Minarto Margoliono lie.r.min.g@gmail.com
