### PR TITLE
po: fix all po headers from git-gui to git-cola

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -1,14 +1,17 @@
-# Copyright (C) 2007 Shawn Pearce, et al.
-# This file is distributed under the same license as the git package.
+# Translation of git-cola to Deutsch.
+# Copyright (C) 2007, 2013 Shawn Pearce, et al.
+# This file is distributed under the same license as the git-cola package.
+#
 # Christian Stimming <stimming@tuhh.de>, 2007
+# Sven Claussner <sclaussner@src.gnome.org>, 2013
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-gui\n"
-"Report-Msgid-Bugs-To: \n"
+"Project-Id-Version: git-cola VERSION\n"
+"Report-Msgid-Bugs-To: https://github.com/git-cola/git-cola/issues\n"
 "POT-Creation-Date: 2014-01-30 20:54-0800\n"
 "PO-Revision-Date: 2013-05-16 19:54+0100\n"
-"Last-Translator: Sven Claussner <<sclaussner@src.gnome.org>>\n"
+"Last-Translator: Sven Claussner <sclaussner@src.gnome.org>\n"
 "Language-Team: German\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,13 +1,14 @@
-# translation of fr.po to French
-# Translation of git-gui to French.
-# Copyright (C) 2008 Shawn Pearce, et al.
-# This file is distributed under the same license as the git package.
+# Translation of git-cola to French.
+# Copyright (C) 2008, 2011 Shawn Pearce, et al.
+# This file is distributed under the same license as the git-cola package.
 #
-# Christian Couder <chriscool@tuxfamily.org>, 2008.
+# Christian Couder <chriscool@tuxfamily.org>, 2008
+# David Aguilar <davvid@gmail.com>, 2011
+# 
 msgid ""
 msgstr ""
-"Project-Id-Version: fr\n"
-"Report-Msgid-Bugs-To: \n"
+"Project-Id-Version: git-cola VERSION\n"
+"Report-Msgid-Bugs-To: https://github.com/git-cola/git-cola/issues\n"
 "POT-Creation-Date: 2014-01-30 20:54-0800\n"
 "PO-Revision-Date: 2008-04-04 22:05+0200\n"
 "Last-Translator: Christian Couder <chriscool@tuxfamily.org>\n"

--- a/po/glossary/de.po
+++ b/po/glossary/de.po
@@ -1,11 +1,11 @@
-# Translation of git-gui glossary to German
+# Translation of git-cola glossary to German
 # Copyright (C) 2007 Shawn Pearce, et al.
-# This file is distributed under the same license as the git package.
+# This file is distributed under the same license as the git-cola package.
 # Christian Stimming <stimming@tuhh.de>, 2007
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-gui glossary\n"
+"Project-Id-Version: git-cola glossary\n"
 "POT-Creation-Date: 2007-10-19 21:43+0200\n"
 "PO-Revision-Date: 2007-10-20 15:24+0200\n"
 "Last-Translator: Christian Stimming <stimming@tuhh.de>\n"

--- a/po/glossary/it.po
+++ b/po/glossary/it.po
@@ -1,11 +1,11 @@
-# Translation of git-gui glossary to Italian
+# Translation of git-cola glossary to Italian
 # Copyright (C) 2007 Shawn Pearce, et al.
-# This file is distributed under the same license as the git package.
+# This file is distributed under the same license as the git-cola package.
 # Christian Stimming <stimming@tuhh.de>, 2007
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-gui glossary\n"
+"Project-Id-Version: git-cola glossary\n"
 "POT-Creation-Date: 2007-10-19 21:43+0200\n"
 "PO-Revision-Date: 2007-10-10 15:24+0200\n"
 "Last-Translator: Michele Ballabio <barra_cuda@katamail.com>\n"

--- a/po/glossary/zh_cn.po
+++ b/po/glossary/zh_cn.po
@@ -1,11 +1,11 @@
-# Translation of git-gui glossary to Simplified Chinese
+# Translation of git-cola glossary to Simplified Chinese
 # Copyright (C) 2007 Shawn Pearce, et al.
-# This file is distributed under the same license as the git package.
+# This file is distributed under the same license as the git-cola package.
 # Xudong Guan <xudong.guan@gmail.com> and the zh-kernel.org mailing list, 2007
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-gui glossary\n"
+"Project-Id-Version: git-cola glossary\n"
 "PO-Revision-Date: 2007-07-23 22:07+0200\n"
 "Last-Translator: Xudong Guan <xudong.guan@gmail.com>\n"
 "Language-Team: Simplified Chinese \n"

--- a/po/glossary/zh_tw.po
+++ b/po/glossary/zh_tw.po
@@ -1,4 +1,6 @@
 # Translation of git-cola glossary to Traditional Chinese(Taiwan)
+# Copyright (C) 2007 Shawn Pearce, et al.
+# This file is distributed under the same license as the git-cola package.
 # Ｖ字龍(Vdragon) <Vdragon.Taiwan@gmail.com>, 2014.
 msgid ""
 msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -1,11 +1,11 @@
-# Hungarian translations for git-gui-i package.
-# Copyright (C) 2007 THE git-gui-i'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the git-gui-i package.
+# Hungarian translations for git-cola package.
+# Copyright (C) 2007 THE git-cola'S Miklos Vajna at el.
+# This file is distributed under the same license as the git-cola package.
 # Miklos Vajna <vmiklos@frugalware.org>, 2007.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-gui-i 18n\n"
+"Project-Id-Version: git-cola VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-01-30 20:54-0800\n"
 "PO-Revision-Date: 2008-03-14 17:24+0100\n"

--- a/po/it.po
+++ b/po/it.po
@@ -1,18 +1,17 @@
-# Translation of git-gui to Italian
-# Copyright (C) 2007 Shawn Pearce
-# This file is distributed under the same license as the git-gui package.
+# Translation of git-cola to Italian
+# Copyright (C) 2007 Shawn Pearce at el.
+# This file is distributed under the same license as the git-cola package.
 # Paolo Ciarrocchi <paolo.ciarrocchi@gmail.com>, 2007
 # Michele Ballabio <barra_cuda@katamail.com>, 2007.
-# 
-# 
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: git-gui\n"
-"Report-Msgid-Bugs-To: \n"
+"Project-Id-Version: git-cola VERSION\n"
+"Report-Msgid-Bugs-To: https://github.com/git-cola/git-cola/issues\n"
 "POT-Creation-Date: 2014-01-30 20:54-0800\n"
 "PO-Revision-Date: 2008-03-12 22:12+0100\n"
-"Last-Translator: Michele Ballabio <barra_cuda@katamail.com>\n"
-"Language-Team: Italian <tp@lists.linux.it>\n"
+"Last-Translator: David Aguilar <davvid@gmail.com>\n"
+"Language-Team: Italian\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,13 +1,13 @@
-# Translation of git-gui to Japanese
-# Copyright (C) 2007 Shawn Pearce
-# This file is distributed under the same license as the git-gui package.
+# Translation of git-cola to Japanese
+# Copyright (C) 2007 Shawn Pearce at el.
+# This file is distributed under the same license as the git-cola package.
 # しらいし ななこ <nanako3@bluebottle.com>, 2007.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: git-gui\n"
-"Report-Msgid-Bugs-To: \n"
+"Project-Id-Version: git-cola VERSION\n"
+"Report-Msgid-Bugs-To: https://github.com/git-cola/git-cola/issues\n"
 "POT-Creation-Date: 2014-01-30 20:54-0800\n"
 "PO-Revision-Date: 2008-03-15 20:12+0900\n"
 "Last-Translator: しらいし ななこ <nanako3@bluebottle.com>\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,16 +1,17 @@
-# Translation of git-gui to russian
-# Copyright (C) 2007 Shawn Pearce
-# This file is distributed under the same license as the git-gui package.
+# Translation of git-cola to russian
+# Copyright (C) 2007 Shawn Pearce at el.
+# This file is distributed under the same license as the git-cola package.
 # Irina Riesen <irina.riesen@gmail.com>, 2007.
-#
+# Alex Riesen <raa.lkml@gmail.com>, 2007.
+# 
 msgid ""
 msgstr ""
-"Project-Id-Version: git-gui\n"
-"Report-Msgid-Bugs-To: \n"
+"Project-Id-Version: git-cola VERSION\n"
+"Report-Msgid-Bugs-To: https://github.com/git-cola/git-cola/issues\n"
 "POT-Creation-Date: 2014-01-30 20:54-0800\n"
 "PO-Revision-Date: 2007-10-22 22:30-0200\n"
 "Last-Translator: Alex Riesen <raa.lkml@gmail.com>\n"
-"Language-Team: Russian Translation <git@vger.kernel.org>\n"
+"Language-Team: Russian\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,16 +1,16 @@
-# Swedish translation of git-gui.
-# Copyright (C) 2007 Shawn Pearce, et al.
-# This file is distributed under the same license as the git-gui package.
+# Swedish translation of git-cola.
+# Copyright (C) 2007, 2008 Shawn Pearce, et al.
+# This file is distributed under the same license as the git-cola package.
 #
 # Peter Karlsson <peter@softwolves.pp.se>, 2007-2008.
 msgid ""
 msgstr ""
-"Project-Id-Version: sv\n"
-"Report-Msgid-Bugs-To: \n"
+"Project-Id-Version: git-cola VERSION\n"
+"Report-Msgid-Bugs-To: https://github.com/git-cola/git-cola/issues\n"
 "POT-Creation-Date: 2014-01-30 20:54-0800\n"
 "PO-Revision-Date: 2008-03-14 07:23+0100\n"
 "Last-Translator: Peter Karlsson <peter@softwolves.pp.se>\n"
-"Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
+"Language-Team: Swedish\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,7 +1,8 @@
-# Translation of git-gui to Chinese
-# Copyright (C) 2007 Shawn Pearce
-# This file is distributed under the same license as the git-gui package.
+# Translation of git-cola to Chinese
+# Copyright (C) 2007, 2008 Shawn Pearce
+# This file is distributed under the same license as the git-cola package.
 # Xudong Guan <xudong.guan@gmail.com>, 2007.
+# Eric Miao <eric.y.miao@gmail.com>, 2008.
 #
 # Please use the following translation throughout the file for consistence:
 #
@@ -17,14 +18,13 @@
 # 	amend		修正
 # 	reset		复位
 #
-# 2008-01-06 Eric Miao <eric.y.miao@gmail.com>
 # FIXME: checkout 的标准翻译
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: git-gui\n"
-"Report-Msgid-Bugs-To: \n"
+"Project-Id-Version: git-cola VERSION\n"
+"Report-Msgid-Bugs-To: https://github.com/git-cola/git-cola/issues\n"
 "POT-Creation-Date: 2014-01-30 20:54-0800\n"
 "PO-Revision-Date: 2007-07-21 01:23-0700\n"
 "Last-Translator: Eric Miao <eric.y.miao@gmail.com>\n"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,16 +1,18 @@
 # Translation of git-cola to Traditional Chinese(Taiwan)
+# Copyright (C) 2007, 2008 Shawn Pearce at el.
 # This file is distributed under the same license as the git-cola package.
-# This file is originally converted to zh_TW from zh_CN.po, made from Eric Miao <eric.y.miao@gmail.com> etc.
+# Xudong Guan <xudong.guan@gmail.com>, 2007.
+# Eric Miao <eric.y.miao@gmail.com>, 2008.
+# Ｖ字龍(Vdragon) <Vdragon.Taiwan@gmail.com>, 2014.
 #
 # 敬請參考 glossary/zh_tw.po 的辭彙翻譯
-# 2008-01-06 Eric Miao <eric.y.miao@gmail.com>
-# Ｖ字龍(Vdragon) <Vdragon.Taiwan@gmail.com>, 2014.
+# 
 msgid ""
 msgstr ""
-"Project-Id-Version: git-gui\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-06-07 20:21+0800\n"
-"PO-Revision-Date: 2014-06-07 22:49+0800\n"
+"Project-Id-Version: git-cola VERSION\n"
+"Report-Msgid-Bugs-To: https://github.com/git-cola/git-cola/issues\n"
+"POT-Creation-Date: 2014-06-06 12:59+0800\n"
+"PO-Revision-Date: 2014-06-06 13:28+0800\n"
 "Last-Translator: Ｖ字龍(Vdragon) <Vdragon.Taiwan@gmail.com>\n"
 "Language-Team: Chinese Traditional <>\n"
 "Language: zh_TW\n"


### PR DESCRIPTION
This commit updates all po headers to the project named 'git-cola',
following the gettext po format.
- Basically, s/git-gui/git-cola/g
- Copyright declaration
  - Previous contributers of git-gui translation are still preserved
  - update copyright year according to git-cola's commit history  
    https://github.com/git-cola/git-cola/commits/master/po/*.po
- point Report-Msgid-Bugs-To entry to https://github.com/git-cola/git-cola/issues
- reset all language team mailing lists since those only applies for git-gui

Signed-off-by: Ｖ字龍(Vdragon) pika1021@gmail.com
