### PR TITLE
zh_TW.po: update translation, fix force push error issue

### DIFF
--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1774,7 +1774,7 @@ msgstr ""
 #: cola/widgets/remote.py:471
 #, python-format
 msgid "Force push to %s?"
-msgstr "強制推送到遠端分支"
+msgstr "要強制推送至 %s 遠端分支嗎？"
 
 #: cola/widgets/remote.py:472
 msgid "Force Push"


### PR DESCRIPTION
commit ec1d3b6d introduces translation lacking format specifiers that
causes force push error, this commit fixes it.

Signed-off-by: Ｖ字龍(Vdragon) pika1021@gmail.com
