### PR TITLE
Use getcwd on Python 3

### DIFF
--- a/cola/app.py
+++ b/cola/app.py
@@ -307,7 +307,7 @@ def add_common_arguments(parser):
                         help='print version number')
 
     # Specifies a git repository to open
-    parser.add_argument('-r', '--repo', metavar='<repo>', default=os.getcwdu(),
+    parser.add_argument('-r', '--repo', metavar='<repo>', default=core.getcwd(),
                         help='open the specified git repository')
 
     # Specifies that we should prompt for a repository at startup

--- a/cola/core.py
+++ b/cola/core.py
@@ -276,7 +276,10 @@ abspath = wrap(mkpath, os.path.abspath, decorator=decode)
 chdir = wrap(mkpath, os.chdir)
 exists = wrap(mkpath, os.path.exists)
 expanduser = wrap(encode, os.path.expanduser, decorator=decode)
-getcwd = os.getcwdu
+try:  # Python 2
+    getcwd = os.getcwdu
+except AttributeError:
+    getcwd = os.getcwd
 isdir = wrap(mkpath, os.path.isdir)
 isfile = wrap(mkpath, os.path.isfile)
 islink = wrap(mkpath, os.path.islink)


### PR DESCRIPTION
In Python 3, getcwdu is renamed to getcwd. This prevented starting git-cola with Python 3.
