### PR TITLE
po/pt_BR.po: fix po syntax, fixes #319

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -290,7 +290,7 @@ msgstr "Histórico de lançamento de erros do Browser"
 #: cola/cmds.py:1277
 #, python-format
 msgid "Cannot exec \"%s\": please configure a history browser"
-msgstr "Não é possivel exec \"%s\": por favor configure o histórico do navegador 
+msgstr "Não é possivel exec \"%s\": por favor configure o histórico do navegador"
 
 #: cola/difftool.py:77
 msgid "git-cola diff"
@@ -383,7 +383,7 @@ msgstr ""
 #: cola/guicmds.py:168
 #, python-format
 msgid "\"%s\" already exists, cola will create a new directory"
-msgstr ""\"%s\" já existe, o cola já criou um novo diretório"
+msgstr "\"%s\" já existe, o cola já criou um novo diretório"
 
 #: cola/guicmds.py:170
 msgid "Directory Exists"


### PR DESCRIPTION
Commit 19c57b94 introduces translation with missing/additional double-
quotes and causes build error

```
msgfmt -o share/locale/pt_BR/LC_MESSAGES/git-cola.mo po/pt_BR.po
po/pt_BR.po:294: end-of-line within string
po/pt_BR.po:386:11: syntax error
msgfmt: found 2 fatal errors
error: command 'msgfmt' failed with exit status 1
make: *** [all] Error 1
```

This commit fixes the syntax.

Signed-off-by: Ｖ字龍(Vdragon) Vdragon.Taiwan@gmail.com
