### PR TITLE
app.py: fix ambiguous error message, fixes #322

### DIFF
--- a/cola/app.py
+++ b/cola/app.py
@@ -230,7 +230,7 @@ def process_args(args):
     repo = core.realpath(repo)
     if not core.isdir(repo):
         errmsg = N_('fatal: "%s" is not a directory.  '
-                    'Please specify --repo <path>.') % repo
+                    'Please specify a correct --repo <path>.') % repo
         core.stderr(errmsg)
         sys.exit(-1)
 


### PR DESCRIPTION
Current message may be comprehended as "You haven’t specify --repo in
the command-line, please specify it." by translators, and it's wrong.

This commit changes the message to "fatal: \"%s\" is not a directory.
Please specify a correct --repo
<path>."

Signed-off-by: Ｖ字龍(Vdragon) pika1021@gmail.com
