### PR TITLE
fixed Python 3 issue in sphinxtogithub.py

### DIFF
--- a/extras/sphinxtogithub/sphinxtogithub.py
+++ b/extras/sphinxtogithub/sphinxtogithub.py
@@ -276,12 +276,12 @@ def sphinx_extension(app, exception):
 
     if not app.config.sphinx_to_github:
         if app.config.sphinx_to_github_verbose:
-            print "Sphinx-to-github: Disabled, doing nothing."
+            print("Sphinx-to-github: Disabled, doing nothing.")
         return
 
     if exception:
         if app.config.sphinx_to_github_verbose:
-            print "Sphinx-to-github: Exception raised in main build, doing nothing."
+            print("Sphinx-to-github: Exception raised in main build, doing nothing.")
         return
 
     dir_helper = DirHelper(


### PR DESCRIPTION
Without those parentheses `make doc` will fail with Python 3

Signed-off-by: Paul Weingardt weingardt.dev@gmail.com
