### PR TITLE
dag:Add context menu for showing file history

### DIFF
--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -1,6 +1,7 @@
 from __future__ import division, absolute_import, unicode_literals
 
 import collections
+import subprocess
 import math
 
 from PyQt4 import QtGui
@@ -28,6 +29,7 @@ from cola.widgets.standard import MainWindow
 from cola.widgets.standard import TreeWidget
 from cola.widgets.diff import COMMITS_SELECTED
 from cola.widgets.diff import DiffWidget
+from cola.widgets.filelist import HISTORIES_SELECTED
 from cola.widgets.filelist import FileWidget
 from cola.compat import ustr
 
@@ -355,6 +357,7 @@ class GitDAG(MainWindow):
         self.notifier = notifier = observable.Observable()
         self.notifier.refs_updated = refs_updated = 'refs_updated'
         self.notifier.add_observer(refs_updated, self.display)
+        self.notifier.add_observer(HISTORIES_SELECTED, self.histories_selected)
 
         self.treewidget = CommitTreeWidget(notifier, self)
         self.diffwidget = DiffWidget(notifier, self)
@@ -573,6 +576,12 @@ class GitDAG(MainWindow):
         MainWindow.resizeEvent(self, e)
         self.treewidget.adjust_columns()
 
+    def histories_selected(self, histories):
+        argv = [self.model.currentbranch, '--']
+        argv.extend(histories)
+        text = subprocess.list2cmdline(argv)
+        self.revtext.setText(text)
+        self.display()
 
 class ReaderThread(QtCore.QThread):
     commits_ready = SIGNAL('commits_ready')

--- a/cola/widgets/filelist.py
+++ b/cola/widgets/filelist.py
@@ -5,10 +5,12 @@ from PyQt4.QtCore import SIGNAL
 
 from cola.i18n import N_
 from cola.git import git
+from cola import qtutils
 from cola.widgets.standard import TreeWidget
 from cola.widgets.diff import COMMITS_SELECTED
 from cola.widgets.diff import FILES_SELECTED
 
+HISTORIES_SELECTED = 'HISTORIES_SELECTED'
 
 class FileWidget(TreeWidget):
 
@@ -65,6 +67,16 @@ class FileWidget(TreeWidget):
     def resizeEvent(self, e):
         self.adjust_columns()
 
+    def contextMenuEvent(self, event):
+        menu = QtGui.QMenu(self)
+        menu.addAction(qtutils.add_action(self, N_('Show history'),
+                               self.show_file_history))
+        menu.exec_(self.mapToGlobal(event.pos()))
+
+    def show_file_history(self):
+        items = self.selected_items()
+        self.notifier.notify_observers(HISTORIES_SELECTED,
+                                       [i.file_name for i in items])
 
 class FileTreeWidgetItem(QtGui.QTreeWidgetItem):
 

--- a/po/git-cola.pot
+++ b/po/git-cola.pot
@@ -1493,6 +1493,10 @@ msgstr ""
 msgid "Deletions"
 msgstr ""
 
+#: cola/widgets/filelist.py:72
+msgid "Show history"
+msgstr ""
+
 #: cola/widgets/grep.py:70 cola/widgets/search.py:45 cola/widgets/search.py:63
 msgid "Search"
 msgstr ""

--- a/po/id_ID.po
+++ b/po/id_ID.po
@@ -1536,6 +1536,10 @@ msgstr "Penambahan"
 msgid "Deletions"
 msgstr "Penghapusan"
 
+#: cola/widgets/filelist.py:72
+msgid "Show history"
+msgstr "Tunjukan sejarah"
+
 #: cola/widgets/grep.py:70 cola/widgets/search.py:45 cola/widgets/search.py:63
 msgid "Search"
 msgstr "Cari"


### PR DESCRIPTION
Currently there is no easy way to track what recently change for a
particular file. This is useful to check which recent commit(s) actually
introduce the bug.

This change adds a context menu 'Show History' for filelist widget item
in DAG. When selected, the DAG will filter the log to display commits
which modified the selected file.

Signed-off-by: Minarto Margoliono lie.r.min.g@gmail.com
