### PR TITLE
Tweaks to worktree_state_dict()

### DIFF
--- a/cola/gitcmds.py
+++ b/cola/gitcmds.py
@@ -471,11 +471,6 @@ def worktree_state_dict(head='HEAD',
     # All submodules
     submodules = staged_submods.union(modified_submods)
 
-    # Only include the submodule in the staged list once it has
-    # been staged.  Otherwise, we'll see the submodule as being
-    # both modified and staged.
-    modified_submods = modified_submods.difference(staged_submods)
-
     # Add submodules to the staged and unstaged lists
     staged.extend(staged_submods)
     modified.extend(modified_submods)


### PR DESCRIPTION
Two changes:  remove some unnecessary set to list conversions, and remove some code that was preventing submodule status from displaying correctly when a submodule had both staged and unstaged changes.  If anyone is able to describe a case where a submodule's status is displayed incorrectly with my change, let me know how to reproduce it and I can make another go at it.
