### PR TITLE
Refactor selection functions in qtutils

### DIFF
--- a/cola/qtutils.py
+++ b/cola/qtutils.py
@@ -278,15 +278,6 @@ def question(title, msg, default=True):
     return result == QtGui.QMessageBox.Yes
 
 
-def selected_row(list_widget):
-    """Returns a(row_number, is_selected) tuple for a QListWidget."""
-    items = list_widget.selectedItems()
-    if not items:
-        return (-1, False)
-    item = items[0]
-    return (list_widget.row(item), True)
-
-
 def tree_selection(tree_item, items):
     """Returns an array of model items that correspond to the selected
     QTreeWidgetItem children"""

--- a/cola/widgets/createbranch.py
+++ b/cola/widgets/createbranch.py
@@ -317,12 +317,10 @@ class CreateBranchDialog(Dialog):
         # When the branch selection changes then we should update
         # the "Revision Expression" accordingly.
         qlist = self.branch_list
-        (row, selected) = qtutils.selected_row(qlist)
-        if not selected:
+        rev = qtutils.selected_item(qlist, self.branch_sources())
+        if rev is None:
             return
         # Update the model with the selection
-        sources = self.branch_sources()
-        rev = sources[row]
         self.revision.setText(rev)
 
         # Set the branch field if we're branching from a remote branch.

--- a/cola/widgets/merge.py
+++ b/cola/widgets/merge.py
@@ -179,9 +179,8 @@ class MergeView(QtGui.QDialog):
         """Update the revision field when a list item is selected"""
         revlist = self.current_revisions()
         widget = self.revisions
-        row, selected = qtutils.selected_row(widget)
-        if selected and row < len(revlist):
-            revision = revlist[row]
+        revision = qtutils.selected_item(widget, revlist)
+        if revision is not None:
             self.revision.setText(revision)
 
     def current_revisions(self):

--- a/cola/widgets/search.py
+++ b/cola/widgets/search.py
@@ -322,32 +322,33 @@ class Search(SearchWidget):
         commit_list = map(lambda x: x[1], self.results)
         self.set_commit_list(commit_list)
 
+    def selected_revision(self):
+        result = qtutils.selected_item(self.commit_list, self.results)
+        if result is None:
+            return None
+        else:
+            return result[0]
+
     def display(self, *args):
-        widget = self.commit_list
-        row, selected = qtutils.selected_row(widget)
-        if not selected or len(self.results) < row:
+        revision = self.selected_revision()
+        if revision is None:
             self.commit_text.setText('')
-            return
-        revision = self.results[row][0]
-        qtutils.set_clipboard(revision)
-        diff = gitcmds.commit_diff(revision)
-        self.commit_text.setText(diff)
+        else:
+            qtutils.set_clipboard(revision)
+            diff = gitcmds.commit_diff(revision)
+            self.commit_text.setText(diff)
 
     def export_patch(self):
-        widget = self.commit_list
-        row, selected = qtutils.selected_row(widget)
-        if not selected or len(self.results) < row:
-            return
-        revision = self.results[row][0]
-        Interaction.log_status(*gitcmds.export_patchset(revision, revision))
+        revision = self.selected_revision()
+        if revision is not None:
+            Interaction.log_status(*gitcmds.export_patchset(revision,
+                                                            revision))
 
     def cherry_pick(self):
-        widget = self.commit_list
-        row, selected = qtutils.selected_row(widget)
-        if not selected or len(self.results) < row:
-            return
-        revision = self.results[row][0]
-        Interaction.log_status(*git.cherry_pick(revision))
+        revision = self.selected_revision()
+        if revision is not None:
+            Interaction.log_status(*git.cherry_pick(revision))
+
 
 def search_commits(parent):
     opts = SearchOptions()

--- a/cola/widgets/selectcommits.py
+++ b/cola/widgets/selectcommits.py
@@ -26,9 +26,6 @@ class Model(object):
         self.revisions = revs
         self.summaries = summaries
 
-    def revision_sha1(self, idx):
-        return self.revisions[idx]
-
 
 class SelectCommitsDialog(QtGui.QDialog):
     def __init__(self, model,
@@ -95,14 +92,13 @@ class SelectCommitsDialog(QtGui.QDialog):
         return qtutils.selected_items(self.commit_list, revs)
 
     def commit_sha1_selected(self):
-        row, selected = qtutils.selected_row(self.commit_list)
+        sha1  = qtutils.selected_item(self.commit_list, self.model.revisions)
+        selected = (sha1 is not None)
         self.select_button.setEnabled(selected)
         if not selected:
             self.commit_text.setText('')
             self.revision.setText('')
             return
-        # Get the sha1 and put it in the revision line
-        sha1 = self.model.revision_sha1(row)
         self.revision.setText(sha1)
         self.revision.selectAll()
 


### PR DESCRIPTION
Several of the functions for getting selected items from a QListWidget or QTreeWidgetItem were either redundant, unused, or could be more efficient.  Refactor accordingly.
