### PR TITLE
Fix search on Python 3

### DIFF
--- a/cola/widgets/search.py
+++ b/cola/widgets/search.py
@@ -319,7 +319,7 @@ class Search(SearchWidget):
             self.search_callback()
 
     def display_results(self):
-        commit_list = map(lambda x: x[1], self.results)
+        commit_list = [result[1] for result in self.results]
         self.set_commit_list(commit_list)
 
     def display(self, *args):


### PR DESCRIPTION
The Search dialog did not work under Python 3.  This is due to the fact that the result of calling the builtin function `map()` was being passed to the `QListWidget.addItems()` method in the `Search.set_commit_list()` method.  This worked fine under Python 2 because `map()` returns a list. Under Python 3 however it returns an iterator, which causes PyQt to raise an exception.  Fix by replacing the call to `map()` in the `Search.display_results()` method with a list comprehension.
