### PR TITLE
Fixes for inotify use

### DIFF
--- a/cola/inotify.py
+++ b/cola/inotify.py
@@ -34,7 +34,7 @@ from PyQt4 import QtCore
 
 from cola import gitcfg
 from cola import core
-from cola.compat import ustr
+from cola.compat import ustr, PY3
 from cola.git import STDOUT
 from cola.i18n import N_
 from cola.interaction import Interaction
@@ -181,9 +181,9 @@ class GitNotifier(QtCore.QThread):
             return
         self._dirs_seen.add(directory)
         if core.exists(directory):
-            encoded_dir = core.encode(directory)
+            dir_arg = directory if PY3 else core.encode(directory)
             try:
-                self._wmgr.add_watch(encoded_dir, self._mask, quiet=False)
+                self._wmgr.add_watch(dir_arg, self._mask, quiet=False)
             except WatchManagerError as e:
                 self._add_watch_failed = True
                 self._add_watch_failed_warning(directory, e)


### PR DESCRIPTION
- On Python 3, pyinotify takes unicode paths, not bytes. Annoyingly, it skips over non-unicode paths without throwing a clear error, so it took a bit of digging to find the problem.
- The `_is_pyinotify_08x()` method is really interested in 0.8 or above, but was testing just for 0.8.x. We're on 0.9.x now, so I updated it to treat that like 0.8. It [looks like](https://github.com/seb-m/pyinotify/releases) pyinotify 0.8 was released more than 5 years ago, so maybe we should just remove this check altogether and assume we have a new enough version.
