### PR TITLE
Fix unstaged deleted diff

### DIFF
--- a/cola/widgets/status.py
+++ b/cola/widgets/status.py
@@ -840,12 +840,12 @@ class StatusTreeWidget(QtGui.QTreeWidget):
         # A staged file
         elif category == self.idx_staged:
             item = self.staged_items()[0]
-            cmds.do(cmds.DiffStaged, item.path, item.deleted)
+            cmds.do(cmds.DiffStaged, item.path, deleted=item.deleted)
 
         # A modified file
         elif category == self.idx_modified:
             item = self.modified_items()[0]
-            cmds.do(cmds.Diff, item.path, item.deleted)
+            cmds.do(cmds.Diff, item.path, deleted=item.deleted)
 
         elif category == self.idx_unmerged:
             item = self.unmerged_items()[0]


### PR DESCRIPTION
2cbd38e2edca6ae6aa732b7afb809fb4b2a7dbf0 broke displaying the diff for an unstaged deleted file.  In the call to `cmds.do(cmds.Diff, ...)`, `item.deleted` was being passed as a positional argument, which meant it was actually being assigned to the `cached` argument, rather than the `deleted` argument, resulting in an empty diff.  Change to pass as a keyword argument to avoid this.
