### PR TITLE
Deleted file diff context menu

### DIFF
--- a/cola/widgets/diff.py
+++ b/cola/widgets/diff.py
@@ -141,7 +141,7 @@ class DiffEditor(DiffTextEdit):
                                N_('Launch git-cola'),
                                cmds.run(cmds.OpenRepo,
                                         core.abspath(s.modified[0])))
-            else:
+            elif s.modified[0] not in main.model().unstaged_deleted:
                 if self.has_selection():
                     apply_text = N_('Stage Selected Lines')
                     revert_text = N_('Revert Selected Lines...')
@@ -167,7 +167,7 @@ class DiffEditor(DiffTextEdit):
                                N_('Launch git-cola'),
                                cmds.do(cmds.OpenRepo,
                                        core.abspath(s.staged[0])))
-            else:
+            elif s.staged[0] not in main.model().staged_deleted:
                 if self.has_selection():
                     apply_text = N_('Unstage Selected Lines')
                 else:


### PR DESCRIPTION
The Stage/Unstage/Revert actions for the Diff widget context menu don't make any sense for deleted files, so don't show them in that case.
