### PR TITLE
Fix Gravatar test

### DIFF
--- a/test/gravatar_test.py
+++ b/test/gravatar_test.py
@@ -9,7 +9,7 @@ class GravatarTestCase(unittest.TestCase):
 
     def test_url_for_email_(self):
         email = 'email@example.com'
-        expect='http://gravatar.com/avatar/5658ffccee7f0ebfda2b226238b1eb6e?s=64&d=http%3A%2F%2Fgit-cola.github.io%2Fimages%2Fgit-64x64.jpg'
+        expect='https://gravatar.com/avatar/5658ffccee7f0ebfda2b226238b1eb6e?s=64&d=http%3A%2F%2Fgit-cola.github.io%2Fimages%2Fgit-64x64.jpg'
         actual = gravatar.Gravatar.url_for_email(email, 64)
         self.assertEqual(expect, actual)
 


### PR DESCRIPTION
d53ec734cb9a183e9b50ffe86dabe631834651b5 broke the Gravatar test because it was checking for a `http://` URL from `url_for_email()`, but that commit changed the generated URL to use `https://`.  Update the test to check for a `https://` URL.
