### PR TITLE
Complete Gravatar test fix

### DIFF
--- a/test/gravatar_test.py
+++ b/test/gravatar_test.py
@@ -9,7 +9,7 @@ class GravatarTestCase(unittest.TestCase):
 
     def test_url_for_email_(self):
         email = 'email@example.com'
-        expect='https://gravatar.com/avatar/5658ffccee7f0ebfda2b226238b1eb6e?s=64&d=http%3A%2F%2Fgit-cola.github.io%2Fimages%2Fgit-64x64.jpg'
+        expect='https://gravatar.com/avatar/5658ffccee7f0ebfda2b226238b1eb6e?s=64&d=https%3A%2F%2Fgit-cola.github.io%2Fimages%2Fgit-64x64.jpg'
         actual = gravatar.Gravatar.url_for_email(email, 64)
         self.assertEqual(expect, actual)
 


### PR DESCRIPTION
ffbd258b00ae8736af1b8ad6bbe7c3dd2fd8caba was supposed to fix the Gravatar test, but there were actually two places where `http://` was changed to `https://`, and that commit only corrected for one.  Correct the other one here.  (Actually tested this time!)
