### PR TITLE
Implement continuous integration, fixes #403

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 # command to install dependencies, git and python are pre-installed in build box thus are ignored
 install:
   # according to Debian control file from Ubuntu 12.04
-  - sudo apt-get install python-support rsync gettext asciidoc xmlto
+  - sudo apt-get install python-support rsync gettext
   - pip install sphinx
   
   # Build and install Git Cola's dependency, SIP and PyQt4

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - sudo apt-get install python-support rsync gettext asciidoc xmlto
   - pip install sphinx
   
-  # Build and install SIP and PyQt4
+  # Build and install Git Cola's dependency, SIP and PyQt4
   - wget "http://sourceforge.net/projects/pyqt/files/sip/sip-4.16.5/sip-4.16.5.tar.gz"
   - tar --verbose --extract --file sip-4.16.5.tar.gz
   - cd sip-4.16.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ python:
   - "3.3"
   - "3.4"
 
+before_install:
+  # Update APT cache data since it may outdated
+  - sudo apt-get update
+
 # command to install dependencies, git and python are pre-installed in build box thus are ignored
 install:
   # according to Debian control file from Ubuntu 12.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+# Travis CI(http://travis-ci.org) configuration file
 language: python
 python:
   - "2.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
   - make -j4
   - sudo make install
   - cd ..
+  
   - wget "http://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.11.3/PyQt-x11-gpl-4.11.3.tar.gz"
   - tar --verbose --extract --file PyQt-x11-gpl-4.11.3.tar.gz
   - cd PyQt-x11-gpl-4.11.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ before_install:
 # command to install dependencies, git and python are pre-installed in build box thus are ignored
 install:
   # according to Debian control file from Ubuntu 12.04
-  - sudo apt-get install python-support pyqt4-dev-tools python-sphinx rsync gettext asciidoc xmlto
+  - sudo apt-get install python-support rsync gettext asciidoc xmlto
   # Additional dependency for python 2.6
-  - pip install argparse
+  - pip install argparse pyqt4 sphinx 
 
 script:
   - make all doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   # Build and install SIP and PyQt4
   - wget "http://sourceforge.net/projects/pyqt/files/sip/sip-4.16.5/sip-4.16.5.tar.gz"
   - tar --verbose --extract --file sip-4.16.5.tar.gz
-  - cd sip-4.16.5.tar.gz
+  - cd sip-4.16.5
   - python configure.py
   - make -j4
   - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
-#  - "3.2" Pygments 2.0 requires Python 3.3+ and is not Git Cola's issue
+#  - "3.2" Sphinx depends on Pygments, which only supports Python 3.3+
   - "3.3"
   - "3.4"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,4 @@ install:
 script:
   - make all
   - make doc
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ install:
   - sudo pip install argparse
 
 script:
-  - make
+  - make all doc
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 # command to install dependencies, git and python are pre-installed in build box thus are ignored
 install:
   # according to Debian control file from Ubuntu 12.04
-  - sudo apt-get install python python-support pyqt4-dev-tools python-sphinx rsync git-core gettext asciidoc xmlto
+  - sudo apt-get install python python-support pyqt4-dev-tools python-sphinx rsync gettext asciidoc xmlto
   # Additional dependency for python 2.6
   - sudo apt-get install pip
   - sudo pip install argparse

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,5 @@ install:
   - pip install argparse 
 
 script:
-  - make all doc
-
+  - make all
+  - make doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
+#  - "3.2" Pygments 2.0 requires Python 3.3+ and is not Git Cola's issue
   - "3.3"
   - "3.4"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   # according to Debian control file from Ubuntu 12.04
   - sudo apt-get install python python-support pyqt4-dev-tools python-sphinx rsync gettext asciidoc xmlto
   # Additional dependency for python 2.6
-  - sudo apt-get install pip
+  - sudo apt-get install python-pip
   - sudo pip install argparse
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+# command to install dependencies
+install:
+  - sudo apt-get build-dep git-cola
+
+script:
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 # command to install dependencies, git and python are pre-installed in build box thus are ignored
 install:
   # according to Debian control file from Ubuntu 12.04
-  - sudo apt-get install python python-support pyqt4-dev-tools python-sphinx rsync gettext asciidoc xmlto
+  - sudo apt-get install python-support pyqt4-dev-tools python-sphinx rsync gettext asciidoc xmlto
   # Additional dependency for python 2.6
   - sudo apt-get install python-pip
   - sudo pip install argparse

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 # command to install dependencies, git and python are pre-installed in build box thus are ignored
 install:
   # according to Debian control file from Ubuntu 12.04
-  - sudo apt-get install python-support rsync gettext
+  - sudo apt-get install rsync gettext
   - pip install sphinx
   
   # Build and install Git Cola's dependency, SIP and PyQt4

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ install:
   # according to Debian control file from Ubuntu 12.04
   - sudo apt-get install python-support pyqt4-dev-tools python-sphinx rsync gettext asciidoc xmlto
   # Additional dependency for python 2.6
-  - sudo apt-get install python-pip
   - sudo pip install argparse
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - wget "http://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.11.3/PyQt-x11-gpl-4.11.3.tar.gz"
   - tar --verbose --extract --file PyQt-x11-gpl-4.11.3.tar.gz
   - cd PyQt-x11-gpl-4.11.3
-  - printf "yes\n" | python configure.py
+  - printf "yes\n" | python configure.py # Configure script requires accepting license
   - make -j4
   - make install
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,5 @@ install:
 script:
   - make all
   - make doc
-  - make test
+#  - make test
+  - nosetests --with-doctest --exclude=sphinxtogithub --verbose # TODO: Temporarily used instead of `make test`, will be dropped in future

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,26 @@ before_install:
 install:
   # according to Debian control file from Ubuntu 12.04
   - sudo apt-get install python-support rsync gettext asciidoc xmlto
+  - pip install sphinx
+  
+  # Build and install SIP and PyQt4
+  - wget "http://sourceforge.net/projects/pyqt/files/sip/sip-4.16.5/sip-4.16.5.tar.gz"
+  - tar --verbose --extract --file sip-4.16.5.tar.gz
+  - cd sip-4.16.5.tar.gz
+  - python configure.py
+  - make -j4
+  - make install
+  - cd ..
+  - wget "http://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.11.3/PyQt-x11-gpl-4.11.3.tar.gz"
+  - tar --verbose --extract --file PyQt-x11-gpl-4.11.3.tar.gz
+  - cd PyQt-x11-gpl-4.11.3
+  - python configure.py
+  - make -j4
+  - make install
+  - cd ..
+  
   # Additional dependency for python 2.6
-  - pip install argparse pyqt4 sphinx 
+  - pip install argparse 
 
 script:
   - make all doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   # according to Debian control file from Ubuntu 12.04
   - sudo apt-get install python-support pyqt4-dev-tools python-sphinx rsync gettext asciidoc xmlto
   # Additional dependency for python 2.6
-  - sudo pip install argparse
+  - pip install argparse
 
 script:
   - make all doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,5 +40,4 @@ install:
 script:
   - make all
   - make doc
-#  - make test
-  - nosetests --with-doctest --exclude=sphinxtogithub --verbose # TODO: Temporarily used instead of `make test`, will be dropped in future
+#  - make test # Disabled due to issue #404

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,14 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
-# command to install dependencies
+
+# command to install dependencies, git and python are pre-installed in build box thus are ignored
 install:
-  - sudo apt-get build-dep git-cola
+  # according to Debian control file from Ubuntu 12.04
+  - sudo apt-get install python python-support pyqt4-dev-tools python-sphinx rsync git-core gettext asciidoc xmlto
+  # Additional dependency for python 2.6
+  - sudo apt-get install pip
+  - sudo pip install argparse
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - wget "http://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.11.3/PyQt-x11-gpl-4.11.3.tar.gz"
   - tar --verbose --extract --file PyQt-x11-gpl-4.11.3.tar.gz
   - cd PyQt-x11-gpl-4.11.3
-  - python configure.py
+  - printf "yes\n" | python configure.py
   - make -j4
   - make install
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - cd sip-4.16.5
   - python configure.py
   - make -j4
-  - make install
+  - sudo make install
   - cd ..
   - wget "http://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.11.3/PyQt-x11-gpl-4.11.3.tar.gz"
   - tar --verbose --extract --file PyQt-x11-gpl-4.11.3.tar.gz


### PR DESCRIPTION
This pull request implements continuous integration via [Travis CI](https://travis-ci.org).  Currently it tries to build Git Cola and its documentation in Python 2.6, 2.7, 3.3 and 3.4 environment on every push.

Currently running unit tests is designed but not enabled due to Issue #404 .