### PR TITLE
Implement refresh-on-focus

### DIFF
--- a/cola/app.py
+++ b/cola/app.py
@@ -206,6 +206,13 @@ class ColaQApplication(QtGui.QApplication):
         self.git_path = git_path
         self.view = None ## injected by application_start()
 
+    def event(self, e):
+        if e.type() == QtCore.QEvent.ApplicationActivate:
+            cfg = gitcfg.current()
+            if cfg.get('cola.refreshonfocus', False):
+                cmds.do(cmds.Refresh)
+        return QtGui.QApplication.event(self, e)
+
     def commitData(self, session_mgr):
         """Save session data"""
         if self.view is None:

--- a/share/doc/git-cola/git-cola.rst
+++ b/share/doc/git-cola/git-cola.rst
@@ -392,6 +392,12 @@ cola.inotify
 Set to `false` to disable inotify support.
 Defaults to `true` when the `pyinotify` module is available.
 
+cola.refreshonfocus
+----------------------
+Set to `true` to automatically refresh when `git cola` gains focus.  Defaults
+to `false` because this can cause a pause whenever switching to `git cola` from
+another application.
+
 cola.linebreak
 --------------
 Whether to automatically break long lines while editing commit messages.


### PR DESCRIPTION
Implement #391:  the ability to refresh `git cola` whenever it gains focus.  This functionality is disabled by default, but can be enabled by setting the `cola.refreshonfocus` git config setting to `true`.  It is not enabled by default because it can result in a pause whenever switching to `git cola` from another application (especially noticeable on Windows).