### PR TITLE
Fix completion code for Python 3

### DIFF
--- a/cola/widgets/completion.py
+++ b/cola/widgets/completion.py
@@ -392,8 +392,8 @@ def filter_matches(match_text, candidates, case_sensitive, cmp=None):
         case_transform = lambda x: x.lower()
 
     if match_text:
-        matches = [r for r in candidates
-                    if case_transform(match_text) in case_transform(r)]
+        match_text = case_transform(match_text)
+        matches = [r for r in candidates if match_text in case_transform(r)]
     else:
         matches = list(candidates)
 

--- a/cola/widgets/completion.py
+++ b/cola/widgets/completion.py
@@ -387,19 +387,17 @@ def filter_matches(match_text, candidates, case_sensitive, cmp=None):
     """Filter candidates and return the matches"""
 
     if case_sensitive:
-        transform = lambda x: x
-        keyfunc = lambda x: x.replace('.', '')
+        case_transform = lambda x: x
     else:
-        transform = lambda x: x.lower()
-        keyfunc = lambda x: x.replace('.', '').lower()
+        case_transform = lambda x: x.lower()
 
     if match_text:
         matches = [r for r in candidates
-                    if transform(match_text) in transform(r)]
+                    if case_transform(match_text) in case_transform(r)]
     else:
         matches = list(candidates)
 
-    matches.sort(key=keyfunc, cmp=cmp)
+    matches.sort(key=case_transform, cmp=cmp)
     return matches
 
 


### PR DESCRIPTION
The `filter_matches()` function in widgets/completion.py was calling the list `sort()` method with a `cmp` parameter which is not supported in Python 3.  Rework the code to only use a `key` parameter, and make a couple of other tweaks to the code.