### PR TITLE
gitcmds: force option "no-abbrev-commit" when running "git log"

### DIFF
--- a/cola/gitcmds.py
+++ b/cola/gitcmds.py
@@ -212,7 +212,8 @@ def tag_list():
 
 
 def log(git, *args, **kwargs):
-    return git.log(no_color=True, no_ext_diff=True, *args, **kwargs)[STDOUT]
+    return git.log(no_color=True, no_abbrev_commit=True,
+                   no_ext_diff=True, *args, **kwargs)[STDOUT]
 
 
 def commit_diff(sha1, git=git):


### PR DESCRIPTION
I have set "log.abbrevCommit = true" in my ".gitconfig" file.

In that case the "More..." items in the "Load previous Commit Message" and
"Fixup previous Commit" sub menus wont work.

The reason is the regular expression REV_LIST_REGEX. It expects the SHA1 to be
exactly 40 characters long in the git log output.

Signed-off-by: Wolfgang Ocker <weo@reccoware.de>