### PR TITLE
Don't use external diff in the stash viewer

### DIFF
--- a/cola/models/stash.py
+++ b/cola/models/stash.py
@@ -28,7 +28,7 @@ class StashModel(observable.Observable):
 
     def stash_diff(self, rev):
         diffstat = git.stash('show', rev)[STDOUT]
-        diff = git.stash('show', '-p', rev)[STDOUT]
+        diff = git.stash('show', '-p', '--no-ext-diff', rev)[STDOUT]
         return diffstat + '\n\n' + diff
 
 


### PR DESCRIPTION
If the user has configured the default diff viewer to be a graphical
viwer then the stash viewer would open the external viewer instead
of displaying the diff in cola