### PR TITLE
Fix syntax highlighting

### DIFF
--- a/cola/widgets/diff.py
+++ b/cola/widgets/diff.py
@@ -33,9 +33,11 @@ FILES_SELECTED = 'FILES_SELECTED'
 class DiffSyntaxHighlighter(QtGui.QSyntaxHighlighter):
     """Implements the diff syntax highlighting"""
 
+    INITIAL_STATE = -1
     DIFFSTAT_STATE = 0
     DIFF_FILE_HEADER_STATE = 1
     DIFF_STATE = 2
+    SUBMODULE_STATE = 3
 
     DIFF_FILE_HEADER_START_RGX = re.compile(r'diff --git a/.* b/.*')
     DIFF_HUNK_HEADER_RGX = re.compile(r'(?:@@ -[0-9,]+ \+[0-9,]+ @@)|'
@@ -75,8 +77,11 @@ class DiffSyntaxHighlighter(QtGui.QSyntaxHighlighter):
             return
 
         state = self.previousBlockState()
-        if state == -1:
-            state = self.DIFFSTAT_STATE
+        if state == self.INITIAL_STATE:
+            if text.startswith('Submodule '):
+                state = self.SUBMODULE_STATE
+            else:
+                state = self.DIFFSTAT_STATE
 
         if state == self.DIFFSTAT_STATE:
             if self.DIFF_FILE_HEADER_START_RGX.match(text):

--- a/cola/widgets/diff.py
+++ b/cola/widgets/diff.py
@@ -37,8 +37,9 @@ class DiffSyntaxHighlighter(QtGui.QSyntaxHighlighter):
     DIFF_FILE_HEADER_STATE = 1
     DIFF_STATE = 2
 
-    DIFF_FILE_HEADER_START_RGX = re.compile(r'^diff --git a/.* b/.*$')
-    DIFF_HUNK_HEADER_RGX = re.compile(r'^@@ -[0-9,]+ \+[0-9,]+ @@')
+    DIFF_FILE_HEADER_START_RGX = re.compile(r'diff --git a/.* b/.*')
+    DIFF_HUNK_HEADER_RGX = re.compile(r'(?:@@ -[0-9,]+ \+[0-9,]+ @@)|'
+                                      r'(?:@@@ (?:-[0-9,]+ ){2}\+[0-9,]+ @@@)')
     BAD_WHITESPACE_RGX = re.compile(r'\s+$')
 
     def __init__(self, doc, whitespace=True):


### PR DESCRIPTION
Fix two regressions in diff syntax highlighting introduced by PR #466:

* Diffs of unmerged files were being highlighted using the diff header color, because the regular expression for detecting a diff hunk header did not match the diff hunk header for unmerged files.  Update the regular expression to match both normal and unmerged diff hunk headers.
* Diffs of submodules were being highlighted using the diff header color.  Detect submodule diffs and do not apply any syntax highlighting to them.