### PR TITLE
dag: add diff tool option

### DIFF
--- a/cola/widgets/browse.py
+++ b/cola/widgets/browse.py
@@ -366,7 +366,7 @@ class BrowserController(QtCore.QObject):
         if not commits:
             return
         commit = commits[0]
-        difftool.launch([commit, '--'] + paths)
+        difftool.launch(left=commit, paths=paths)
 
 
 class BrowseModel(object):

--- a/cola/widgets/compare.py
+++ b/cola/widgets/compare.py
@@ -250,7 +250,8 @@ class CompareBranchesDialog(standard.Dialog):
     def compare_file(self, filename):
         """Initiates the difftool session"""
         if self.use_sandbox:
-            arg = self.diff_arg
+            left = self.diff_arg[0]
+            right = self.diff_arg[1] if len(self.diff_arg) > 1 else None
         else:
-            arg = (self.start, self.end)
-        difftool.launch(arg + ('--', filename))
+            left, right = self.start, self.end
+        difftool.launch(left=left, right=right, paths=filename)

--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -12,6 +12,7 @@ from PyQt4.QtCore import QPointF
 from PyQt4.QtCore import QRectF
 
 from cola import cmds
+from cola import core
 from cola import difftool
 from cola import observable
 from cola import qtutils
@@ -252,8 +253,7 @@ class CommitTreeWidget(ViewerMixin, standard.TreeWidget):
         selected_items = self.selected_items()
         if not selected_items:
             return None, None
-        item_below = self.itemBelow(selected_items[-1])
-        return item_below.commit.sha1 if item_below else None, selected_items[0].commit.sha1
+        return selected_items[-1].commit.sha1, selected_items[0].commit.sha1
 
     def set_selecting(self, selecting):
         self.selecting = selecting
@@ -600,7 +600,7 @@ class GitDAG(standard.MainWindow):
     def diff_commits(self, a, b):
         paths = self.ctx.paths()
         if paths:
-            difftool.launch([a, b, '--'] + paths)
+            difftool.launch(left=a, right=b, paths=paths)
         else:
             difftool.diff_commits(self, a, b)
 
@@ -625,9 +625,7 @@ class GitDAG(standard.MainWindow):
         bottom, top = self.treewidget.selected_commit_range()
         if not top:
             return
-        if not bottom:
-            bottom = '%s^' % top
-        difftool.launch([bottom, top, '--'] + list(files))
+        difftool.launch(left=bottom, left_take_parent=True, right=top, paths=list(files))
 
 
 class ReaderThread(QtCore.QThread):

--- a/cola/widgets/filelist.py
+++ b/cola/widgets/filelist.py
@@ -73,7 +73,7 @@ class FileWidget(TreeWidget):
         menu.addAction(qtutils.add_action(self, N_('Show history'),
                                self.show_file_history))
         menu.addAction(qtutils.add_action(self, N_('Launch Diff Tool'),
-                               self.show_file_diff))
+                               self.show_file_diff, 'Ctrl+D'))
 
         menu.exec_(self.mapToGlobal(event.pos()))
 

--- a/cola/widgets/filelist.py
+++ b/cola/widgets/filelist.py
@@ -11,6 +11,7 @@ from cola.widgets.diff import COMMITS_SELECTED
 from cola.widgets.diff import FILES_SELECTED
 
 HISTORIES_SELECTED = 'HISTORIES_SELECTED'
+DIFFTOOL_SELECTED = 'DIFFTOOL_SELECTED'
 
 class FileWidget(TreeWidget):
 
@@ -71,7 +72,15 @@ class FileWidget(TreeWidget):
         menu = QtGui.QMenu(self)
         menu.addAction(qtutils.add_action(self, N_('Show history'),
                                self.show_file_history))
+        menu.addAction(qtutils.add_action(self, N_('Launch Diff Tool'),
+                               self.show_file_diff))
+
         menu.exec_(self.mapToGlobal(event.pos()))
+
+    def show_file_diff(self):
+        items = self.selected_items()
+        self.notifier.notify_observers(DIFFTOOL_SELECTED,
+                                       [i.file_name for i in items])
 
     def show_file_history(self):
         items = self.selected_items()


### PR DESCRIPTION
This adds a context menu option for each file when viewing commit(s) in the DAG. It opens the external diff tool for
- one commit selected: \<commit below selected commit> .. \<selected commit>
- more commits selected: \<commit below bottom selected commit> .. \<top selected commit>

I didn't manage to add Ctrl+D shortcut for that because I don't have that much time (got an error "QAction::eventFilter: Ambiguous shortcut overload: Ctrl+D").

Please check carefully since I don't know the code base / style at all.