### PR TITLE
Menu: Disable "Branch" menu in empty repositories

### DIFF
--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -216,6 +216,9 @@ class MainModel(Observable):
         return not(bool(self.staged or self.modified or
                         self.unmerged or self.untracked))
 
+    def is_empty_repository(self):
+        return not self.local_branches
+
     def _update_remotes(self):
         self.remotes = self.git.remote()[STDOUT].splitlines()
 

--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -635,6 +635,8 @@ class MainView(standard.MainWindow):
         self.rebase_continue_action.setEnabled(is_rebasing)
         self.rebase_skip_action.setEnabled(is_rebasing)
         self.rebase_abort_action.setEnabled(is_rebasing)
+        self.branch_rename_action.setEnabled(not self.model.is_empty_repository())
+        self.branch_delete_action.setEnabled(not self.model.is_empty_repository())
 
     def export_state(self):
         state = standard.MainWindow.export_state(self)


### PR DESCRIPTION
When current working repository is empty (eg: just initialised or cloned
an empty repository), it doesn't make sense to rename or delete local
branch.

For checking whether repository is empty or not, local branches is used.
Alternative considered was:
1. Git log/rev-list and check exit code (Fail when there is remote
branches, bot not local branches)
2. Git count-objects (probably has similar issue with above)

Issue: #459
Reported-By: Vdragon
Signed-off-by: Minarto Margoliono <lie.r.min.g@gmail.com>