### PR TITLE
tests: set 'user.name' and 'user.email' options after the repository init

### DIFF
--- a/test/helper.py
+++ b/test/helper.py
@@ -87,6 +87,8 @@ class GitRepositoryTestCase(TmpPathTestCase):
 
     def initialize_repo(self):
         self.git('init')
+        self.git('config', '--local', 'user.name', 'Your Name')
+        self.git('config', '--local', 'user.email', 'you@example.com')
         self.touch('A', 'B')
         self.git('add', 'A', 'B')
 


### PR DESCRIPTION
Hello.

When running tests in clean sandboxed environments (like the ones used in Gentoo distro), i.e. without a global git config, there is usually no `user.name` and `user.email` specified in the system git config. Because of this, recent versions of git will refuse to commit changes. This in turn makes tests fail.

A simple change should be made to update the said git options. The values are the default ones provided by git's own help message:
```
Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.
```