### PR TITLE
fix history browser default value on win32

### DIFF
--- a/cola/models/prefs.py
+++ b/cola/models/prefs.py
@@ -53,8 +53,8 @@ def default_history_browser():
         # On Windows, a sensible default is "python git-cola dag"
         # which is different than `gitk` below, but is preferred
         # because we don't have to guess paths.
-        git_cola = sys.argv[0]
-        python = sys.executable
+        git_cola = sys.argv[0].replace("\\", '/')
+        python = sys.executable.replace("\\", '/')
         argv = [python, git_cola, 'dag']
         argv = core.prep_for_subprocess(argv)
         default = core.decode(subprocess.list2cmdline(argv))


### PR DESCRIPTION
Default history browser fails to start due to backslashes in Windows path. Converting backslashes to slashes beforehand makes it work for all cases.