### PR TITLE
Center the startup dialog on the screen and make it larger

### DIFF
--- a/cola/widgets/startup.py
+++ b/cola/widgets/startup.py
@@ -90,6 +90,9 @@ class StartupDialog(QtGui.QDialog):
         qtutils.connect_button(self.clone_button, self.clone_repo)
         qtutils.connect_button(self.new_button, self.new_repo)
         qtutils.connect_button(self.close_button, self.reject)
+        screen = QtGui.QDesktopWidget().screenGeometry()
+        self.setGeometry(screen.width() // 4, screen.height() // 4,
+                         screen.width() // 2, screen.height() // 2)
 
         self.connect(self.bookmarks,
                      SIGNAL('activated(QModelIndex)'), self.open_bookmark)


### PR DESCRIPTION
The start-up screen's size has always been a pain point with me, because I could not see at a glance which repositories I wanted to look at with git cola. The path names of the repository were always longer than the window itself. Like this:

![smallstartupgitcola](https://cloud.githubusercontent.com/assets/1186534/9852405/59769f3e-5abb-11e5-992d-9677d0b73c24.png)

This PR widens the window to half the screen width/length, and centers the window on the screen:

![bigstartupgitcola](https://cloud.githubusercontent.com/assets/1186534/9852530/09a7a2a4-5abc-11e5-96bc-ee8d0d480a17.png)

I have found this modification very useful and wanted to share it. Please consider merging it :), if you don't like how I fixed the small window problem I can change the code to your satisfaction.