### PR TITLE
Fewer dag refreshes

### DIFF
--- a/bin/git-dag
+++ b/bin/git-dag
@@ -84,7 +84,7 @@ def parse_args():
 def cmd_dag(args):
     context = application_init(args)
     view = git_dag(context.model, args=args, settings=args.settings)
-    return application_start(context, view)
+    return application_start(context, view, monitor_refs_only=True)
 
 
 if __name__ == '__main__':

--- a/cola/app.py
+++ b/cola/app.py
@@ -281,7 +281,7 @@ def application_init(args, update=False):
     return ApplicationContext(args, app, cfg, model)
 
 
-def application_start(context, view):
+def application_start(context, view, monitor_refs_only=False):
     """Show the GUI and start the main event loop"""
     # Store the view for session management
     context.app.set_view(view)
@@ -295,7 +295,7 @@ def application_start(context, view):
     init_update_task(view, runtask, context.model)
 
     # Start the filesystem monitor thread
-    fsmonitor.instance().start()
+    fsmonitor.instance().start(monitor_refs_only)
 
     msg_timer = QtCore.QTimer()
     msg_timer.setSingleShot(True)


### PR DESCRIPTION
This PR should fix issue #516.  It first of all limits the scope of `.git` dir monitoring in general to only refresh on changes to `index` and `HEAD` (in additional to changes to files under `refs/`).  Then, for `git-dag`, if further ignores changes to `.git/index` as well as the worktree.  As a result, `git-dag` should only refresh on changes to `HEAD` or `.git/refs/`.

I would like some feedback on how `git-dag` actually enables this behavior however.  I added an optional parameter to `application_start()`, `monitor_refs_only`.  That parameter gets passed in turn to `fsmonitor.instance().start()`.  However, I don't know if this the best mechanism for controlling that behavior.