### PR TITLE
fsmonitor: use the resolved git repository path

### DIFF
--- a/cola/fsmonitor.py
+++ b/cola/fsmonitor.py
@@ -116,7 +116,7 @@ if AVAILABLE == 'inotify':
         def __init__(self, monitor, refs_only):
             _BaseThread.__init__(self, monitor, refs_only)
             self._worktree = core.abspath(git.worktree())
-            self._git_dir = git.git_dir()
+            self._git_dir = git.git_path()
             self._lock = Lock()
             self._inotify_fd = None
             self._pipe_r = None

--- a/share/doc/git-cola/relnotes/v2.6.rst
+++ b/share/doc/git-cola/relnotes/v2.6.rst
@@ -19,3 +19,10 @@ Fixes
   diff.supressBlankEmpty=true in their git config.
 
   https://github.com/git-cola/git-cola/issues/541
+
+* The filesystem monitor now properly handles repositories that use
+  `.git`-files, e.g. when using submodules.
+
+  https://github.com/git-cola/git-cola/issues/545
+
+  https://github.com/git-cola/git-cola/pulls/546


### PR DESCRIPTION
git_dir() is the worktree's .git path, but it is not necessarily
the path where refs/ objects/ and friends are found.  When using
submodules, for example, .git is a file that contains the path
to the actual git repository.

The fsmonitor registers the git path so that it can notice
changes.  When doing so it ignores ENOTDIR errors to avoid a
race condition, but it also silently ignores the request to
watch the .git-file.

This later causes an exception when asking for the git path:

	File "cola/fsmonitor.py", line 207, in refresh
	self._git_dir_wd = self._git_dir_wd_map[self._git_dir]
	KeyError: u'/home/david/src/git/.git'

Fix the logic by using git_path() when setting up the monitor so
that the real git repository path is used.

Closes #545
Reported-by: Wolfgang Ocker <weo@reccoware.de>
Signed-off-by: David Aguilar <davvid@gmail.com>