### PR TITLE
git: add support for bare repositories and GIT_CEILING_DIRECTORIES

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,9 +7,6 @@
 # pygtk.require().
 #init-hook=
 
-# Profiled execution.
-profile=no
-
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
 ignore=.git
@@ -87,19 +84,12 @@ reports=yes
 # (RP0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
-# Add a comment according to your evaluation note. This is used by the global
-# evaluation report (RP0004).
-comment=yes
-
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details
 #msg-template=
 
 
 [BASIC]
-
-# Required attributes for module, separated by a comma
-required-attributes=
 
 # List of builtins function names that should not be used, separated by a comma
 bad-functions=map,filter,input
@@ -236,10 +226,6 @@ ignored-modules=
 # (useful for classes with attributes dynamically set).
 ignored-classes=SQLObject
 
-# When zope mode is activated, add a predefined set of Zope acquired attributes
-# to generated-members.
-zope=no
-
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed. Python regular
 # expressions are accepted.
@@ -304,10 +290,6 @@ callbacks=cb_,_cb
 
 
 [CLASSES]
-
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ install:
   - cd ../../..
   # Additional dependency for python 2.6
   - pip install argparse
+  # Test dependencies
+  - pip install mock
   # Pylint
   - pip install astroid==1.3.8
   - pip install pylint==1.4.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,8 @@ install:
   # Test dependencies
   - pip install mock
   # Pylint
-  - pip install astroid==1.3.8
-  - pip install pylint==1.4.4
+  - pip install astroid==1.4.3
+  - pip install pylint==1.5.2
 
 script:
   - make all

--- a/cola/app.py
+++ b/cola/app.py
@@ -355,7 +355,7 @@ def new_model(app, repo, prompt=False, settings=None):
         valid = model.set_worktree(gitdir)
 
     # Finally, go to the root of the git repo
-    os.chdir(model.git.worktree())
+    os.chdir(model.git.getcwd())
     return model
 
 

--- a/cola/fsmonitor.py
+++ b/cola/fsmonitor.py
@@ -115,7 +115,7 @@ if AVAILABLE == 'inotify':
 
         def __init__(self, monitor, refs_only):
             _BaseThread.__init__(self, monitor, refs_only)
-            self._worktree = core.abspath(git.worktree())
+            self._worktree = core.abspath(git.getcwd())
             self._git_dir = git.git_path()
             self._lock = Lock()
             self._inotify_fd = None
@@ -343,7 +343,7 @@ if AVAILABLE == 'pywin32':
 
         def __init__(self, monitor, refs_only):
             _BaseThread.__init__(self, monitor, refs_only)
-            self._worktree = self._transform_path(core.abspath(git.worktree()))
+            self._worktree = self._transform_path(core.abspath(git.getcwd()))
             self._worktree_watch = None
             self._git_dir = self._transform_path(core.abspath(git.git_path()))
             self._git_dir_watch = None

--- a/cola/git.py
+++ b/cola/git.py
@@ -85,12 +85,19 @@ def find_git_directory(curpath):
                   worktree=core.getenv('GIT_WORKTREE'),
                   git_file=None)
 
+    ceiling_dirs = set()
+    ceiling = core.getenv('GIT_CEILING_DIRECTORIES')
+    if ceiling:
+        ceiling_dirs.update([x for x in ceiling.split(':') if x])
+
     if not paths.git_dir or not paths.worktree:
         if curpath:
             curpath = core.abspath(curpath)
 
         # Search for a .git directory
         while curpath:
+            if curpath in ceiling_dirs:
+                break
             if is_git_dir(curpath):
                 paths.git_dir = curpath
                 if os.path.basename(curpath) == '.git':

--- a/cola/git.py
+++ b/cola/git.py
@@ -47,13 +47,18 @@ def is_git_worktree(d):
 
 
 def read_git_file(path):
-    if path is None:
-        return None
-    if is_git_file(path):
+    """Read the path from a .git-file
+
+    `None` is returned when <path> is not a .git-file.
+
+    """
+    result = None
+    if path and is_git_file(path):
+        header = 'gitdir: '
         data = core.read(path).strip()
-        if data.startswith('gitdir: '):
-            return data[len('gitdir: '):]
-    return None
+        if data.startswith(header):
+            result = data[len(header):]
+    return result
 
 
 class Git(object):

--- a/cola/git.py
+++ b/cola/git.py
@@ -66,10 +66,13 @@ class Git(object):
     The Git class manages communication with the Git binary
     """
     def __init__(self):
-        self._git_cwd = None #: The working directory used by execute()
         self._worktree = None
         self._git_file_path = None
+        self._git_cwd = None  #: The working directory used by execute()
         self.set_worktree(core.getcwd())
+
+    def getcwd(self):
+        return self._git_cwd
 
     def set_worktree(self, path):
         self._git_dir = core.decode(path)

--- a/cola/git.py
+++ b/cola/git.py
@@ -68,86 +68,112 @@ def read_git_file(path):
     return result
 
 
+class Paths(object):
+    """Git repository paths of interest"""
+
+    def __init__(self, git_dir=None, git_file=None, worktree=None):
+        self.git_dir = git_dir
+        self.git_file = git_file
+        self.worktree = worktree
+
+
+def find_git_directory(curpath):
+    """Perform Git repository discovery
+
+    """
+    paths = Paths(git_dir=core.getenv('GIT_DIR'),
+                  worktree=core.getenv('GIT_WORKTREE'),
+                  git_file=None)
+
+    if not paths.git_dir or not paths.worktree:
+        if curpath:
+            curpath = core.abspath(curpath)
+
+        # Search for a .git directory
+        while curpath:
+            if is_git_dir(curpath):
+                paths.git_dir = curpath
+                if os.path.basename(curpath) == '.git':
+                    paths.worktree = os.path.dirname(curpath)
+                break
+            gitpath = join(curpath, '.git')
+            if is_git_dir(gitpath):
+                paths.git_dir = gitpath
+                paths.worktree = curpath
+                break
+            curpath, dummy = os.path.split(curpath)
+            if not dummy:
+                break
+
+        git_dir_path = read_git_file(paths.git_dir)
+        if git_dir_path:
+            paths.git_file = paths.git_dir
+            paths.git_dir = git_dir_path
+
+    return paths
+
+
 class Git(object):
     """
     The Git class manages communication with the Git binary
     """
     def __init__(self):
-        self._worktree = None
-        self._git_file_path = None
+        self.paths = Paths()
+
         self._git_cwd = None  #: The working directory used by execute()
+        self._valid = {}  #: Store the result of is_git_dir() for performance
         self.set_worktree(core.getcwd())
 
     def getcwd(self):
         return self._git_cwd
 
+    def _find_git_directory(self, path):
+        self._git_cwd = None
+        self.paths = find_git_directory(path)
+
+        # Update the current directory for executing commands
+        if self.paths.worktree:
+            self._git_cwd = self.paths.worktree
+        elif self.paths.git_dir:
+            self._git_cwd = self.paths.git_dir
+
     def set_worktree(self, path):
-        self._git_dir = core.decode(path)
-        self._git_file_path = None
-        self._worktree = None
-        return self.worktree()
+        path = core.decode(path)
+        self._find_git_directory(path)
+        return self.paths.worktree
 
     def worktree(self):
-        if self._worktree:
-            return self._worktree
-        self.git_dir()
-        if self._git_dir:
-            curdir = self._git_dir
-        else:
-            curdir = core.getcwd()
-
-        if is_git_dir(join(curdir, '.git')):
-            return curdir
-
-        # Handle bare repositories
-        if (len(os.path.basename(curdir)) > 4
-                and curdir.endswith('.git')):
-            return curdir
-        if 'GIT_WORK_TREE' in os.environ:
-            self._worktree = core.getenv('GIT_WORK_TREE')
-        if not self._worktree or not core.isdir(self._worktree):
-            if self._git_dir:
-                gitparent = join(core.abspath(self._git_dir), '..')
-                self._worktree = core.abspath(gitparent)
-                self.set_cwd(self._worktree)
-        return self._worktree
+        if not self.paths.worktree:
+            path = core.abspath(core.getcwd())
+            self._find_git_directory(path)
+        return self.paths.worktree
 
     def is_valid(self):
-        return self._git_dir and is_git_dir(self._git_dir)
+        """Is this a valid git repostiory?
+
+        Cache the result to avoid hitting the filesystem.
+
+        """
+        git_dir = self.paths.git_dir
+        try:
+            valid = bool(git_dir) and self._valid[git_dir]
+        except KeyError:
+            valid = self._valid[git_dir] = is_git_dir(git_dir)
+
+        return valid
 
     def git_path(self, *paths):
-        if self._git_file_path is None:
-            return join(self.git_dir(), *paths)
+        if self.paths.git_dir:
+            result = join(self.paths.git_dir, *paths)
         else:
-            return join(self._git_file_path, *paths)
+            result = None
+        return result
 
     def git_dir(self):
-        if self.is_valid():
-            return self._git_dir
-        if 'GIT_DIR' in os.environ:
-            self._git_dir = core.getenv('GIT_DIR')
-        if self._git_dir:
-            curpath = core.abspath(self._git_dir)
-        else:
-            curpath = core.abspath(core.getcwd())
-        # Search for a .git directory
-        while curpath:
-            if is_git_dir(curpath):
-                self._git_dir = curpath
-                break
-            gitpath = join(curpath, '.git')
-            if is_git_dir(gitpath):
-                self._git_dir = gitpath
-                break
-            curpath, dummy = os.path.split(curpath)
-            if not dummy:
-                break
-        self._git_file_path = read_git_file(self._git_dir)
-        return self._git_dir
-
-    def set_cwd(self, path):
-        """Sets the current directory."""
-        self._git_cwd = path
+        if not self.paths.git_dir:
+            path = core.abspath(core.getcwd())
+            self._find_git_directory(path)
+        return self.paths.git_dir
 
     def __getattr__(self, name):
         git_cmd = functools.partial(self.git, name)

--- a/cola/git.py
+++ b/cola/git.py
@@ -26,16 +26,23 @@ def dashify(s):
     return s.replace('_', '-')
 
 
-def is_git_dir(d):
+def is_git_dir(git_dir):
     """From git's setup.c:is_git_directory()."""
-    if (core.isdir(d) and core.isdir(join(d, 'objects')) and
-            core.isdir(join(d, 'refs'))):
-        headref = join(d, 'HEAD')
-        return (core.isfile(headref) or
-                (core.islink(headref) and
-                    core.readlink(headref).startswith('refs')))
+    result = False
+    if git_dir:
+        headref = join(git_dir, 'HEAD')
 
-    return is_git_file(d)
+        if (core.isdir(git_dir) and
+                core.isdir(join(git_dir, 'objects')) and
+                core.isdir(join(git_dir, 'refs'))):
+
+            result = (core.isfile(headref) or
+                      (core.islink(headref) and
+                        core.readlink(headref).startswith('refs/')))
+        else:
+            result = is_git_file(git_dir)
+
+    return result
 
 
 def is_git_file(f):

--- a/cola/gitcfg.py
+++ b/cola/gitcfg.py
@@ -31,10 +31,13 @@ def current():
 
 def _stat_info():
     # Try /etc/gitconfig as a fallback for the system config
-    paths = (('system', '/etc/gitconfig'),
+    paths = [('system', '/etc/gitconfig'),
              ('user', _USER_XDG_CONFIG),
-             ('user', _USER_CONFIG),
-             ('repo', git.current().git_path('config')))
+             ('user', _USER_CONFIG)]
+    config = git.current().git_path('config')
+    if config:
+         paths.append(('repo', config))
+
     statinfo = []
     for category, path in paths:
         try:
@@ -46,10 +49,13 @@ def _stat_info():
 
 def _cache_key():
     # Try /etc/gitconfig as a fallback for the system config
-    paths = ('/etc/gitconfig',
+    paths = ['/etc/gitconfig',
              _USER_XDG_CONFIG,
-             _USER_CONFIG,
-             git.current().git_path('config'))
+             _USER_CONFIG]
+    config = git.current().git_path('config')
+    if config:
+        paths.append(config)
+
     mtimes = []
     for path in paths:
         try:

--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -116,7 +116,7 @@ class MainModel(Observable):
         self.git.set_worktree(worktree)
         is_valid = self.git.is_valid()
         if is_valid:
-            self.project = os.path.basename(self.git.worktree())
+            self.project = os.path.basename(self.git.getcwd())
         return is_valid
 
     def set_commitmsg(self, msg, notify=True):

--- a/test/git_test.py
+++ b/test/git_test.py
@@ -8,9 +8,116 @@ import signal
 import time
 import unittest
 
+from mock import patch
+
 from cola import git
 from cola.compat import WIN32
 from cola.git import STDOUT
+
+
+class GitModuleTestCase(unittest.TestCase):
+
+    @patch('cola.git.is_git_dir')
+    def test_find_git_dir_None(self, is_git_dir):
+
+        paths = git.find_git_directory(None)
+
+        self.assertFalse(is_git_dir.called)
+        self.assertEqual(None, paths.git_dir)
+        self.assertEqual(None, paths.git_file)
+        self.assertEqual(None, paths.worktree)
+
+    @patch('cola.git.is_git_dir')
+    def test_find_git_dir_empty_string(self, is_git_dir):
+
+        paths = git.find_git_directory('')
+
+        self.assertFalse(is_git_dir.called)
+        self.assertEqual(None, paths.git_dir)
+        self.assertEqual(None, paths.git_file)
+        self.assertEqual(None, paths.worktree)
+
+    @patch('cola.git.is_git_dir')
+    def test_find_git_dir_never_found(self, is_git_dir):
+        is_git_dir.return_value = False
+
+        paths = git.find_git_directory('/does/not/exist')
+
+        self.assertTrue(is_git_dir.called)
+        self.assertEqual(None, paths.git_dir)
+        self.assertEqual(None, paths.git_file)
+        self.assertEqual(None, paths.worktree)
+
+        self.assertEqual(8, is_git_dir.call_count)
+        kwargs = {}
+        is_git_dir.assert_has_calls([
+            (('/does/not/exist',), kwargs),
+            (('/does/not/exist/.git',), kwargs),
+            (('/does/not',), kwargs),
+            (('/does/not/.git',), kwargs),
+            (('/does',), kwargs),
+            (('/does/.git',), kwargs),
+            (('/',), kwargs),
+            (('/.git',), kwargs),
+        ])
+
+    @patch('cola.git.is_git_dir')
+    def test_find_git_dir_found_right_away(self, is_git_dir):
+        git_dir = '/seems/to/exist/.git'
+        worktree = '/seems/to/exist'
+        is_git_dir.return_value = True
+
+        paths = git.find_git_directory(git_dir)
+
+        self.assertTrue(is_git_dir.called)
+        self.assertEqual(git_dir, paths.git_dir)
+        self.assertEqual(None, paths.git_file)
+        self.assertEqual(worktree, paths.worktree)
+
+    @patch('cola.git.is_git_dir')
+    def test_find_git_does_discovery(self, is_git_dir):
+        git_dir = '/the/root/.git'
+        worktree = '/the/root'
+        is_git_dir.side_effect = lambda x: x == git_dir
+
+        paths = git.find_git_directory('/the/root/sub/dir')
+
+        self.assertEqual(git_dir, paths.git_dir)
+        self.assertEqual(None, paths.git_file)
+        self.assertEqual(worktree, paths.worktree)
+
+    @patch('cola.git.read_git_file')
+    @patch('cola.git.is_git_file')
+    @patch('cola.git.is_git_dir')
+    def test_find_git_honors_git_files(self,
+                                       is_git_dir,
+                                       is_git_file,
+                                       read_git_file):
+        git_file = '/the/root/.git'
+        worktree = '/the/root'
+        git_dir = '/super/module/.git/modules/root'
+
+        is_git_dir.side_effect = lambda x: x == git_file
+        is_git_file.side_effect = lambda x: x == git_file
+        read_git_file.return_value = git_dir
+
+        paths = git.find_git_directory('/the/root/sub/dir')
+
+        self.assertEqual(git_dir, paths.git_dir)
+        self.assertEqual(git_file, paths.git_file)
+        self.assertEqual(worktree, paths.worktree)
+
+        kwargs = {}
+        self.assertEqual(6, is_git_dir.call_count)
+        is_git_dir.assert_has_calls([
+            (('/the/root/sub/dir',), kwargs),
+            (('/the/root/sub/dir/.git',), kwargs),
+            (('/the/root/sub',), kwargs),
+            (('/the/root/sub/.git',), kwargs),
+            (('/the/root',), kwargs),
+            (('/the/root/.git',), kwargs),
+        ])
+        read_git_file.assert_called_once_with('/the/root/.git')
 
 
 class GitCommandTest(unittest.TestCase):


### PR DESCRIPTION
Refactor the git module to simplify the code and make it more amenable to testing.
Teach fsmonitor, gitcfg, and app startup to handle bare repositories.
Teach the git discovery code to honor GIT_CEILING_DIRECTORIES.
Add unit tests covering various aspects of repository discovery.

Signed-off-by: David Aguilar <davvid@gmail.com>