### PR TITLE
Read per-repository configuration when launched from a desktop icon

### DIFF
--- a/cola/app.py
+++ b/cola/app.py
@@ -240,10 +240,6 @@ def process_args(args):
         core.stderr(errmsg)
         sys.exit(EX_USAGE)
 
-    # We do everything relative to the repo root
-    os.chdir(args.repo)
-    return repo
-
 
 def restore_session(args):
     # args.settings is provided when restoring from a session.
@@ -354,8 +350,6 @@ def new_model(app, repo, prompt=False, settings=None):
             sys.exit(EX_NOINPUT)
         valid = model.set_worktree(gitdir)
 
-    # Finally, go to the root of the git repo
-    os.chdir(model.git.getcwd())
     return model
 
 

--- a/cola/app.py
+++ b/cola/app.py
@@ -162,7 +162,7 @@ class ColaApplication(object):
         qtutils.install()
         icons.install()
 
-        QtCore.QObject.connect(fsmonitor.instance(), SIGNAL('files_changed'),
+        QtCore.QObject.connect(fsmonitor.current(), SIGNAL('files_changed'),
                                self._update_files)
 
         if gui:
@@ -283,7 +283,7 @@ def application_start(context, view, monitor_refs_only=False):
     init_update_task(view, runtask, context.model)
 
     # Start the filesystem monitor thread
-    fsmonitor.instance().start(monitor_refs_only)
+    fsmonitor.current().start(monitor_refs_only)
 
     msg_timer = QtCore.QTimer()
     msg_timer.setSingleShot(True)
@@ -294,7 +294,7 @@ def application_start(context, view, monitor_refs_only=False):
     result = context.app.exec_()
 
     # All done, cleanup
-    fsmonitor.instance().stop()
+    fsmonitor.current().stop()
     QtCore.QThreadPool.globalInstance().waitForDone()
 
     tmpdir = utils.tmpdir()

--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -1073,8 +1073,8 @@ class OpenRepo(Command):
         git = self.model.git
         old_repo = git.gitcwd()
         if self.model.set_worktree(self.repo_path):
-            fsmonitor.instance().stop()
-            fsmonitor.instance().start()
+            fsmonitor.current().stop()
+            fsmonitor.current().start()
             self.model.update_status()
         else:
             self.model.set_worktree(old_repo)
@@ -1262,7 +1262,7 @@ class Refresh(Command):
 
     def do(self):
         self.model.update_status(update_index=True)
-        fsmonitor.instance().refresh()
+        fsmonitor.current().refresh()
 
 
 class RevertEditsCommand(ConfirmAction):

--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -1071,18 +1071,13 @@ class OpenRepo(Command):
 
     def do(self):
         git = self.model.git
-        old_worktree = git.worktree()
-        if not self.model.set_worktree(self.repo_path):
-            self.model.set_worktree(old_worktree)
-            return
-        new_worktree = git.worktree()
-        core.chdir(new_worktree)
-        self.model.set_directory(self.repo_path)
-        cfg = gitcfg.current()
-        cfg.reset()
-        fsmonitor.instance().stop()
-        fsmonitor.instance().start()
-        self.model.update_status()
+        old_repo = git.gitcwd()
+        if self.model.set_worktree(self.repo_path):
+            fsmonitor.instance().stop()
+            fsmonitor.instance().start()
+            self.model.update_status()
+        else:
+            self.model.set_worktree(old_repo)
 
 
 class Clone(Command):

--- a/cola/fsmonitor.py
+++ b/cola/fsmonitor.py
@@ -434,7 +434,7 @@ if AVAILABLE == 'pywin32':
 
 
 @memoize
-def instance():
+def current():
     return _create_instance()
 
 

--- a/cola/fsmonitor.py
+++ b/cola/fsmonitor.py
@@ -11,6 +11,7 @@ import select
 from threading import Lock
 
 from cola import utils
+from cola.decorators import memoize
 
 AVAILABLE = None
 
@@ -432,13 +433,9 @@ if AVAILABLE == 'pywin32':
             self.wait()
 
 
-_instance = None
-
+@memoize
 def instance():
-    global _instance
-    if _instance is None:
-        _instance = _create_instance()
-    return _instance
+    return _create_instance()
 
 
 def _create_instance():

--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -9,6 +9,7 @@ import os
 from cola import core
 from cola import git
 from cola import gitcmds
+from cola import gitcfg
 from cola.git import STDOUT
 from cola.observable import Observable
 from cola.decorators import memoize
@@ -30,7 +31,6 @@ class MainModel(Observable):
     message_about_to_update = 'about_to_update'
     message_commit_message_changed = 'commit_message_changed'
     message_diff_text_changed = 'diff_text_changed'
-    message_directory_changed = 'directory_changed'
     message_filename_changed = 'filename_changed'
     message_mode_about_to_change = 'mode_about_to_change'
     message_mode_changed = 'mode_changed'
@@ -116,7 +116,11 @@ class MainModel(Observable):
         self.git.set_worktree(worktree)
         is_valid = self.git.is_valid()
         if is_valid:
-            self.project = os.path.basename(self.git.getcwd())
+            cwd = self.git.getcwd()
+            self.project = os.path.basename(cwd)
+            self.set_directory(cwd)
+            core.chdir(cwd)
+            gitcfg.current().reset()
         return is_valid
 
     def set_commitmsg(self, msg, notify=True):
@@ -137,7 +141,6 @@ class MainModel(Observable):
 
     def set_directory(self, path):
         self.directory = path
-        self.notify_observers(self.message_directory_changed, path)
 
     def set_filename(self, filename):
         self.filename = filename

--- a/share/doc/git-cola/relnotes/v2.6.rst
+++ b/share/doc/git-cola/relnotes/v2.6.rst
@@ -26,3 +26,8 @@ Fixes
   https://github.com/git-cola/git-cola/issues/545
 
   https://github.com/git-cola/git-cola/pulls/546
+
+* Per-repository git configuration is now properly detected when launching
+  `git cola` from an application launcher.
+
+  https://github.com/git-cola/git-cola/issues/548


### PR DESCRIPTION
Move common functionality into the main model to fix a subtle bug when launching
from a desktop icon, and to simplify responsibility for callers.

Closes #548 
Signed-off-by: David Aguilar <davvid@gmail.com>