### PR TITLE
Add Ctrl+K shortcut to focus status window

### DIFF
--- a/cola/hotkeys.py
+++ b/cola/hotkeys.py
@@ -32,6 +32,7 @@ MOVE_UP_SECONDARY = Qt.AltModifier + Qt.Key_K
 MOVE_UP_TERTIARY = Qt.ShiftModifier + Qt.Key_K
 MOVE_RIGHT = Qt.Key_L
 FOCUS = Qt.ControlModifier + Qt.Key_L
+FOCUS_STATUS = Qt.ControlModifier + Qt.Key_K
 AMEND = Qt.ControlModifier + Qt.Key_M
 MERGE = Qt.ControlModifier + Qt.ShiftModifier + Qt.Key_M
 PUSH = Qt.ControlModifier + Qt.Key_P

--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -703,13 +703,16 @@ class MainView(standard.MainWindow):
             # Create a new shortcut Shift+<shortcut> that gives focus
             toggleview = QtGui.QAction(self)
             toggleview.setShortcut(shortcut)
+
             def focusdock(dockwidget=dockwidget):
                 focus_dock(dockwidget)
             self.addAction(toggleview)
             qtutils.connect_action(toggleview, focusdock)
 
         focus = lambda: focus_dock(self.commitdockwidget)
+        focus_status = lambda: focus_dock(self.statusdockwidget)
         qtutils.add_action(self, 'Focus Commit Message', focus, hotkeys.FOCUS)
+        qtutils.add_action(self, 'Focus Status Window', focus_status, hotkeys.FOCUS_STATUS)
 
     def preferences(self):
         return prefs_widget.preferences(model=self.prefs_model, parent=self)


### PR DESCRIPTION
Hi, I didn't see anything about your policy on pull requests but since you have a how-to fork line I thought I might just send it directly.

Using CTRL+L to focus the commit message box came naturally but going back to the status window was not as intuitive. I figured CTRL+K is a good choice since CTRL+L came to me from browser use and CTRL+K is sometimes used for the search box in browsers (e.g. firefox)

If you don't want to merge it that's fine though.