### PR TITLE
Fix main Read the Docs links

### DIFF
--- a/share/doc/git-cola/_themes/sphinx_rtd_theme/footer.html
+++ b/share/doc/git-cola/_themes/sphinx_rtd_theme/footer.html
@@ -28,6 +28,6 @@
     </p>
   </div>
 
-  {% trans %}Built with <a href="http://sphinx-doc.org/">Sphinx</a> using a <a href="https://github.com/snide/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.io">Read the Docs</a>{% endtrans %}.
+  {% trans %}Built with <a href="http://sphinx-doc.org/">Sphinx</a> using a <a href="https://github.com/snide/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>{% endtrans %}.
   
 </footer>

--- a/share/doc/git-cola/_themes/sphinx_rtd_theme/versions.html
+++ b/share/doc/git-cola/_themes/sphinx_rtd_theme/versions.html
@@ -29,7 +29,7 @@
           </dd>
       </dl>
       <hr/>
-      Free document hosting provided by <a href="http://www.readthedocs.io">Read the Docs</a>.
+      Free document hosting provided by <a href="https://readthedocs.org">Read the Docs</a>.
 
     </div>
   </div>


### PR DESCRIPTION
The main Read the Docs site is still at `readthedocs.org`, so switch those links back from `readthedocs.io`.