### PR TITLE
fix early crash on python3 + PyQt5

### DIFF
--- a/cola/compat.py
+++ b/cola/compat.py
@@ -14,7 +14,12 @@ WIN32 = sys.platform == 'win32' or sys.platform == 'cygwin'
 
 try:
     # pylint: disable=bytes-builtin
-    bstr = bytes
+    bytes()
+    if PY3:
+        def bstr(x):
+            return bytes(x, encoding='latin1')
+    else:
+        bstr = bytes
 except NameError:
     # Python <= 2.5
     bstr = str

--- a/cola/widgets/standard.py
+++ b/cola/widgets/standard.py
@@ -2,6 +2,7 @@ from __future__ import division, absolute_import, unicode_literals
 
 import time
 
+import qtpy
 from qtpy import QtCore
 from qtpy import QtGui
 from qtpy import QtWidgets
@@ -128,9 +129,12 @@ class MainWindowMixin(WidgetMixin):
         if windowstate is None:
             result = False
         else:
+            windowstate = str(windowstate)
+            if qtpy.PYQT5:
+                windowstate = str.encode(windowstate, encoding='us-ascii')
             from_base64 = QtCore.QByteArray.fromBase64
             result = self.restoreState(
-                    from_base64(str(windowstate)),
+                    from_base64(windowstate),
                     self.widget_version) and result
         self.lock_layout = state.get('lock_layout', self.lock_layout)
         self.update_dockwidget_lock_state()


### PR DESCRIPTION
Must pass "bytes" data type to QByteArray in PyQt5.