### PR TITLE
Allow auto-reset of "Bypass Commit Hooks" setting

### DIFF
--- a/cola/widgets/commitmsg.py
+++ b/cola/widgets/commitmsg.py
@@ -460,6 +460,7 @@ class CommitMessageEditor(QtWidgets.QWidget):
         sign = self.sign_action.isChecked()
         status, out, err = cmds.do(cmds.Commit, amend, msg, sign,
                                    no_verify=no_verify)
+        self.bypass_commit_hooks_action.setChecked(False)
         if status != 0:
             Interaction.critical(N_('Commit failed'),
                                  N_('"git commit" returned exit code %s') %


### PR DESCRIPTION
This feature is typically used in exceptional cases (e.g. commit something that I will not push unchanged), so my usual workflow is to reset the flag immediately after using it. Add a configuration for auto-resetting that flag.