### PR TITLE
Added custom name for favorites item

### DIFF
--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -569,10 +569,11 @@ class RemoteRename(RemoteCommand):
 
 class RemoveFromSettings(ConfirmAction):
 
-    def __init__(self, settings, repo, icon=None):
+    def __init__(self, settings, repo, name, icon=None):
         ConfirmAction.__init__(self)
         self.settings = settings
         self.repo = repo
+        self.name = name
         self.icon = icon
 
     def success(self):
@@ -582,14 +583,14 @@ class RemoveFromSettings(ConfirmAction):
 class RemoveBookmark(RemoveFromSettings):
 
     def confirm(self):
-        repo = self.repo
+        name = self.name
         title = msg = N_('Delete Bookmark?')
-        info = N_('%s will be removed from your bookmarks.') % repo
+        info = N_('%s will be removed from your bookmarks.') % name
         ok_text = N_('Delete Bookmark')
         return Interaction.confirm(title, msg, info, ok_text, icon=self.icon)
 
     def action(self):
-        self.settings.remove_bookmark(self.repo)
+        self.settings.remove_bookmark(self.repo,self.name)
         return (0, '', '')
 
 
@@ -1425,9 +1426,10 @@ class RunConfigAction(Command):
 
 class SetDefaultRepo(Command):
 
-    def __init__(self, repo):
+    def __init__(self, repo, name):
         Command.__init__(self)
         self.repo = repo
+        self.name = name
 
     def do(self):
         gitcfg.current().set_user('cola.defaultrepo', self.repo)

--- a/cola/settings.py
+++ b/cola/settings.py
@@ -63,7 +63,7 @@ class Settings(object):
         missing_recent = []
 
         for bookmark in self.bookmarks:
-            if not self.verify(bookmark):
+            if not self.verify(bookmark['path']):
                 missing_bookmarks.append(bookmark)
 
         for bookmark in missing_bookmarks:
@@ -82,13 +82,15 @@ class Settings(object):
             except:
                 pass
 
-    def add_bookmark(self, bookmark):
+    def add_bookmark(self, path, name):
         """Adds a bookmark to the saved settings"""
+        bookmark = { 'path': path, 'name' : name }
         if bookmark not in self.bookmarks:
             self.bookmarks.append(bookmark)
 
-    def remove_bookmark(self, bookmark):
+    def remove_bookmark(self, path, name):
         """Remove a bookmark"""
+        bookmark = { 'path': path, 'name' : name }
         if bookmark in self.bookmarks:
             self.bookmarks.remove(bookmark)
 


### PR DESCRIPTION
* Refs: #599
* Custom name for favorites item.
* Recent item name is now full path.
* Very initial implementation. My first contact with Python.
* TODO:
- [ ] Old settings file (~/.config/git-cola/settings) must be removed. Make compatibility.
- [ ] Unify 2 prompt windows when add favorite on one window.
- [ ]  Traductions for new strings.
- [ ] Add rename line on contextual menu.
- [ ]  Extend renaming to recent repo list.


