### PR TITLE
Update DAG window when shown again

### DIFF
--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -707,8 +707,7 @@ class MainView(standard.MainWindow):
         return prefs_widget.preferences(model=self.prefs_model, parent=self)
 
     def git_dag(self):
-        if self.dag is None:
-            self.dag = dag.git_dag(self.model)
+        self.dag = dag.git_dag(self.model, existing_view=self.dag)
         view = self.dag
         view.show()
         view.raise_()


### PR DESCRIPTION
293364b45c4cbf3faff3fd7aba79b474d0abc845 introduced the problem that e.g. the displayed branch isn't updated when opening the DAG window a second time from the menu. I noticed because I switch between Git repositories all the time using bookmarks, and suddenly the DAG tried to show a feature branch that wasn't in the current repo ;)

This change adds an option to update an existing DAG view, which is used when opened from the main widget.