### PR TITLE
widgets/browse: fix save bug for "Grab File..."

### DIFF
--- a/cola/widgets/browse.py
+++ b/cola/widgets/browse.py
@@ -630,7 +630,7 @@ class BrowseDialog(QtWidgets.QDialog):
         filenames = self.tree.selected_files()
         if not filenames:
             return
-        self.path_chosen(filenames[0], close=True)
+        self.save_path(filenames[0])
 
     def selection_changed(self):
         """Update actions based on the current selection"""


### PR DESCRIPTION
Fixes bug #616

The save button did not prompt to enter a location to save the blob
This change replaces one (presumably) wrong method call with the same
method call that is used when double-clicking a file instead of using
the save button.