### PR TITLE
Require remote branch to be specified in Push dialog for non-fast forward mode since implementation only does force-push in that case

### DIFF
--- a/cola/widgets/remote.py
+++ b/cola/widgets/remote.py
@@ -438,6 +438,14 @@ class RemoteActionDialog(standard.Dialog):
                 info_txt = N_('Force fetching from %s?') % remote
                 ok_text = N_('Force Fetch')
             elif action == PUSH:
+                if not remote_branch:
+                    # Push implementation (see function `refspec_arg`) only
+                    # does force-push if remote branch name is given
+                    title = N_('Force Push')
+                    msg = N_('You must first select the remote branch for a force-push.')
+                    qtutils.critical(title, msg)
+                    return
+
                 title = N_('Force Push?')
                 msg = N_('Non-fast-forward push overwrites published '
                          'history!\n(Did you pull first?)')


### PR DESCRIPTION
Even if "Fast Forward Only" was deselected, a branch wouldn't be force-pushed unless the remote branch is selected in the dialog. That's because of the implementation

```
def refspec(src, dst, ffwd, push=False):
    if push and src == dst:
        spec = src
    else:
        spec = '%s:%s' % (src, dst)
    if not ffwd:
        spec = '+' + spec # <-----------
    return spec


def refspec_arg(local_branch, remote_branch, ffwd, pull, push):
    """Return the refspec for a fetch or pull command"""
    if not pull and local_branch and remote_branch: # <-------------
        what = refspec(remote_branch, local_branch, ffwd, push=push)
    else:
        what = local_branch or remote_branch or None
    return what
```

This change therefore requires the remote branch to be selected. I could have changed the implementation, but I think since force-push is so dangerous, it's a safe choice to require the user to select the target.