### PR TITLE
Revert "app: Make homebrew work by default"

### DIFF
--- a/cola/app.py
+++ b/cola/app.py
@@ -9,14 +9,6 @@ __copyright__ = """
 Copyright (C) 2009-2016 David Aguilar and contributors
 """
 
-# Make homebrew work by default
-if sys.platform == 'darwin':
-    from distutils import sysconfig
-    python_version = sysconfig.get_python_version()
-    homebrew_mods = '/usr/local/lib/python%s/site-packages' % python_version
-    if os.path.isdir(homebrew_mods):
-        sys.path.append(homebrew_mods)
-
 from . import core
 try:
     from qtpy import QtCore


### PR DESCRIPTION
This change was introduced to fix Homebrew/legacy-homebrew#7462, which describes an installation issue that is specific to Homebrew and not to macOS in general. If Homebrew really needs this workaround, this change should be applied as a local patch instead of forcing /usr/local to be added to sys.path for everyone.

MacPorts has to remove this addition to sys.path, see macports/macports-ports@e215228a4a18d51ae099e63ad1b416757af64150

If the git-cola maintainers insist on this `sys.path` addition and there is no other solution to be found for Homebrew, I am also fine with keeping the local patch in MacPorts, but in my opinion the maintenance overhead should be where problems are introduced.

I could not find responsible maintainers from @Homebrew to specifically mention on this.

This reverts commit 9674055ba59182c488e32d225331dbcda6ba3afd.