### PR TITLE
commitmsg: keep spellcheck selection after exit

### DIFF
--- a/cola/models/prefs.py
+++ b/cola/models/prefs.py
@@ -30,6 +30,7 @@ TABWIDTH = 'cola.tabwidth'
 TEXTWIDTH = 'cola.textwidth'
 USER_EMAIL = 'user.email'
 USER_NAME = 'user.name'
+SPELL_CHECK = 'cola.spellcheck'
 
 
 def default_blame_viewer():
@@ -86,6 +87,8 @@ def history_browser():
 def linebreak():
     return gitcfg.current().get(LINEBREAK, True)
 
+def spellcheck():
+    return gitcfg.current().get(SPELL_CHECK, False)
 
 def sort_bookmarks():
     return gitcfg.current().get(SORT_BOOKMARKS, True)

--- a/cola/widgets/prefs.py
+++ b/cola/widgets/prefs.py
@@ -170,6 +170,7 @@ class SettingsFormWidget(FormWidget):
         self.sort_bookmarks = qtutils.checkbox()
         self.bold_headers = qtutils.checkbox()
         self.save_gui_settings = qtutils.checkbox()
+        self.check_spelling = qtutils.checkbox()
 
         self.add_row(N_('Fixed-Width Font'), self.fixed_font)
         self.add_row(N_('Font Size'), self.font_size)
@@ -186,6 +187,7 @@ class SettingsFormWidget(FormWidget):
         self.add_row(N_('Bold with dark background font instead of italic '
                         'headers (restart required)'), self.bold_headers)
         self.add_row(N_('Save GUI Settings'), self.save_gui_settings)
+        self.add_row(N_('Check spelling'), self.check_spelling)
 
         self.set_config({
             prefs.SAVEWINDOWSETTINGS: (self.save_gui_settings, True),
@@ -202,6 +204,7 @@ class SettingsFormWidget(FormWidget):
                                  prefs.default_blame_viewer()),
             prefs.MERGE_KEEPBACKUP: (self.keep_merge_backups, True),
             prefs.MERGETOOL: (self.mergetool, 'xxdiff'),
+            prefs.SPELL_CHECK: (self.check_spelling, False),
         })
 
         self.fixed_font.currentFontChanged.connect(self.current_font_changed)


### PR DESCRIPTION
The spellcheck setting was stored in checkbox and reseted after program exit.
The setting is now stored via gitcfg and retrieved after program startup.
Also, add another spellcheck checkbox in preferences window.

Motivation: #596 #632 

Signed-off-by: Szymon Judasz szymon.judasz@student.uj.edu.pl