### PR TITLE
Prevent label overlapping in DAG

### DIFF
--- a/cola/models/dag.py
+++ b/cola/models/dag.py
@@ -101,6 +101,7 @@ class Commit(object):
                  'email',
                  'generation',
                  'column',
+                 'row',
                  'parsed')
 
     def __init__(self, oid=None, log_entry=None):
@@ -115,6 +116,7 @@ class Commit(object):
         self.parsed = False
         self.generation = CommitFactory.root_generation
         self.column = None
+        self.row = None
         if log_entry:
             self.parse(log_entry)
 

--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -1702,7 +1702,7 @@ coordinates based on its row and column multiplied by the coefficient.
 
         for node in self.commits:
             x_pos = x_min + node.column * x_off
-            y_pos = y_off + node.generation * y_off
+            y_pos = y_off + node.row * y_off
 
             positions[node.oid] = (x_pos, y_pos)
 

--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -1092,7 +1092,7 @@ class GraphView(QtWidgets.QGraphicsView, ViewerMixin):
     y_adjust = Commit.commit_radius*4/3
 
     x_off = 18
-    y_off = 24
+    y_off = -24
 
     def __init__(self, notifier, parent):
         QtWidgets.QGraphicsView.__init__(self, parent)
@@ -1595,7 +1595,7 @@ coordinates based on its row and column multiplied by the coefficient.
 
         for node in self.commits:
             x_pos = x_min + node.column * x_off
-            y_pos = -y_off - node.generation * y_off
+            y_pos = y_off + node.generation * y_off
 
             positions[node.oid] = (x_pos, y_pos)
 

--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -1595,7 +1595,7 @@ coordinates based on its row and column multiplied by the coefficient.
 
         for node in self.commits:
             x_pos = x_min + node.column * x_off
-            y_pos = y_off - node.generation * y_off
+            y_pos = -y_off - node.generation * y_off
 
             positions[node.oid] = (x_pos, y_pos)
 

--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -1512,7 +1512,7 @@ gather than 1, but leave_column method is written in generic way.
 
     Initialization is performed by reset_columns method. Column allocation is
 implemented in alloc_column method. Initialization and main loop are in
-recompute_columns method. Main loop also embeds row assignment algorithm by
+recompute_grid method. Main loop also embeds row assignment algorithm by
 implementation. So, the algorithm initialization is also performed during
 recompute_grid method by calling reset_rows.
 
@@ -1633,7 +1633,7 @@ coordinates based on its row and column multiplied by the coefficient.
         else:
             self.columns[column] = count - 1
 
-    def recompute_columns(self):
+    def recompute_grid(self):
         self.reset_columns()
         self.reset_rows()
 
@@ -1690,7 +1690,7 @@ coordinates based on its row and column multiplied by the coefficient.
                     self.propagate_frontier(child.column, node.row + 1)
 
     def position_nodes(self):
-        self.recompute_columns()
+        self.recompute_grid()
 
         x_max = self.x_max
         x_min = self.x_min


### PR DESCRIPTION
The patch series improves DAG laying out algorithm to prevent label overlapping with commits and other labels. It introduces row distribution technique and embeds it into column distribution algorithm.

The difference could be easy seen by adding tags to left branch commits of parallel branches.

![before](https://cloud.githubusercontent.com/assets/14236428/22302164/067e5784-e347-11e6-8fb4-6c80e1e32e00.png)
![after](https://cloud.githubusercontent.com/assets/14236428/22302166/0870e55c-e347-11e6-8a33-3f832c03a5cf.png)


First patch fixes incorrect DAG scrolling. If bottom commit generation is zero then it is hidden below bottom edge of the widget. The issue could be reproduced by showing whole the graph.

![scrolling bug](https://cloud.githubusercontent.com/assets/14236428/22302017/889ab722-e346-11e6-9b46-1fb798ad55b5.png)
