### PR TITLE
Simplify column assignment algorithm

### DIFF
--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -1672,14 +1672,14 @@ coordinates based on its row and column multiplied by the coefficient.
                     if parent.column == node.column:
                         continue
                     if parent.column is None:
-                        # Parent is in not among commits being layoutted, so it
+                        # Parent is in not among commits being laid out. Hence, it
                         # have no column.
                         continue
                     self.leave_column(parent.column)
 
             node.row = self.alloc_cell(node.column, node.tags)
 
-            # Propagate column to children which are still without one. Also
+            # Allocate columns for children which are still without one. Also
             # propagate frontier for children.
             if node.is_fork():
                 sorted_children = sorted(node.children,
@@ -1708,6 +1708,8 @@ coordinates based on its row and column multiplied by the coefficient.
                     # Note that frontier is propagated in course of alloc_cell.
                 elif child.column != node.column:
                     # Child node have other parents and occupies side column.
+                    # But frontier must be propagated with respect to this
+                    # parent.
                     self.propagate_frontier(child.column, node.row + 1)
 
     def position_nodes(self):

--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -1525,47 +1525,37 @@ commit which occupies different column. This meets first aim.
 that a node will be visited after all its parents.
 
     The set of occupied columns are maintained during work. Initially it is
-empty and no node occupied a column. Empty columns are selected by request in
-index ascend order starting from 0. Each column has its reference counter.
-Being allocated a column is assigned 1 reference. When a counter reaches 0 the
-column is removed from occupied column set. Currently no counter becomes
-gather than 1, but leave_column method is written in generic way.
+empty and no node occupied a column. Empty columns are allocated on demand.
+Index of allocated column is selected in ascend order starting from 0. The
+index is added to set of occupied column.
 
     Initialization is performed by reset_columns method. Column allocation is
 implemented in alloc_column method. Initialization and main loop are in
-recompute_grid method. Main loop also embeds row assignment algorithm by
-implementation. So, the algorithm initialization is also performed during
-recompute_grid method by calling reset_rows.
+recompute_grid method. The method also embeds row assignment algorithm by
+implementation.
 
     Actions for each node are follow.
     1. If the node was not assigned a column then it is assigned empty one.
-    2. Handle columns occupied by parents. Handling is leaving columns of some
-parents. One of parents occupies same column as the node. The column should not
-be left. Hence if the node is not a merge then nothing is done during the step.
-Other parents of merge node are processed in follow way.
-    2.1. If parent is fork then a brother node could be at column of the
-parent. So, the column cannot be left. Note that the brother itself or one of
-its descendant will perform the column leaving at appropriate time.
-    2.2 The parent may not occupy a column. This is possible when some commits
-were not added to the DAG (during repository reading, for instance). No column
-should be left.
-    2.3. Leave column of the parent. The parent is a regular commit. Its
-outgoing edge is turned form its column to column of the node. Hence, the
-column is left.
-    3. Get row for the node.
-    4. Define columns and rows of children.
-    4.1 If a child have a column assigned then it should no be overridden. One
-of children is assigned same column as the node. If the node is a fork then the
+    2. Allocate row.
+    3. Allocate columns for children.
+    If a child have a column assigned then it should no be overridden. One of
+children is assigned same column as the node. If the node is a fork then the
 child is chosen in generation descent order. This is a heuristic and it only
 affects resulting appearance of the graph. Other children are assigned empty
 columns in same order. It is the heuristic too.
-    4.2 All children will got row during step 3 of its iteration. But frontier
-must be propagated during this iteration to meet first aim of the row
-assignment algorithm. Frontier of child that occupies same row was propagated
-during step 3. Hence, it must be propagated for children on side columns.
+    4. If no child occupies column of the node then leave it.
+    It is possible in consequent situations.
+    4.1 The node is a leaf.
+    4.2 The node is a fork and all its children are already assigned side
+column. It is possible if all the children are merges.
+    4.3 Single node child is a merge that is already assigned a column.
+    5. Propagate frontier with respect to this node.
+    Each frontier entry corresponding to column occupied by any node's child
+must be gather than node row index. This meets first aim of the row assignment
+algorithm.
+    Note that frontier of child that occupies same row was propagated during
+step 2. Hence, it must be propagated for children on side columns.
 
-    After the algorithm was done all commit graphic items are assigned
-coordinates based on its row and column multiplied by the coefficient.
     """
 
     def reset_columns(self):


### PR DESCRIPTION
A graph configuration is found that is not correctly handled using current way to maintain occupied column set. If all children of a fork commit are merges and they are assigned a column before the commit processing then no one of children will be assigned same column. Also, no one of them will left parent's column because of the condition in the main loop. In other configuration the column is left when a non-fork ancestor at the column merges. But, in current configuration, no child remains on the column. As a result, the column 'leaks'. This causes the graph spreading.

Such configuration is not found in Git-Cola graph. I've found one in Qemu graph. After selected fork the 7-th column leaks.

![example](https://cloud.githubusercontent.com/assets/14236428/22474360/036fdbbe-e7f5-11e6-909d-a73e12329b74.png)

Investigating the bug I have realized that fixing up the predicate is possible but it will result in new nested loop. Instead, another way was found. It is described in comments and commit messages.