### PR TITLE
Fix up infinity loop bug while multiroot graph drawing

### DIFF
--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -1586,7 +1586,11 @@ step 2. Hence, it must be propagated for children on side columns.
 
     def declare_column(self, column):
         if self.frontier:
-            # Align new column frontier by frontier of nearest column.
+            # Align new column frontier by frontier of nearest column. If all
+            # columns were left then select maximum frontier value.
+            if not self.columns:
+                self.frontier[column] = max(self.frontier.values())
+                return
             # This is heuristic that mostly affects roots. Note that the
             # frontier values for fork children will be overridden in course of
             # propagate_frontier.


### PR DESCRIPTION
I just faced a DAG window freezing. When a column is allocated after all columns were left, declare_column method falls into infinity loop searching for an occupied column. The situation may occurs during multiroot graph drawing.