### PR TITLE
Depth-first traversal column reset

### DIFF
--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -1652,8 +1652,21 @@ step 2. Hence, it must be propagated for children on side columns.
     """
 
     def reset_columns(self):
+        # Some children of displayed commits might not be accounted in
+        # 'commits' list. It is common case during loading of big graph.
+        # But, they are assigned a column that must be reseted. Hence, use
+        # depth-first traversal to reset all columns assigned.
         for node in self.commits:
-            node.column = None
+            if node.column is None:
+                continue
+            stack = [node]
+            while stack:
+                node = stack.pop()
+                node.column = None
+                for child in node.children:
+                    if child.column is not None:
+                        stack.append(child)
+
         self.columns = {}
         self.max_column = 0
         self.min_column = 0

--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -1771,10 +1771,7 @@ step 2. Hence, it must be propagated for children on side columns.
         return cell_row
 
     def propagate_frontier(self, column, value):
-        try:
-            current = self.frontier[column]
-        except KeyError:
-            current = self.frontier[column] = max(self.frontier.values())
+        current = self.frontier[column]
         if current < value:
             self.frontier[column] = value
 


### PR DESCRIPTION
I've investigated the issue about KeyError in propagate_frontier. That was 52-th column in may case. Sometimes the error had not appeared. Hence, I guess the error is related to non-determinism of incremental graph loading. All children of currently added nodes are assigned a column. But, some of them might not be reset because they are not added yet. During consequent iteration the algorithm assumes that corresponding column is allocated because it was not reset. This time the error raises.

I suggest to use depth-first traversal of graph during reset. Complexity of the algorithm seems to remain O(N) while this guaranties that all nodes are reset.

I had not got an error during 10 runs. However, it would be nice if you check it at your side.