### PR TITLE
return abspath in read_git_file for submodule

### DIFF
--- a/cola/git.py
+++ b/cola/git.py
@@ -67,6 +67,9 @@ def read_git_file(path):
         data = core.read(path).strip()
         if data.startswith(header):
             result = data[len(header):]
+    if result and not os.path.isabs(result):
+        path_folder = os.path.dirname(path)
+        result = os.path.join(path_folder, result)
     return result
 
 


### PR DESCRIPTION
should return an absolute path if a relative path is in the .git file of a submodule