### PR TITLE
for submodule's folder,if stage with /,stage all files in it in windows

### DIFF
--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -467,8 +467,8 @@ class MainModel(Observable):
 
         for path in set(paths):
             if core.exists(path):
-                if path[-1:] == '/':
-                    path = path[:-1]
+                if path.endswith('/'):
+                    path = path.rstrip('/')
                 add.append(path)
             else:
                 remove.append(path)

--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -467,6 +467,8 @@ class MainModel(Observable):
 
         for path in set(paths):
             if core.exists(path):
+                if path[-1:] == '/':
+                    path = path[:-1]
                 add.append(path)
             else:
                 remove.append(path)


### PR DESCRIPTION
After adding a submodule, its folder will be shown in untracked. However, git add folder/ will add all files in folder in windows and git add folder will only add the submodule's folder. Or one can do this check in status.py, but I think in gui, adding a folder will never happen because it always shows untracked or modified files one by one