### PR TITLE
editremotes: update referenced attribute, fixes #684

### DIFF
--- a/cola/widgets/editremotes.py
+++ b/cola/widgets/editremotes.py
@@ -123,7 +123,7 @@ class RemoteEditor(standard.Dialog):
         widget = AddRemoteWidget(self)
         if not widget.add_remote():
             return
-        name = widget.name.value()
+        name = widget.remote_name.value()
         url = widget.url.value()
         cmds.do(cmds.RemoteAdd, name, url)
         self.refresh()


### PR DESCRIPTION
In commit 98303c5 AddRemoteWidget's `name` attribute has been renamed to
`remote_name`, however RemoteEditor.add() isn't updated accordingly,
causing add new remote operation failed silently.  This commit completes
the attribute name change.

Signed-off-by: Ｖ字龍 <Vdragon.Taiwan@gmail.com>