### PR TITLE
get submodule list via git submodule

### DIFF
--- a/cola/gitcmds.py
+++ b/cola/gitcmds.py
@@ -739,3 +739,23 @@ def strip_remote(remotes, remote_branch):
         if remote_branch.startswith(prefix):
             return remote_branch[len(prefix):]
     return remote_branch.split('/', 1)[-1]
+
+
+def list_submodule():
+    SHA1_LENGTH = 40
+    status, data, err = git.submodule()
+    ret = []
+    if status == 0 and data:
+        data = data.splitlines()
+        #*8ca4b61504c200ba6af3a457f01fb95b7c1b9782 path (git describe for the SHA-1)
+        #* == '+': does not match the SHA-1 found in the index of the containing repository
+        #* == '-': not initialized
+        #* == ' ': otherwise
+        for line in data:
+            sign = line[:1]
+            sha1 = line[1:1+SHA1_LENGTH]
+            left_bracket = line.find('(',SHA1_LENGTH + 3)
+            path = line[1+SHA1_LENGTH+1:left_bracket-1]
+            desc = line[left_bracket+1:-1]
+            ret.append((sign,sha1,path,desc))
+    return ret

--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -91,6 +91,7 @@ class MainModel(Observable):
         self.staged_deleted = set()
         self.unstaged_deleted = set()
         self.submodules = set()
+        self.submodule_list = []
 
         self.local_branches = []
         self.remote_branches = []
@@ -199,7 +200,11 @@ class MainModel(Observable):
         self._update_branches_and_tags()
         self._update_branch_heads()
         self._update_commitmsg()
+        self._update_submodule_list()
         self.notify_observers(self.message_updated)
+
+    def _update_submodule_list(self):
+        self.submodule_list = gitcmds.list_submodule()
 
     def _update_files(self, update_index=False):
         display_untracked = prefs.display_untracked()


### PR DESCRIPTION
Maybe GitKraken uses .gitsubmodule file as well.
Is this the correct way to get the list?
By the way, I was wondering if it is possible to add a feature like GitKraken's commit tree to dag. It seems that it combines all branches & remotes together to make it more visually clear.
