### PR TITLE
text: add option to change pressed tab into spaces

### DIFF
--- a/cola/models/prefs.py
+++ b/cola/models/prefs.py
@@ -24,7 +24,7 @@ MERGE_KEEPBACKUP = 'merge.keepbackup'
 MERGE_SUMMARY = 'merge.summary'
 MERGE_VERBOSITY = 'merge.verbosity'
 MERGETOOL = 'merge.tool'
-OVERRIDE_TAB_WITH_SPACES = 'cola.overridetabwithspaces'
+INSERT_SPACES_INSTEAD_OF_TABS = 'cola.expandtab'
 SAVEWINDOWSETTINGS = 'cola.savewindowsettings'
 SORT_BOOKMARKS = 'cola.sortbookmarks'
 TABWIDTH = 'cola.tabwidth'
@@ -88,11 +88,14 @@ def history_browser():
 def linebreak():
     return gitcfg.current().get(LINEBREAK, True)
 
+
 def spellcheck():
     return gitcfg.current().get(SPELL_CHECK, False)
 
-def override_tab_with_spaces():
-    return gitcfg.current().get(OVERRIDE_TAB_WITH_SPACES, False)
+
+def insert_spaces_instead_of_tabs():
+    return gitcfg.current().get(INSERT_SPACES_INSTEAD_OF_TABS, False)
+
 
 def sort_bookmarks():
     return gitcfg.current().get(SORT_BOOKMARKS, True)

--- a/cola/models/prefs.py
+++ b/cola/models/prefs.py
@@ -24,6 +24,7 @@ MERGE_KEEPBACKUP = 'merge.keepbackup'
 MERGE_SUMMARY = 'merge.summary'
 MERGE_VERBOSITY = 'merge.verbosity'
 MERGETOOL = 'merge.tool'
+OVERRIDE_TAB_WITH_SPACES = 'cola.overridetabwithspaces'
 SAVEWINDOWSETTINGS = 'cola.savewindowsettings'
 SORT_BOOKMARKS = 'cola.sortbookmarks'
 TABWIDTH = 'cola.tabwidth'
@@ -89,6 +90,9 @@ def linebreak():
 
 def spellcheck():
     return gitcfg.current().get(SPELL_CHECK, False)
+
+def override_tab_with_spaces():
+    return gitcfg.current().get(OVERRIDE_TAB_WITH_SPACES, False)
 
 def sort_bookmarks():
     return gitcfg.current().get(SORT_BOOKMARKS, True)

--- a/cola/widgets/prefs.py
+++ b/cola/widgets/prefs.py
@@ -171,10 +171,12 @@ class SettingsFormWidget(FormWidget):
         self.bold_headers = qtutils.checkbox()
         self.save_gui_settings = qtutils.checkbox()
         self.check_spelling = qtutils.checkbox()
+        self.override_tab_with_spaces = qtutils.checkbox()
 
         self.add_row(N_('Fixed-Width Font'), self.fixed_font)
         self.add_row(N_('Font Size'), self.font_size)
         self.add_row(N_('Tab Width'), self.tabwidth)
+        self.add_row(N_('Override tab with spaces'), self.override_tab_with_spaces)
         self.add_row(N_('Text Width'), self.textwidth)
         self.add_row(N_('Auto-Wrap Lines'), self.linebreak)
         self.add_row(N_('Editor'), self.editor)
@@ -192,6 +194,7 @@ class SettingsFormWidget(FormWidget):
         self.set_config({
             prefs.SAVEWINDOWSETTINGS: (self.save_gui_settings, True),
             prefs.TABWIDTH: (self.tabwidth, 8),
+            prefs.OVERRIDE_TAB_WITH_SPACES: (self.override_tab_with_spaces, False),
             prefs.TEXTWIDTH: (self.textwidth, 72),
             prefs.LINEBREAK: (self.linebreak, True),
             prefs.SORT_BOOKMARKS: (self.sort_bookmarks, True),

--- a/cola/widgets/prefs.py
+++ b/cola/widgets/prefs.py
@@ -171,12 +171,12 @@ class SettingsFormWidget(FormWidget):
         self.bold_headers = qtutils.checkbox()
         self.save_gui_settings = qtutils.checkbox()
         self.check_spelling = qtutils.checkbox()
-        self.override_tab_with_spaces = qtutils.checkbox()
+        self.insert_spaces_instead_of_tabs = qtutils.checkbox()
 
         self.add_row(N_('Fixed-Width Font'), self.fixed_font)
         self.add_row(N_('Font Size'), self.font_size)
         self.add_row(N_('Tab Width'), self.tabwidth)
-        self.add_row(N_('Override tab with spaces'), self.override_tab_with_spaces)
+        self.add_row(N_('Insert spaces instead of tabs'), self.insert_spaces_instead_of_tabs)
         self.add_row(N_('Text Width'), self.textwidth)
         self.add_row(N_('Auto-Wrap Lines'), self.linebreak)
         self.add_row(N_('Editor'), self.editor)
@@ -194,7 +194,7 @@ class SettingsFormWidget(FormWidget):
         self.set_config({
             prefs.SAVEWINDOWSETTINGS: (self.save_gui_settings, True),
             prefs.TABWIDTH: (self.tabwidth, 8),
-            prefs.OVERRIDE_TAB_WITH_SPACES: (self.override_tab_with_spaces, False),
+            prefs.INSERT_SPACES_INSTEAD_OF_TABS: (self.insert_spaces_instead_of_tabs, False),
             prefs.TEXTWIDTH: (self.textwidth, 72),
             prefs.LINEBREAK: (self.linebreak, True),
             prefs.SORT_BOOKMARKS: (self.sort_bookmarks, True),

--- a/share/doc/git-cola/git-cola.rst
+++ b/share/doc/git-cola/git-cola.rst
@@ -478,6 +478,12 @@ cola.dicitionary
 Specifies an additional dictionary for `git cola` to use in its spell checker.
 This should be configured to the path of a newline-separated list of words.
 
+cola.expandtab
+--------------
+Enables to expand tabs into spaces in text edit fields when set to `true`.
+Amount of spaces is determined by `cola.tabwidth`.
+Defaults to `false`.
+
 cola.fileattributes
 -------------------
 Enables per-file gitattributes encoding support when set to `true`.
@@ -518,7 +524,7 @@ but also requires either Linux with inotify support or Windows with `pywin32`
 installed for file system change monitoring to actually function.
 
 cola.refreshonfocus
-----------------------
+-------------------
 Set to `true` to automatically refresh when `git cola` gains focus.  Defaults
 to `false` because this can cause a pause whenever switching to `git cola` from
 another application.


### PR DESCRIPTION
Add option in models/prefs.py and widgets/prefs.py to override tab with spaces
Override keyPressEvent in TextEdit with new behaviour (intercept tab key when
option is checked and post new keypress and keyrelease events with spaces).

Reported-by: @conz27 #660
Signed-off-by: Szymon Judasz szymon.judasz@student.uj.edu.pl