### PR TITLE
qtutils: use the proper clicked signal instead of pressed

### DIFF
--- a/cola/qtutils.py
+++ b/cola/qtutils.py
@@ -46,7 +46,7 @@ def connect_action_bool(action, fn):
 
 def connect_button(button, fn):
     """Connect a button to a function"""
-    button.pressed.connect(fn)
+    button.clicked.connect(fn)
 
 
 def connect_released(button, fn):

--- a/cola/widgets/action.py
+++ b/cola/widgets/action.py
@@ -50,6 +50,9 @@ def tooltip_button(text, layout):
     button.setToolTip(text)
     return button
 
+""" Takes care of argument mismatch for connect_button event"""
+def RefreshButtonAction():
+    return cmds.run(cmds.Refresh)
 
 class ActionButtons(QFlowLayoutWidget):
     def __init__(self, parent=None):
@@ -67,7 +70,7 @@ class ActionButtons(QFlowLayoutWidget):
         self.setMinimumHeight(30)
 
         # Add callbacks
-        connect_button(self.refresh_button, cmds.run(cmds.Refresh))
+        connect_button(self.refresh_button, RefreshButtonAction)
         connect_button(self.fetch_button, remote.fetch)
         connect_button(self.push_button, remote.push)
         connect_button(self.pull_button, remote.pull)


### PR DESCRIPTION
Reacting to the pushed event makes the interface behave unlike any other
GUI out there. Restore the normal clicked behaviour. Fix #604 using a
bounce function.

This reverts d9a3f3f8f84d15723dd10ded2adeb6d9ffeb1fcd while still
fixing #604