### PR TITLE
Freezing without git

### DIFF
--- a/cola/git.py
+++ b/cola/git.py
@@ -234,13 +234,15 @@ class Git(object):
         # Guard against thread-unsafe .git/index.lock files
         if not _readonly:
             INDEX_LOCK.acquire()
-        status, out, err = core.run_command(
-                command, cwd=_cwd, encoding=_encoding,
-                stdin=_stdin, stdout=_stdout, stderr=_stderr,
-                no_win32_startupinfo=_no_win32_startupinfo, **extra)
-        # Let the next thread in
-        if not _readonly:
-            INDEX_LOCK.release()
+        try:
+            status, out, err = core.run_command(
+                    command, cwd=_cwd, encoding=_encoding,
+                    stdin=_stdin, stdout=_stdout, stderr=_stderr,
+                    no_win32_startupinfo=_no_win32_startupinfo, **extra)
+        finally:
+            # Let the next thread in
+            if not _readonly:
+                INDEX_LOCK.release()
 
         if not _raw and out is not None:
             out = out.rstrip('\n')

--- a/cola/git.py
+++ b/cola/git.py
@@ -332,9 +332,14 @@ class Git(object):
                 # case of argv overflow. we should be safe from that but use
                 # defensive coding for the worst-case scenario. on other OS-en
                 # we have ENAMETOOLONG which doesn't exist in with32 API.
-                status, out, err = self.execute(['git', '--version'])
-                if status == 0:
-                    raise e
+                try:
+                    status, out, err = self.execute(['git', '--version'])
+                except FileNotFoundError:
+                    pass # git command is not available
+                else:
+                    if status == 0:
+                        # git is ok, there is something else...
+                        raise e
 
             core.stderr("error: unable to execute 'git'\n"
                         "error: please ensure that 'git' is in your $PATH")


### PR DESCRIPTION
git-cola freezes when `git` is not found in `PATH`. The cause is a deadlock on `INDEX_LOCK`. The mutex is not released after an exception. I faced with this under Windows but the problem is probably actual for all the OSes.

This patch request elimenates the deadlock and also fixes checking for git existence under Windows.