### PR TITLE
Fixup non-UTF-8 line staging

### DIFF
--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -250,11 +250,12 @@ class ApplyDiffSelection(Command):
         if patch is None:
             return
 
-        cfg = gitcfg.current()
-        encoding = cfg.file_encoding(self.model.filename)
         tmp_file = utils.tmp_filename('patch')
         try:
-            core.write(tmp_file, patch, encoding=encoding)
+            # Patch encoding is always "raw_unicode_escape" because
+            # model.diff_text is always same. See method `git` of
+            # class `cola.git.Git`.
+            core.write(tmp_file, patch, encoding="raw_unicode_escape")
             if self.apply_to_worktree:
                 status, out, err = self.model.apply_diff_to_worktree(tmp_file)
             else:

--- a/cola/git.py
+++ b/cola/git.py
@@ -312,6 +312,10 @@ class Git(object):
                 '_no_win32_startupinfo',
                 )
 
+        if cmd == "diff":
+            # use invariant encoding for diff
+            kwargs["_encoding"] = "raw_unicode_escape"
+
         for kwarg in execute_kwargs:
             if kwarg in kwargs:
                 _kwargs[kwarg] = kwargs.pop(kwarg)

--- a/cola/gitcmds.py
+++ b/cola/gitcmds.py
@@ -359,18 +359,14 @@ def diff_helper(commit=None,
     elif head and amending and cached:
         argv.append(head)
 
-    encoding = None
     if filename:
         argv.append('--')
         if type(filename) is list:
             argv.extend(filename)
         else:
             argv.append(filename)
-            cfg = gitcfg.current()
-            encoding = cfg.file_encoding(filename)
 
     status, out, err = git.diff(R=reverse, M=True, cached=cached,
-                                _encoding=encoding,
                                 *argv,
                                 **common_diff_opts())
     if status != 0:


### PR DESCRIPTION
Recently I have faced the problem, I cannot stage selected lines in several files. This related to lines those cannot be decoded using default `"utf-8"` coder. The core of the problem can be easily seen by data flow description presented below.

1. Git-Cola uses `git` utility to obtain diff text. This utility is launched using `subprocess.Popen` (see `cola.core.start_command` function).

2. Then, diff text is taken from `stdout` returned by `communicate` method (see `cola.core.run_command` function). `run_command` uses `cola.core.decode` to decode raw data returned by `git` to unicode (`str` under Py3 or `unicode` under Py2).

The problem begins at this step. `decode` is given an `encoding` argument. This encoding is used to decode those raw data. If it failed then default encodings are probed one by one (see `cola.core._encoding_tests` list).

In my case, `encoding` argument is set to `"utf-8"` because of it is default and no encoding has been explicitly set for the file. But real encoding of the file is cp1251 (Cyrillic). A file encoded in cp1251 frequently contains bytes those cannot be decoded using `"utf-8"`. As a result, first "successful" decoding happens for `'iso-8859-15'`. To be continued...

3. After, those data are passed unchanged through several wrappers towards a `DiffParser` object. Given line indices, the parser formats a patch changing selected lines. See `do` method of `cola.cmds.ApplyDiffSelection`

4. Next, the patch is written to a temp file. In course of it, the patch is encoded using either explicitly set encoding or default `'utf-8'` (for me).

Now, data originally decoded in `'iso-8859-15'` are encoded in `'utf-8'`. Non-ANSII characters are encoded to different bytes.

5. Finally, Git Cola attempts to apply the patch using `git apply` command. It failed because removed lines in the patch is not equal to themselves in the file.

I suggest to use `"raw_unicode_escape"` for both diff text and patch files. This coder seems to be able to decode any byte in raw data and encode it back unchanged. Non-UTF-8 lines in diff widget are displayed differently but remain unreadable.