### PR TITLE
selectcommits: add output dir selector

### DIFF
--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -867,13 +867,15 @@ class Edit(Command):
 class FormatPatch(Command):
     """Output a patch series given all revisions and a selected subset."""
 
-    def __init__(self, to_export, revs):
+    def __init__(self, to_export, revs, output='patches'):
         Command.__init__(self)
         self.to_export = list(to_export)
         self.revs = list(revs)
+        self.output = output
 
     def do(self):
-        status, out, err = gitcmds.format_patchsets(self.to_export, self.revs)
+        status, out, err = gitcmds.format_patchsets(self.to_export, self.revs,
+                                                    self.output)
         Interaction.log_status(status, out, err)
 
 

--- a/cola/guicmds.py
+++ b/cola/guicmds.py
@@ -8,6 +8,7 @@ from .models import main
 from .widgets import completion
 from .widgets.browse import BrowseBranch
 from .widgets.selectcommits import select_commits
+from .widgets.selectcommits import select_commits_and_output
 from . import cmds
 from . import core
 from . import difftool
@@ -164,10 +165,13 @@ def prompt_for_clone():
 def export_patches():
     """Run 'git format-patch' on a list of commits."""
     revs, summaries = gitcmds.log_helper()
-    to_export = select_commits(N_('Export Patches'), revs, summaries)
-    if not to_export:
+    to_export_and_output = select_commits_and_output(N_('Export Patches'), revs,
+                                                     summaries)
+    if not to_export_and_output['to_export']:
         return
-    cmds.do(cmds.FormatPatch, reversed(to_export), reversed(revs))
+
+    cmds.do(cmds.FormatPatch, reversed(to_export_and_output['to_export']),
+            reversed(revs), to_export_and_output['output'])
 
 
 def diff_expression():


### PR DESCRIPTION
Hi! 

I was playing with 'Export Patches' option and I found that I could not choose the output directory as it is says in the issue #711, so I added a button in the 'Export Patches' dialog which opens a directory selector prompt.

![git-cola_export-patches](https://user-images.githubusercontent.com/4667395/32769336-ccf83460-c91b-11e7-8cfb-fe88975acc1b.png)

