### PR TITLE
localization: Fix French push-pull mixup 

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -964,7 +964,7 @@ msgstr "Parcourir la branche courante..."
 
 #: cola/widgets/branch.py:190 cola/widgets/remote.py:655
 msgid "Pull"
-msgstr "Pousser"
+msgstr "Tirer"
 
 #: cola/widgets/branch.py:195 cola/widgets/remote.py:537
 #: cola/widgets/remote.py:629


### PR DESCRIPTION
Line should have read « Tirer » ("Pull") instead of « Pousser » ("Pull").
Signed-off-by: Louis Rousseau <louisrousseau@gmail.com>