### PR TITLE
status: Don't mark custom copy action value template string as translatable

### DIFF
--- a/cola/widgets/status.py
+++ b/cola/widgets/status.py
@@ -1136,7 +1136,7 @@ class CustomizeCopyActions(standard.Dialog):
         self.table.setRowCount(rows + 1)
 
         name = QtWidgets.QTableWidgetItem(N_('Name'))
-        fmt = QtWidgets.QTableWidgetItem(N_(r'%(path)s'))
+        fmt = QtWidgets.QTableWidgetItem(r'%(path)s')
         self.table.setItem(rows, 0, name)
         self.table.setItem(rows, 1, fmt)
 


### PR DESCRIPTION
Corresponding interface:

![screenshot_20180311_125124](https://user-images.githubusercontent.com/1192163/37249877-f823b6a8-252a-11e8-84f2-42e3d499b1c3.png)

I have no idea what the `r` character before the single quote is so I leave it intact, please review.

Signed-off-by: Ｖ字龍 <Vdragon.Taiwan@gmail.com>