### PR TITLE
startup: fix missing GUI after cloning a repo

### DIFF
--- a/cola/widgets/startup.py
+++ b/cola/widgets/startup.py
@@ -150,7 +150,7 @@ class StartupDialog(standard.Dialog):
                            self.clone_repo_done, False)
 
     def clone_repo_done(self, task):
-        if task.cmd and task.cmd.ok:
+        if task.cmd and task.cmd.status == 0:
             self.repodir = task.destdir
             self.accept()
         else:


### PR DESCRIPTION
Currently, after cloning a remote repository within the startup window, an `AttributeError: 'Clone' object has no attribute 'ok'` is thrown and the main window is not opening despite successful result.

This patch changes the conditional check to use the `status` property of `Clone` object instead, to fix this.