### PR TITLE
app: change date/time format in log widget

### DIFF
--- a/cola/widgets/log.py
+++ b/cola/widgets/log.py
@@ -53,7 +53,7 @@ class LogWidget(QtWidgets.QWidget):
         cursor.movePosition(cursor.End)
         text = self.output_text
         # NOTE: the ':  ' colon-SP-SP suffix in used by the syntax highlighter
-        prefix = core.decode(time.strftime('%I:%M %p %Ss %Y-%m-%d:  '))
+        prefix = core.decode(time.strftime('%x %X:  '))
         for line in msg.splitlines():
             cursor.insertText(prefix + line + '\n')
         cursor.movePosition(cursor.End)


### PR DESCRIPTION
The previous format displayed a weird date/time when the active locale
didn't have AM/PM (%p): `10:45  57s 2018-04-12`.