### PR TITLE
gitcmds: Don't force patience diff algorithm

### DIFF
--- a/cola/gitcmds.py
+++ b/cola/gitcmds.py
@@ -290,7 +290,7 @@ def common_diff_opts(config=None):
         config = gitcfg.current()
     submodule = version.check('diff-submodule', version.git_version())
     opts = {
-        'patience': True,
+        'patience': config.get('diff.algorithm', 'patience') == 'patience',
         'submodule': submodule,
         'no_color': True,
         'no_ext_diff': True,


### PR DESCRIPTION
If the user specified a different preference, Git-Cola should honor that
and not use the patience algorithm. If no preference is set, Git-Cola
continues defaulting to the patience algorithm.

Fixes #799

Signed-off-by: Kai Krakow <kai@kaishome.de>