### PR TITLE
Fixup GitDialog input focus

### DIFF
--- a/cola/widgets/completion.py
+++ b/cola/widgets/completion.py
@@ -776,7 +776,7 @@ class GitDialog(QtWidgets.QDialog):
             dlg.lineedit.popup().show()
             dlg.lineedit.refresh()
 
-        QtCore.QTimer().singleShot(0, show_popup)
+        QtCore.QTimer().singleShot(100, show_popup)
 
         if dlg.exec_() == cls.Accepted:
             return dlg.text()


### PR DESCRIPTION
I faced a buggy behaviour of `GitDialog` (`GitBranchDialog` in particular).

Sequence to reproduce:

1. press `Alt` and `B`
2. release them after the branch dialog showed
3. press some buttons to input a branch name (for instance, `m`, `a`, `s`, `t`, `e`, `r`)

Expected result: the branch name (`master`) was entered.
Actual result: only first character (`m`) was entered.
Environment: Ubuntu Linux 16.04 amd64, GNOME Flashback desktop env., Compiz window mgr.

This bug is not appears if the branch dialog is opened using menu.
Adding a short delay before auto completion popup showing fixes it.

