### PR TITLE
Add Alt+R hotkeys for both rebase Start and Continue

### DIFF
--- a/cola/hotkeys.py
+++ b/cola/hotkeys.py
@@ -95,6 +95,7 @@ CTRL_RETURN = hotkey(Qt.CTRL + Qt.Key_Return)
 CTRL_ENTER = hotkey(Qt.CTRL + Qt.Key_Enter)
 
 # Rebase
+REBASE_START_AND_CONTINUE = hotkey(Qt.ALT + Qt.Key_R)
 REBASE_PICK = (hotkey(Qt.Key_1), hotkey(Qt.Key_P))
 REBASE_REWORD = (hotkey(Qt.Key_2), hotkey(Qt.Key_R))
 REBASE_EDIT = (hotkey(Qt.Key_3), hotkey(Qt.Key_E))

--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -336,13 +336,15 @@ class MainView(standard.MainWindow):
         self.dag_action.setIcon(icons.cola())
 
         self.rebase_start_action = add_action(
-            self, N_('Start Interactive Rebase...'), self.rebase_start)
+            self, N_('Start Interactive Rebase...'), self.rebase_start,
+            hotkeys.REBASE_START_AND_CONTINUE)
 
         self.rebase_edit_todo_action = add_action(
             self, N_('Edit...'), cmds.rebase_edit_todo)
 
         self.rebase_continue_action = add_action(
-            self, N_('Continue'), cmds.rebase_continue)
+            self, N_('Continue'), cmds.rebase_continue,
+            hotkeys.REBASE_START_AND_CONTINUE)
 
         self.rebase_skip_action = add_action(
             self, N_('Skip Current Patch'), cmds.rebase_skip)


### PR DESCRIPTION
git's rebase feature is frequently used while preparing commits for publication.
Currently, rebase controls are placed deep in the menu.
Assigning hotkeys for them would be very handy.

I propose to use same hotkeys (`Alt` + `R`) for both Start and Continue
because they are never active simultaneously.

