### PR TITLE
cmds: Fix NameError in Commit > Unstage From Commit

### DIFF
--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -2220,7 +2220,7 @@ class Unstage(ModelCommand):
         paths = self.paths
         head = self.model.head
         if not paths:
-            return unstage_all(model)
+            return unstage_all(self.model)
         status, out, err = gitcmds.unstage_paths(paths, head=head)
         Interaction.command(N_('Error'), 'git reset', status, out, err)
         self.model.update_file_status()


### PR DESCRIPTION
The following error occurred when selecting Commit > Unstage From Commit from the menu:

```
UnstageSelected exception:
NameError("global name 'model' is not defined",)

Traceback (most recent call last):

  File "/share/git-cola/lib/cola/cmds.py", line 2365, in do
    return cmd.do()

  File "/share/git-cola/lib/cola/cmds.py", line 2217, in do
    self.unstage_paths()

  File "/share/git-cola/lib/cola/cmds.py", line 2223, in unstage_paths
    return unstage_all(model)

NameError: global name 'model' is not defined
```

This appears to be a misnamed name reference, this patch renames it with the surrounding references.

Signed-off-by: Ｖ字龍 <Vdragon.Taiwan@gmail.com>