### PR TITLE
diff: fix changing diff viewer options

### DIFF
--- a/cola/widgets/diff.py
+++ b/cola/widgets/diff.py
@@ -382,6 +382,9 @@ class Viewer(QtWidgets.QWidget):
         else:
             self.stack.setCurrentWidget(self.text)
 
+    def update_options(self):
+        self.text.update_options()
+
     def reset(self):
         self.image.pixmap = QtGui.QPixmap()
         self.cleanup()


### PR DESCRIPTION
In commit 649de5bb248c3a33e6778c44f75ab4457e13508c the diff viewer was refactored to be able to display images diffs.  As a result of that change the `parent` passed to the `Options` object is now a `Viewer` rather than a `DiffEditor`.  In the `Options.update_options()` method, it calls the `update_options()` method of the `parent` provided when it was constructed.  However, unlike `DiffEditor`, `Viewer` did not have an `update_options()` method, which would cause an exception when `Options.update_options()` was executed.

To address this add an `update_options()` method to `Viewer` which delegates to the `update_options()` method of the contained `DiffEditor`.

Fixes: #833