### PR TITLE
cola.gitcfg: handle single-quoted strings in git config

### DIFF
--- a/cola/gitcfg.py
+++ b/cola/gitcfg.py
@@ -73,6 +73,8 @@ def _config_to_python(v):
         v = True
     elif v in ('false', 'no'):
         v = False
+    elif v.startswith("'") and v.endswith("'"):
+        return v[1:-1]
     else:
         try:
             v = int(v)


### PR DESCRIPTION
In order to handle string values which happen to be a valid int (for
example a hex string '030303'), establish some type of quoting
mechanism.  In this case, single quotes at the beginning and end of the
value will be stripped and the value itself will be interpreted as a
string rather than an int, as was previously.

Signed-off-by: Uri Okrent <uokrent@gmail.com>