### PR TITLE
cmds: Remove redundant query message

### DIFF
--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -686,11 +686,9 @@ class RemoteRename(RemoteCommand):
 
     def confirm(self):
         title = N_('Rename Remote')
-        question = N_('Rename remote?')
         info = (N_('Rename remote "%(current)s" to "%(new)s"?') %
                 dict(current=self.name, new=self.new_name))
-        ok_text = N_('Rename')
-        return Interaction.confirm(title, question, info, ok_text)
+        return Interaction.question(title, info)
 
     def action(self):
         git = self.model.git


### PR DESCRIPTION
The first line of the body in the "Rename Remote" dialog is redundant and
unnecessary, this patch removes the message and changes the interaction
to a question.

![screenshot_20180611_230034](https://user-images.githubusercontent.com/1192163/41240751-d1fcfc50-6dcd-11e8-8e2e-1fe55881a8f6.png)

The new interaction choice might not be sane though, please review.

Fixes #838.

Refer-to: Redundant query message · Issue #838 · git-cola/git-cola <https://github.com/git-cola/git-cola/issues/838>
Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>