### PR TITLE
Makefile: Avoid word separation in parameter expansion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,10 @@ endif
 
 # These values can be overridden on the command-line or via config.mak
 prefix = $(HOME)
-bindir = $(prefix)/bin
-datadir = $(prefix)/share/git-cola
+bindir = "$(prefix)"/bin
+datadir = "$(prefix)"/share/git-cola
 coladir = $(datadir)/lib
-hicolordir = $(prefix)/share/icons/hicolor/scalable/apps
+hicolordir = "$(prefix)"/share/icons/hicolor/scalable/apps
 # DESTDIR =
 
 cola_base := git-cola
@@ -77,7 +77,7 @@ cola_app = $(CURDIR)/$(cola_app_base)
 cola_version = $(shell $(PYTHON) bin/git-cola version --brief)
 cola_dist := $(cola_base)-$(cola_version)
 SETUP ?= $(PYTHON) setup.py
-setup_args += --prefix=$(prefix)
+setup_args += --prefix="$(prefix)"
 setup_args += --force
 setup_args += --install-scripts=$(bindir)
 setup_args += --record=build/MANIFEST
@@ -158,31 +158,31 @@ install-man:
 .PHONY: install-man
 
 uninstall:
-	$(RM) "$(DESTDIR)"$(prefix)/bin/git-cola
-	$(RM) "$(DESTDIR)"$(prefix)/bin/git-dag
-	$(RM) "$(DESTDIR)"$(prefix)/bin/cola
-	$(RM) "$(DESTDIR)"$(prefix)/share/applications/git-cola.desktop
-	$(RM) "$(DESTDIR)"$(prefix)/share/applications/git-cola-folder-handler.desktop
-	$(RM) "$(DESTDIR)"$(prefix)/share/applications/git-dag.desktop
-	$(RM) "$(DESTDIR)"$(prefix)/share/appdata/git-dag.appdata.xml
-	$(RM) "$(DESTDIR)"$(prefix)/share/appdata/git-cola.appdata.xml
-	$(RM) "$(DESTDIR)"$(prefix)/share/icons/hicolor/scalable/apps/git-cola.svg
-	$(RM_R) "$(DESTDIR)"$(prefix)/share/doc/git-cola
-	$(RM_R) "$(DESTDIR)"$(prefix)/share/git-cola
-	$(RM) "$(DESTDIR)"$(prefix)/share/locale/*/LC_MESSAGES/git-cola.mo
-	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/applications 2>/dev/null
-	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/appdata 2>/dev/null
-	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/doc 2>/dev/null
-	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/locale/*/LC_MESSAGES 2>/dev/null
-	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/locale/* 2>/dev/null
-	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/locale 2>/dev/null
-	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/icons/hicolor/scalable/apps 2>/dev/null
-	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/icons/hicolor/scalable 2>/dev/null
-	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/icons/hicolor 2>/dev/null
-	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/icons 2>/dev/null
-	-$(RMDIR) "$(DESTDIR)"$(prefix)/share 2>/dev/null
-	-$(RMDIR) "$(DESTDIR)"$(prefix)/bin 2>/dev/null
-	-$(RMDIR) "$(DESTDIR)"$(prefix) 2>/dev/null
+	$(RM) "$(DESTDIR)""$(prefix)"/bin/git-cola
+	$(RM) "$(DESTDIR)""$(prefix)"/bin/git-dag
+	$(RM) "$(DESTDIR)""$(prefix)"/bin/cola
+	$(RM) "$(DESTDIR)""$(prefix)"/share/applications/git-cola.desktop
+	$(RM) "$(DESTDIR)""$(prefix)"/share/applications/git-cola-folder-handler.desktop
+	$(RM) "$(DESTDIR)""$(prefix)"/share/applications/git-dag.desktop
+	$(RM) "$(DESTDIR)""$(prefix)"/share/appdata/git-dag.appdata.xml
+	$(RM) "$(DESTDIR)""$(prefix)"/share/appdata/git-cola.appdata.xml
+	$(RM) "$(DESTDIR)""$(prefix)"/share/icons/hicolor/scalable/apps/git-cola.svg
+	$(RM_R) "$(DESTDIR)""$(prefix)"/share/doc/git-cola
+	$(RM_R) "$(DESTDIR)""$(prefix)"/share/git-cola
+	$(RM) "$(DESTDIR)""$(prefix)"/share/locale/*/LC_MESSAGES/git-cola.mo
+	-$(RMDIR) "$(DESTDIR)""$(prefix)"/share/applications 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)""$(prefix)"/share/appdata 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)""$(prefix)"/share/doc 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)""$(prefix)"/share/locale/*/LC_MESSAGES 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)""$(prefix)"/share/locale/* 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)""$(prefix)"/share/locale 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)""$(prefix)"/share/icons/hicolor/scalable/apps 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)""$(prefix)"/share/icons/hicolor/scalable 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)""$(prefix)"/share/icons/hicolor 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)""$(prefix)"/share/icons 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)""$(prefix)"/share 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)""$(prefix)"/bin 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)""$(prefix)" 2>/dev/null
 .PHONY: uninstall
 
 test: all

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ setup_args += --install-scripts=$(bindir)
 setup_args += --record=build/MANIFEST
 setup_args += --install-lib=$(coladir)
 ifdef DESTDIR
-    setup_args += --root=$(DESTDIR)
+    setup_args += --root="$(DESTDIR)"
     export DESTDIR
 endif
 export prefix
@@ -120,10 +120,10 @@ build: build_version
 
 install: all
 	$(SETUP) $(QUIET) install $(setup_args)
-	$(MKDIR_P) $(DESTDIR)$(hicolordir)
-	$(LN_S) $(datadir)/icons/git-cola.svg $(DESTDIR)$(hicolordir)/git-cola.svg
-	$(LN_S) git-cola $(DESTDIR)$(bindir)/cola
-	$(RM_R) $(DESTDIR)$(coladir)/git_cola*
+	$(MKDIR_P) "$(DESTDIR)"$(hicolordir)
+	$(LN_S) $(datadir)/icons/git-cola.svg "$(DESTDIR)"$(hicolordir)/git-cola.svg
+	$(LN_S) git-cola "$(DESTDIR)"$(bindir)/cola
+	$(RM_R) "$(DESTDIR)"$(coladir)/git_cola*
 	$(RM_R) git_cola.egg-info
 .PHONY: install
 
@@ -158,31 +158,31 @@ install-man:
 .PHONY: install-man
 
 uninstall:
-	$(RM) $(DESTDIR)$(prefix)/bin/git-cola
-	$(RM) $(DESTDIR)$(prefix)/bin/git-dag
-	$(RM) $(DESTDIR)$(prefix)/bin/cola
-	$(RM) $(DESTDIR)$(prefix)/share/applications/git-cola.desktop
-	$(RM) $(DESTDIR)$(prefix)/share/applications/git-cola-folder-handler.desktop
-	$(RM) $(DESTDIR)$(prefix)/share/applications/git-dag.desktop
-	$(RM) $(DESTDIR)$(prefix)/share/appdata/git-dag.appdata.xml
-	$(RM) $(DESTDIR)$(prefix)/share/appdata/git-cola.appdata.xml
-	$(RM) $(DESTDIR)$(prefix)/share/icons/hicolor/scalable/apps/git-cola.svg
-	$(RM_R) $(DESTDIR)$(prefix)/share/doc/git-cola
-	$(RM_R) $(DESTDIR)$(prefix)/share/git-cola
-	$(RM) $(DESTDIR)$(prefix)/share/locale/*/LC_MESSAGES/git-cola.mo
-	-$(RMDIR) $(DESTDIR)$(prefix)/share/applications 2>/dev/null
-	-$(RMDIR) $(DESTDIR)$(prefix)/share/appdata 2>/dev/null
-	-$(RMDIR) $(DESTDIR)$(prefix)/share/doc 2>/dev/null
-	-$(RMDIR) $(DESTDIR)$(prefix)/share/locale/*/LC_MESSAGES 2>/dev/null
-	-$(RMDIR) $(DESTDIR)$(prefix)/share/locale/* 2>/dev/null
-	-$(RMDIR) $(DESTDIR)$(prefix)/share/locale 2>/dev/null
-	-$(RMDIR) $(DESTDIR)$(prefix)/share/icons/hicolor/scalable/apps 2>/dev/null
-	-$(RMDIR) $(DESTDIR)$(prefix)/share/icons/hicolor/scalable 2>/dev/null
-	-$(RMDIR) $(DESTDIR)$(prefix)/share/icons/hicolor 2>/dev/null
-	-$(RMDIR) $(DESTDIR)$(prefix)/share/icons 2>/dev/null
-	-$(RMDIR) $(DESTDIR)$(prefix)/share 2>/dev/null
-	-$(RMDIR) $(DESTDIR)$(prefix)/bin 2>/dev/null
-	-$(RMDIR) $(DESTDIR)$(prefix) 2>/dev/null
+	$(RM) "$(DESTDIR)"$(prefix)/bin/git-cola
+	$(RM) "$(DESTDIR)"$(prefix)/bin/git-dag
+	$(RM) "$(DESTDIR)"$(prefix)/bin/cola
+	$(RM) "$(DESTDIR)"$(prefix)/share/applications/git-cola.desktop
+	$(RM) "$(DESTDIR)"$(prefix)/share/applications/git-cola-folder-handler.desktop
+	$(RM) "$(DESTDIR)"$(prefix)/share/applications/git-dag.desktop
+	$(RM) "$(DESTDIR)"$(prefix)/share/appdata/git-dag.appdata.xml
+	$(RM) "$(DESTDIR)"$(prefix)/share/appdata/git-cola.appdata.xml
+	$(RM) "$(DESTDIR)"$(prefix)/share/icons/hicolor/scalable/apps/git-cola.svg
+	$(RM_R) "$(DESTDIR)"$(prefix)/share/doc/git-cola
+	$(RM_R) "$(DESTDIR)"$(prefix)/share/git-cola
+	$(RM) "$(DESTDIR)"$(prefix)/share/locale/*/LC_MESSAGES/git-cola.mo
+	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/applications 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/appdata 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/doc 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/locale/*/LC_MESSAGES 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/locale/* 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/locale 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/icons/hicolor/scalable/apps 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/icons/hicolor/scalable 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/icons/hicolor 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)"$(prefix)/share/icons 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)"$(prefix)/share 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)"$(prefix)/bin 2>/dev/null
+	-$(RMDIR) "$(DESTDIR)"$(prefix) 2>/dev/null
 .PHONY: uninstall
 
 test: all


### PR DESCRIPTION
The build will break when either DESTDIR or prefix contains spaces, this patch wraps the expansion with quotes to avoid the word separations.