### PR TITLE
import os in pynsist-preamble.py

### DIFF
--- a/contrib/win32/pynsist-preamble.py
+++ b/contrib/win32/pynsist-preamble.py
@@ -1,4 +1,5 @@
 # TODO pynsist commands call it "installdir", entry points call it "scriptdir"
+import os
 try:
     installdir = scriptdir
 except NameError:


### PR DESCRIPTION
__os__ is used 5 times but is never imported.