### PR TITLE
Makefile: 'make flake8' tests the entire codebase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,7 @@ app-tarball: git-cola.app
 	$(MARKDOWN) $< >$@
 
 flake8:
-	$(FLAKE8) $(FLAKE8_FLAGS) $(PYTHON_SOURCES) $(PYTHON_DIRS)
+	$(FLAKE8) $(FLAKE8_FLAGS) .
 .PHONY: flake8
 
 pylint3k:


### PR DESCRIPTION
It is safer and just as fast to have flake8 test the entire codebase.