### PR TITLE
windows: run git bash when open terminal action is invoked on windows

### DIFF
--- a/cola/app.py
+++ b/cola/app.py
@@ -589,7 +589,8 @@ def find_git():
     # Try to find Git's bin/ directory in one of the typical locations
     pf = os.environ.get('ProgramFiles', 'C:\\Program Files')
     pf32 = os.environ.get('ProgramFiles(x86)', 'C:\\Program Files (x86)')
-    for p in [pf32, pf, 'C:\\']:
+    pf64 = os.environ.get('ProgramW6432', 'C:\\Program Files')
+    for p in [pf64, pf32, pf, 'C:\\']:
         candidate = os.path.join(p, 'Git\\bin')
         if os.path.isdir(candidate):
             return candidate

--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -1265,15 +1265,26 @@ class LaunchTerminal(ContextCommand):
     def name():
         return N_('Launch Terminal')
 
+    @staticmethod
+    def is_available(context):
+        return context.cfg.terminal() is not None
+
     def __init__(self, context, path):
         super(LaunchTerminal, self).__init__(context)
         self.path = path
 
     def do(self):
-        cmd = self.cfg.terminal()
-        argv = utils.shell_split(cmd)
-        argv.append(os.getenv('SHELL', '/bin/sh'))
-        core.fork(argv, cwd=self.path)
+        cmd = self.context.cfg.terminal()
+        if cmd is None:
+            return
+        if utils.is_win32():
+            argv = ['start', '', cmd, '--login']
+            shell = True
+        else:
+            argv = utils.shell_split(cmd)
+            argv.append(os.getenv('SHELL', '/bin/sh'))
+            shell = False
+        core.fork(argv, cwd=self.path, shell=shell)
 
 
 class LaunchEditor(Edit):

--- a/cola/core.py
+++ b/cola/core.py
@@ -253,13 +253,13 @@ def run_command(cmd, *args, **kwargs):
 
 
 @interruptable
-def _fork_posix(args, cwd=None):
+def _fork_posix(args, cwd=None, shell=False):
     """Launch a process in the background."""
     encoded_args = [encode(arg) for arg in args]
-    return subprocess.Popen(encoded_args, cwd=cwd).pid
+    return subprocess.Popen(encoded_args, cwd=cwd, shell=shell).pid
 
 
-def _fork_win32(args, cwd=None):
+def _fork_win32(args, cwd=None, shell=False):
     """Launch a background process using crazy win32 voodoo."""
     # This is probably wrong, but it works.  Windows.. wow.
     if args[0] == 'git-dag':
@@ -274,7 +274,8 @@ def _fork_win32(args, cwd=None):
         argv = [encode(arg) for arg in args]
 
     DETACHED_PROCESS = 0x00000008  # Amazing!
-    return subprocess.Popen(argv, cwd=cwd, creationflags=DETACHED_PROCESS).pid
+    return subprocess.Popen(argv, cwd=cwd, creationflags=DETACHED_PROCESS,
+                            shell=shell).pid
 
 
 def _win32_find_exe(exe):

--- a/cola/widgets/browse.py
+++ b/cola/widgets/browse.py
@@ -196,8 +196,8 @@ class RepoTreeView(standard.TreeView):
             self.action_parent_dir = common.parent_dir_action(
                 context, self, self.selected_paths)
 
-            self.action_terminal = common.terminal_action(
-                context, self, self.selected_paths)
+        self.action_terminal = common.terminal_action(
+            context, self, self.selected_paths)
 
         self.x_width = QtGui.QFontMetrics(self.font()).width('x')
         self.size_columns()
@@ -347,6 +347,8 @@ class RepoTreeView(standard.TreeView):
         if not utils.is_win32():
             self.action_default_app.setEnabled(selected)
             self.action_parent_dir.setEnabled(selected)
+
+        if self.action_terminal is not None:
             self.action_terminal.setEnabled(selected)
 
         self.action_stage.setEnabled(staged or unstaged)
@@ -376,6 +378,8 @@ class RepoTreeView(standard.TreeView):
             menu.addSeparator()
             menu.addAction(self.action_default_app)
             menu.addAction(self.action_parent_dir)
+
+        if self.action_terminal is not None:
             menu.addAction(self.action_terminal)
         menu.exec_(self.mapToGlobal(event.pos()))
 

--- a/cola/widgets/common.py
+++ b/cola/widgets/common.py
@@ -55,7 +55,9 @@ def refresh_action(context, parent):
 
 def terminal_action(context, parent, fn):
     """Launch a terminal -> QAction"""
-    action = cmd_action(parent, cmds.LaunchTerminal, context,
-                        lambda: utils.select_directory(fn()),
-                        hotkeys.TERMINAL)
+    action = None
+    if cmds.LaunchTerminal.is_available(context):
+        action = cmd_action(parent, cmds.LaunchTerminal, context,
+                            lambda: utils.select_directory(fn()),
+                            hotkeys.TERMINAL)
     return action

--- a/cola/widgets/status.py
+++ b/cola/widgets/status.py
@@ -167,8 +167,8 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
             self.parent_dir_action = common.parent_dir_action(
                 context, self, self.selected_group)
 
-            self.terminal_action = common.terminal_action(
-                context, self, self.selected_group)
+        self.terminal_action = common.terminal_action(
+            context, self, self.selected_group)
 
         self.up_action = qtutils.add_action(
             self, N_('Move Up'), self.move_up,
@@ -573,6 +573,8 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
             if not self.selection_model.is_empty():
                 menu.addAction(self.default_app_action)
                 menu.addAction(self.parent_dir_action)
+
+        if self.terminal_action is not None:
             menu.addAction(self.terminal_action)
 
         self._add_copy_actions(menu)


### PR DESCRIPTION
On Windows, Launch Terminal action was not avaliable. Instead we can
just run git bash. This change add following behaviour: Try to find git
bash (sh.exe) executable in typical locations and if one is found, add
Launch Terminal action just like on Unix platforms.

Possible future improvements: better way to find git bash location and
ability to customize it in preferences.

Signed-off-by: Mariusz Jaskółka <mar.jaskolka@gmail.com>