### PR TITLE
Branch sort order based on committer time

### DIFF
--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -586,6 +586,12 @@ class Commit(ResetMode):
         return msg
 
 
+class CycleReferenceSort(ContextCommand):
+    """Choose the next reference sort type"""
+    def do(self):
+        self.model.cycle_ref_sort()
+
+
 class Ignore(ContextCommand):
     """Add files to .gitignore"""
 

--- a/cola/gitcmds.py
+++ b/cola/gitcmds.py
@@ -216,9 +216,9 @@ def branch_list(context, remote=False):
     return for_each_ref_basename(context, 'refs/heads')
 
 
-def _version_sort(context):
+def _version_sort(context, key='version:refname'):
     if version.check_git(context, 'version-sort'):
-        sort = 'version:refname'
+        sort = key
     else:
         sort = False
     return sort
@@ -240,7 +240,7 @@ def _triple(x, y):
     return (x, len(x) + 1, y)
 
 
-def all_refs(context, split=False):
+def all_refs(context, split=False, sort_key='version:refname'):
     """Return a tuple of (local branches, remote branches, tags)."""
     git = context.git
     local_branches = []
@@ -250,7 +250,7 @@ def all_refs(context, split=False):
     query = (triple('refs/tags', tags),
              triple('refs/heads', local_branches),
              triple('refs/remotes', remote_branches))
-    sort = _version_sort(context)
+    sort = _version_sort(context, key=sort_key)
     _, out, _ = git.for_each_ref(format='%(refname)',
                                  sort=sort, _readonly=True)
     for ref in out.splitlines():

--- a/cola/icons.py
+++ b/cola/icons.py
@@ -136,7 +136,7 @@ def add():
     return from_theme('list-add', fallback='plus.svg')
 
 
-def a_z_order():
+def alphabetical():
     return icon('a-z-order.svg')
 
 
@@ -232,10 +232,6 @@ def fold():
     return icon('fold.svg')
 
 
-def last_first_order():
-    return icon('last-first-order.svg')
-
-
 def merge():
     return icon('git-merge.svg')
 
@@ -282,6 +278,10 @@ def remove():
 
 def repo():
     return icon('repo.svg')
+
+
+def reverse_chronological():
+    return icon('last-first-order.svg')
 
 
 def save():

--- a/cola/icons.py
+++ b/cola/icons.py
@@ -334,3 +334,11 @@ def zoom_in():
 
 def zoom_out():
     return icon('zoom-out.svg')
+
+
+def a_z_order():
+    return icon('a-z-order.svg')
+
+
+def last_first_order():
+    return icon("last-first-order.svg")

--- a/cola/icons.py
+++ b/cola/icons.py
@@ -136,6 +136,10 @@ def add():
     return from_theme('list-add', fallback='plus.svg')
 
 
+def a_z_order():
+    return icon('a-z-order.svg')
+
+
 def branch():
     return icon('git-branch.svg')
 
@@ -226,6 +230,10 @@ def file_zip():
 
 def fold():
     return icon('fold.svg')
+
+
+def last_first_order():
+    return icon('last-first-order.svg')
 
 
 def merge():
@@ -334,11 +342,3 @@ def zoom_in():
 
 def zoom_out():
     return icon('zoom-out.svg')
-
-
-def a_z_order():
-    return icon('a-z-order.svg')
-
-
-def last_first_order():
-    return icon("last-first-order.svg")

--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -96,6 +96,7 @@ class MainModel(Observable):
         self.submodules = set()
         self.submodules_list = []
 
+        self._refs_sort_key = 'version:refname'
         self.local_branches = []
         self.remote_branches = []
         self.tags = []
@@ -283,7 +284,7 @@ class MainModel(Observable):
     def _update_branches_and_tags(self):
         context = self.context
         local_branches, remote_branches, tags = gitcmds.all_refs(
-            context, split=True)
+            context, split=True, sort_key=self._refs_sort_key)
         self.local_branches = local_branches
         self.remote_branches = remote_branches
         self.tags = tags
@@ -392,6 +393,17 @@ class MainModel(Observable):
         if self.directory:
             return self.directory
         return core.getcwd()
+
+    @property
+    def refs_sort_key(self):
+        return self._refs_sort_key
+
+    @refs_sort_key.setter
+    def refs_sort_key(self, val):
+        if val == self._refs_sort_key:
+            return
+        self._refs_sort_key = val
+        self._update_branches_and_tags()
 
 
 # Helpers

--- a/cola/widgets/branch.py
+++ b/cola/widgets/branch.py
@@ -77,7 +77,10 @@ class BranchesWidget(QtWidgets.QFrame):
         ))
         self.model = context.model
 
-        tooltip_order = N_('Toggle references sorting order')
+        tooltip_order = N_(
+            'Set the sort order for branches and tags.\n'
+            'Toggle between date-based and version-name-based sorting.'
+        )
         icon = self.order_icons[context.model.refs_sort_key]
         self.sort_order_button = qtutils.create_action_button(
             tooltip=tooltip_order, icon=icon)

--- a/cola/widgets/branch.py
+++ b/cola/widgets/branch.py
@@ -71,6 +71,17 @@ class BranchesWidget(QtWidgets.QFrame):
         self.filter_button = qtutils.create_action_button(tooltip=tooltip,
                                                           icon=icon)
 
+        self.order_icons = odict((
+            ('version:refname', icons.a_z_order()),
+            ('-committerdate', icons.last_first_order())
+        ))
+        self.model = context.model
+
+        tooltip_order = N_('Toggle references sorting order')
+        icon = self.order_icons[context.model.refs_sort_key]
+        self.sort_order_button = qtutils.create_action_button(
+            tooltip=tooltip_order, icon=icon)
+
         self.tree = BranchesTreeWidget(context, parent=self)
         self.filter_widget = BranchesFilterWidget(self.tree)
         self.filter_widget.hide()
@@ -87,6 +98,8 @@ class BranchesWidget(QtWidgets.QFrame):
                                                 hotkeys.FILTER)
         qtutils.connect_button(self.filter_button, self.toggle_filter)
 
+        qtutils.connect_button(self.sort_order_button, self.toggle_sort_order)
+
     def toggle_filter(self):
         shown = not self.filter_widget.isVisible()
         self.filter_widget.setVisible(shown)
@@ -94,6 +107,14 @@ class BranchesWidget(QtWidgets.QFrame):
             self.filter_widget.setFocus()
         else:
             self.tree.setFocus()
+
+    def toggle_sort_order(self):
+        keys = tuple(self.order_icons)
+        next_i = (keys.index(self.model.refs_sort_key) + 1) % len(keys)
+        self.model.refs_sort_key = keys[next_i]
+        self.sort_order_button.setIcon(
+            self.order_icons[self.model.refs_sort_key])
+        self.tree.refresh()
 
 
 class BranchesTreeWidget(standard.TreeWidget):

--- a/cola/widgets/branch.py
+++ b/cola/widgets/branch.py
@@ -112,6 +112,9 @@ class BranchesWidget(QtWidgets.QFrame):
         keys = tuple(self.order_icons)
         next_i = (keys.index(self.model.refs_sort_key) + 1) % len(keys)
         self.model.refs_sort_key = keys[next_i]
+        self.refresh()
+
+    def refresh(self):
         self.sort_order_button.setIcon(
             self.order_icons[self.model.refs_sort_key])
         self.tree.refresh()

--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -885,6 +885,7 @@ class MainView(standard.MainWindow):
         state['show_status_filter'] = show_status_filter
         state['toolbars'] = self.toolbar_state.export_state()
         self.diffviewer.export_state(state)
+        state['refs_sort_key'] = self.model.refs_sort_key
 
         return state
 
@@ -899,6 +900,10 @@ class MainView(standard.MainWindow):
 
         toolbars = state.get('toolbars', [])
         self.toolbar_state.apply_state(toolbars)
+
+        if 'refs_sort_key' in state:
+            self.model.refs_sort_key = state['refs_sort_key']
+            self.branchwidget.refresh()
 
         diff_ok = self.diffviewer.apply_state(state)
         return base_ok and diff_ok

--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -884,8 +884,8 @@ class MainView(standard.MainWindow):
         show_status_filter = self.statuswidget.filter_widget.isVisible()
         state['show_status_filter'] = show_status_filter
         state['toolbars'] = self.toolbar_state.export_state()
+        state['ref_sort'] = self.model.ref_sort
         self.diffviewer.export_state(state)
-        state['refs_sort_key'] = self.model.refs_sort_key
 
         return state
 
@@ -901,9 +901,8 @@ class MainView(standard.MainWindow):
         toolbars = state.get('toolbars', [])
         self.toolbar_state.apply_state(toolbars)
 
-        if 'refs_sort_key' in state:
-            self.model.refs_sort_key = state['refs_sort_key']
-            self.branchwidget.refresh()
+        sort_key = state.get('ref_sort', 0)
+        self.model.set_ref_sort(sort_key)
 
         diff_ok = self.diffviewer.apply_state(state)
         return base_ok and diff_ok

--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -120,6 +120,7 @@ class MainView(standard.MainWindow):
         self.branchwidget = self.branchdock.widget()
         titlebar = self.branchdock.titleBarWidget()
         titlebar.add_corner_widget(self.branchwidget.filter_button)
+        titlebar.add_corner_widget(self.branchwidget.sort_order_button)
 
         # "Submodule" widgets
         self.submodulesdock = create_dock(

--- a/share/git-cola/icons/a-z-order.svg
+++ b/share/git-cola/icons/a-z-order.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="4.7549686mm"
+   height="6.8598337mm"
+   viewBox="0 0 16.848314 24.306497"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="a-z-order.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9195959"
+     inkscape:cx="-9.5983893"
+     inkscape:cy="-15.464899"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1920"
+     inkscape:window-height="1153"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-353.0704,-543.11908)">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.00000095px;line-height:125%;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="357.2879"
+       y="554.23077"
+       id="text4136"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         x="357.2879"
+         y="554.23077"
+         id="tspan4140"
+         style="font-size:16.25px">A</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.00000095px;line-height:125%;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="357.20917"
+       y="566.6051"
+       id="text4144"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4146"
+         x="357.20917"
+         y="566.6051"
+         style="font-size:16.25px">Z</tspan></text>
+    <g
+       id="g4152"
+       transform="translate(0.50507627,0.63134534)">
+      <rect
+         y="542.48773"
+         x="366.14105"
+         height="21.970779"
+         width="1.7677797"
+         id="rect4148"
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:20;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4150"
+         d="m 369.41364,560.48128 -4.77738,0 2.38869,6.31295 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/share/git-cola/icons/dark/a-z-order.svg
+++ b/share/git-cola/icons/dark/a-z-order.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="4.7549686mm"
+   height="6.8598337mm"
+   viewBox="0 0 16.848314 24.306497"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.1 r15371"
+   sodipodi:docname="a-z-order.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9195959"
+     inkscape:cx="-31.632342"
+     inkscape:cy="-15.464899"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1920"
+     inkscape:window-height="1018"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-353.0704,-543.11908)">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;"
+       x="357.2879"
+       y="554.23077"
+       id="text4136"><tspan
+         sodipodi:role="line"
+         x="357.2879"
+         y="554.23077"
+         id="tspan4140"
+         style="font-size:16.25px;line-height:1.25;fill:#ffffff;">A</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;"
+       x="357.20917"
+       y="566.6051"
+       id="text4144"><tspan
+         sodipodi:role="line"
+         id="tspan4146"
+         x="357.20917"
+         y="566.6051"
+         style="font-size:16.25px;line-height:1.25;fill:#ffffff;">Z</tspan></text>
+    <g
+       id="g4152"
+       transform="translate(0.50507627,0.63134534)"
+       style="fill:#ffffff">
+      <rect
+         y="542.48773"
+         x="366.14105"
+         height="21.970779"
+         width="1.7677797"
+         id="rect4148"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:20;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4150"
+         d="m 369.41364,560.48128 -4.77738,0 2.38869,6.31295 z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/share/git-cola/icons/dark/last-first-order.svg
+++ b/share/git-cola/icons/dark/last-first-order.svg
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="8.2617321mm"
+   height="6.2944207mm"
+   viewBox="0 0 29.273854 22.303065"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.1 r15371"
+   sodipodi:docname="last-first-order.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="2.1568652"
+     inkscape:cy="10.007863"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1920"
+     inkscape:window-height="1018"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-349.03978,-543.13091)">
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 373.63014,549.42397 3.97169,-2.08957 -4.74704,-4.20349 z"
+       id="path4150"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <g
+       id="g4243"
+       transform="matrix(2.092364,0,0,2.1094418,-390.07167,-602.54612)"
+       style="stroke:#ffffff">
+      <circle
+         r="4.9680939"
+         cy="548.51959"
+         cx="358.41425"
+         id="path4144"
+         style="opacity:1;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.40772328;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path4146"
+         d="m 359.57326,546.59119 -1.26269,2.0203 3.18829,3.18829"
+         style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1" />
+      <g
+         transform="translate(0,-0.06032771)"
+         id="g4199"
+         style="stroke:#ffffff">
+        <g
+           id="g4189"
+           transform="translate(0.01912561,0)"
+           style="stroke:#ffffff">
+          <path
+             inkscape:connector-curvature="0"
+             id="path4172"
+             d="m 353.89115,548.57992 1.4521,0"
+             style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4172-2"
+             d="m 361.44699,548.57992 1.4521,0"
+             style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <g
+           transform="matrix(0,1,-1,0,906.99417,190.1848)"
+           id="g4193"
+           style="stroke:#ffffff">
+          <path
+             style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 353.89115,548.57992 1.4521,0"
+             id="path4195"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 361.44699,548.57992 1.4521,0"
+             id="path4197"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </g>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 373.98621,563.8095 c 4.82143,-5.625 4.10714,-12.32143 0.0893,-17.76786"
+       id="path4147"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>

--- a/share/git-cola/icons/last-first-order.svg
+++ b/share/git-cola/icons/last-first-order.svg
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="8.2617321mm"
+   height="6.2944207mm"
+   viewBox="0 0 29.273854 22.303065"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="last-first-order.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="9.9470438"
+     inkscape:cy="10.007863"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1884"
+     inkscape:window-height="1177"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-349.03978,-543.13091)">
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 373.63014,549.42397 3.97169,-2.08957 -4.74704,-4.20349 z"
+       id="path4150"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <g
+       id="g4243"
+       transform="matrix(2.092364,0,0,2.1094418,-390.07167,-602.54612)">
+      <circle
+         r="4.9680939"
+         cy="548.51959"
+         cx="358.41425"
+         id="path4144"
+         style="opacity:1;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#000000;stroke-width:0.40772328;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path4146"
+         d="m 359.57326,546.59119 -1.26269,2.0203 3.18829,3.18829"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1" />
+      <g
+         transform="translate(0,-0.06032771)"
+         id="g4199">
+        <g
+           id="g4189"
+           transform="translate(0.01912561,0)">
+          <path
+             inkscape:connector-curvature="0"
+             id="path4172"
+             d="m 353.89115,548.57992 1.4521,0"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4172-2"
+             d="m 361.44699,548.57992 1.4521,0"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <g
+           transform="matrix(0,1,-1,0,906.99417,190.1848)"
+           id="g4193">
+          <path
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 353.89115,548.57992 1.4521,0"
+             id="path4195"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 361.44699,548.57992 1.4521,0"
+             id="path4197"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </g>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 373.98621,563.8095 c 4.82143,-5.625 4.10714,-12.32143 0.0893,-17.76786"
+       id="path4147"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>


### PR DESCRIPTION
Currently, branches are alphabet ordered.
But it's also handy to sort them by committer time.
So, recently edited branches are to the top of the list.

This patch series adds a toggle button to branch widget, allowing a user to select desired order.
Current order is also preserved in the state.