### PR TITLE
Python2 unicode support with translations

### DIFF
--- a/cola/i18n.py
+++ b/cola/i18n.py
@@ -19,7 +19,6 @@ def gettext(s):
         # Python 3 compat
         _translation.ugettext = _translation.gettext
         txt = _translation.gettext(s)
-    txt = core.decode(txt)
     txt = txt.replace('@@verb', '').replace('@@noun', '')  # handle @@verb / @@noun
     return txt
 

--- a/cola/i18n.py
+++ b/cola/i18n.py
@@ -20,8 +20,7 @@ def gettext(s):
         _translation.ugettext = _translation.gettext
         txt = _translation.gettext(s)
     txt = core.decode(txt)
-    if txt[-6:-4] == '@@':  # handle @@verb / @@noun
-        txt = txt[:-6]
+    txt = txt.replace('@@verb', '').replace('@@noun', '')  # handle @@verb / @@noun
     return txt
 
 

--- a/cola/i18n.py
+++ b/cola/i18n.py
@@ -19,7 +19,8 @@ def gettext(s):
         # Python 3 compat
         _translation.ugettext = _translation.gettext
         txt = _translation.gettext(s)
-    txt = txt.replace('@@verb', '').replace('@@noun', '')  # handle @@verb / @@noun
+    # handle @@verb / @@noun
+    txt = txt.replace('@@verb', '').replace('@@noun', '')
     return txt
 
 


### PR DESCRIPTION
This is not a complete solution. But it can solve the errors in `cola/i18n.py`. After this is solved, I get new errors from `cola/decorators.py`:

```
Traceback (most recent call last):
  File "./bin/git-cola", line 54, in <module>
    sys.exit(main())
  File "/home/guo/git/other/git-cola/cola/main.py", line 28, in main
    return args.func(args)
  File "/home/guo/git/other/git-cola/cola/main.py", line 300, in cmd_cola
    view = MainView(context, settings=args.settings)
  File "/home/guo/git/other/git-cola/cola/widgets/main.py", line 143, in __init__
    editor = commitmsg.CommitMessageEditor(context, self)
  File "/home/guo/git/other/git-cola/cola/widgets/commitmsg.py", line 104, in __init__
    icon=icons.configure(), tooltip=N_('Actions...'))
  File "/home/guo/git/other/git-cola/cola/icons.py", line 177, in configure
    return from_theme('configure', fallback='gear.svg')
  File "/home/guo/git/other/git-cola/cola/decorators.py", line 32, in _decorated
    return caller(func, *args, **opts)
  File "/home/guo/git/other/git-cola/cola/decorators.py", line 51, in _memoize
    key = (args, frozenset(list(opts.items())))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-1: ordinal not in range(128)
```
I can disable `@memoize` to skip this error. Then here is another use of `.items()` function in `cola/utils.py` that cause the same error.

I don't have much knowledge about Python's data structure and cannot dive further. The exact code works in Python 3.x but not in Python 2.7.