### PR TITLE
display the real import error for easier debug

### DIFF
--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -174,8 +174,8 @@ if API in PYSIDE_API:
         PYQT_VERSION = None
         PYQT5 = PYSIDE2 = False
         PYSIDE = True
-    except ImportError:
-        raise PythonQtError('No Qt bindings could be found')
+    except ImportError as err:
+        raise PythonQtError('No Qt bindings could be found (%s)' % err)
 
 
 API_NAME = {'pyqt5': 'PyQt5', 'pyqt': 'PyQt4', 'pyqt4': 'PyQt4',


### PR DESCRIPTION
In my case i see this error:

`qtpy.PythonQtError: No Qt bindings could be found (No module named 'PySide')`

instead of only:

`qtpy.PythonQtError: No Qt bindings could be found`
