### PR TITLE
fsmonitor: don't display conflicting messages

### DIFF
--- a/cola/fsmonitor.py
+++ b/cola/fsmonitor.py
@@ -204,8 +204,9 @@ if AVAILABLE == 'inotify':
 
                 self.refresh()
 
-                self._log_enabled_message()
-                self._process_events(poll_obj)
+                if self._running:
+                    self._log_enabled_message()
+                    self._process_events(poll_obj)
             finally:
                 self._close_fds()
 


### PR DESCRIPTION
If file system change monitoring is disabled due to reaching the inotify
watch limit, don't display the message indicating that change monitoring
is enabled after displaying the message indicating that it is disabled.

Signed-off-by: Daniel Harding <dharding@living180.net>