### PR TITLE
main: hide current repo from "Open Recent" menu

### DIFF
--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -728,10 +728,11 @@ class MainView(standard.MainWindow):
         menu = self.open_recent_menu
         menu.clear()
         for entry in settings.recent:
-            name = entry['name']
             directory = entry['path']
-            text = '%s %s %s' % (name, uchr(0x2192), directory)
-            menu.addAction(text, cmds.run(cmd, context, directory))
+            if self.git.worktree() != directory:
+                name = entry['name']
+                text = '%s %s %s' % (name, uchr(0x2192), directory)
+                menu.addAction(text, cmds.run(cmd, context, directory))
 
     # Accessors
     mode = property(lambda self: self.model.mode)


### PR DESCRIPTION
The current repo was showing up in the "Open Recent" menu, which serves
no purpose.

Now the current repo is not shown, with the current repo determined from
the path.

Closes #983
Signed-off-by: Tim Brown <stimut@gmail.com>