### PR TITLE
recent: update recent repo list when opening repo

### DIFF
--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -27,6 +27,7 @@ from .git import MISSING_BLOB_OID
 from .i18n import N_
 from .interaction import Interaction
 from .models import prefs
+from .settings import Settings
 
 
 class UsageError(Exception):
@@ -1552,6 +1553,10 @@ class OpenRepo(EditModel):
             self.fsmonitor.start()
             self.model.update_status()
             self.model.set_commitmsg(self.new_commitmsg)
+            settings = Settings()
+            settings.load()
+            settings.add_recent(self.repo_path, prefs.maxrecent(self.context))
+            settings.save()
             super(OpenRepo, self).do()
         else:
             self.model.set_worktree(old_repo)

--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -36,6 +36,7 @@ class MainModel(Observable):
     message_submodules_changed = 'message_submodules_changed'
     message_refs_updated = 'message_refs_updated'
     message_updated = 'updated'
+    message_worktree_changed = 'message_worktree_changed'
 
     # States
     mode_none = 'none'  # Default: nothing's happened, do nothing
@@ -131,6 +132,7 @@ class MainModel(Observable):
             self.set_directory(cwd)
             core.chdir(cwd)
             self.update_config(reset=True)
+            self.notify_observers(self.message_worktree_changed)
         return is_valid
 
     def is_git_lfs_enabled(self):

--- a/cola/widgets/bookmarks.py
+++ b/cola/widgets/bookmarks.py
@@ -104,6 +104,7 @@ def disable_rename(_path, _name, _new_name):
 
 class BookmarksTreeWidget(standard.TreeWidget):
     default_changed = Signal()
+    worktree_changed = Signal()
 
     def __init__(self, context, style, settings, parent=None):
         standard.TreeWidget.__init__(self, parent=parent)
@@ -165,6 +166,13 @@ class BookmarksTreeWidget(standard.TreeWidget):
         self.set_default_repo_action.setEnabled(False)
         self.clear_default_repo_action.setEnabled(False)
 
+        # Connections
+        if style == RECENT_REPOS:
+            self.worktree_changed.connect(self.refresh,
+                                          type=Qt.QueuedConnection)
+            context.model.add_observer(context.model.message_worktree_changed,
+                                       self.worktree_changed.emit)
+
     def refresh(self):
         context = self.context
         settings = self.settings
@@ -175,6 +183,7 @@ class BookmarksTreeWidget(standard.TreeWidget):
             entries = settings.bookmarks
         # recent items
         elif self.style == RECENT_REPOS:
+            settings.reload_recent()
             entries = settings.recent
 
         items = [builder.get(entry['path'], entry['name']) for entry in entries]


### PR DESCRIPTION
Currently, the recent repo list is only updated when the application is
exited, due to the list being stored in the settings, which are saved on
exit. As well as newly opened repos not showing on the recent list, it
means that if you start on repo A, open repo B, then open repo C, and
finally exit, repo B will not have been added to the recent list.

With this change, when a repo is opened it will be added to the recent
list immediately, and will therefore show in the recent repo list in the
menu. In addition to that, a signal was created for the changing of the
worktree, so that the bookmarks widget for the recent repo list can be
updated.

Closes #937
Signed-off-by: Tim Brown stimut@gmail.com