### PR TITLE
editremotes: select newly added remote

### DIFF
--- a/cola/widgets/editremotes.py
+++ b/cola/widgets/editremotes.py
@@ -256,7 +256,9 @@ class RemoteEditor(standard.Dialog):
 
     def add(self):
         if add_remote(self.context, self):
-            self.refresh()
+            self.refresh(select=False)
+            # Newly added remote will be last; select it
+            self.select_remote(len(self.remote_list) - 1)
 
     def delete(self):
         remote = qtutils.selected_item(self.remotes, self.remote_list)


### PR DESCRIPTION
Previously after added a new remote, we would either reselect the
previously selected remote, or select the first remote in the list.
Since newly added remotes get added to the end of the list, the new
remote was therefore never selected.

This change makes the newly added remote selected in the list.

Closes #875
Signed-off-by: Tim Brown stimut@gmail.com