### PR TITLE
widgets: #1000 allow adding to local exclusions

### DIFF
--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -600,22 +600,28 @@ class CycleReferenceSort(ContextCommand):
 
 
 class Ignore(ContextCommand):
-    """Add files to .gitignore"""
+    """Add files to an exclusion file"""
 
-    def __init__(self, context, filenames):
+    def __init__(self, context, filenames, local=False):
         super(Ignore, self).__init__(context)
         self.filenames = list(filenames)
+        self.local = local
 
     def do(self):
         if not self.filenames:
             return
         new_additions = '\n'.join(self.filenames) + '\n'
         for_status = new_additions
-        if core.exists('.gitignore'):
-            current_list = core.read('.gitignore')
+        if self.local:
+            filename = os.path.join('.git', 'info', 'exclude')
+        else:
+            filename = '.gitignore'
+        if core.exists(filename):
+            current_list = core.read(filename)
             new_additions = current_list.rstrip() + '\n' + new_additions
-        core.write('.gitignore', new_additions)
-        Interaction.log_status(0, 'Added to .gitignore:\n%s' % for_status, '')
+        core.write(filename, new_additions)
+        Interaction.log_status(0, 'Added to %s:\n%s' % (filename, for_status),
+                               '')
         self.model.update_file_status()
 
 

--- a/cola/widgets/gitignore.py
+++ b/cola/widgets/gitignore.py
@@ -27,7 +27,7 @@ class AddToGitIgnore(Dialog):
         self.selection = context.selection
         if parent is not None:
             self.setWindowModality(QtCore.Qt.WindowModal)
-        self.setWindowTitle(N_('Add to .gitignore'))
+        self.setWindowTitle(N_('Add to exclusions'))
 
         # Create text
         self.text_description = QtWidgets.QLabel()
@@ -45,9 +45,21 @@ class AddToGitIgnore(Dialog):
         self.radio_filename = qtutils.radio(text=N_('Ignore exact filename'),
                                             checked=True)
         self.radio_pattern = qtutils.radio(text=N_('Ignore custom pattern'))
+        self.name_radio_group = qtutils.buttongroup(self.radio_filename,
+                                                    self.radio_pattern)
+        self.name_radio_layt = qtutils.vbox(defs.no_margin, defs.spacing,
+                                            self.radio_filename,
+                                            self.radio_pattern)
 
-        self.radio_layt = qtutils.vbox(defs.no_margin, defs.spacing,
-                                       self.radio_filename, self.radio_pattern)
+        self.radio_in_repo = qtutils.radio(text=N_('Add to .gitignore'),
+                                           checked=True)
+        self.radio_local = qtutils.radio(text=N_('Add to local '
+                                                 '.git/info/exclude'))
+        self.location_radio_group = qtutils.buttongroup(self.radio_in_repo,
+                                                        self.radio_local)
+        self.location_radio_layt = qtutils.vbox(defs.no_margin, defs.spacing,
+                                                self.radio_in_repo,
+                                                self.radio_local)
 
         # Create buttons
         self.button_apply = qtutils.ok_button(text=N_('Add'))
@@ -59,9 +71,11 @@ class AddToGitIgnore(Dialog):
 
         # Layout
         self.main_layout = qtutils.vbox(defs.margin, defs.spacing,
-                                        self.radio_layt,
+                                        self.name_radio_layt,
                                         defs.button_spacing,
                                         self.filename_layt,
+                                        defs.button_spacing,
+                                        self.location_radio_layt,
                                         qtutils.STRETCH,
                                         self.btn_layt)
         self.setLayout(self.main_layout)
@@ -91,5 +105,6 @@ class AddToGitIgnore(Dialog):
 
     def apply(self):
         context = self.context
-        cmds.do(cmds.Ignore, context, self.edit_filename.text().split(';'))
+        cmds.do(cmds.Ignore, context, self.edit_filename.text().split(';'),
+                self.radio_local.isChecked())
         self.accept()

--- a/cola/widgets/status.py
+++ b/cola/widgets/status.py
@@ -745,7 +745,7 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
                 menu.addAction(self.move_to_trash_action)
             menu.addAction(self.delete_untracked_files_action)
             menu.addSeparator()
-            menu.addAction(icons.edit(), N_('Add to .gitignore'),
+            menu.addAction(icons.edit(), N_('Ignore...'),
                            partial(gitignore.gitignore_view, self.context))
 
         if not self.selection_model.is_empty():


### PR DESCRIPTION
Allow to add files to the local .git/info/exclude
- Rename status widget entry to `Ignore...`
- Add a radio choice between committed .gitignore and local exclusion file

Signed-off-by: Benjamin Somers <benjamin.somers@telecom-bretagne.eu>