### PR TITLE
widgets: Add menu item to reset main window layout

### DIFF
--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -419,6 +419,9 @@ class MainView(standard.MainWindow):
         self.lock_layout_action = add_action_bool(
             self, N_('Lock Layout'), self.set_lock_layout, False)
 
+        self.reset_layout_action = add_action(
+            self, N_('Reset Layout'), self.reset_layout)
+
         # Create the application menu
         self.menubar = QtWidgets.QMenuBar(self)
         self.setMenuBar(self.menubar)
@@ -714,6 +717,7 @@ class MainView(standard.MainWindow):
 
         menu.addSeparator()
         menu.addAction(self.lock_layout_action)
+        menu.addAction(self.reset_layout_action)
 
         return menu
 

--- a/cola/widgets/standard.py
+++ b/cola/widgets/standard.py
@@ -152,6 +152,13 @@ class MainWindowMixin(WidgetMixin):
         self.lock_layout = False
         self.widget_version = 0
         qtcompat.set_common_dock_options(self)
+        self.default_state = None
+
+    def init_state(self, settings, callback, *args, **kwargs):
+        """Save the initial state before calling the parent initializer"""
+        self.default_state = self.saveState(self.widget_version)
+        super(MainWindowMixin, self).init_state(settings, callback, *args,
+                                                **kwargs)
 
     def export_state(self):
         """Exports data for save/restore"""
@@ -185,6 +192,9 @@ class MainWindowMixin(WidgetMixin):
         self.update_dockwidget_tooltips()
 
         return result
+
+    def reset_layout(self):
+        self.restoreState(self.default_state, self.widget_version)
 
     def set_lock_layout(self, lock_layout):
         self.lock_layout = lock_layout


### PR DESCRIPTION
Allow the user to reset the default layout for the main window.
- Add an entry in the main menu;
- Store the default layout at initialization and restore it when asked.

Closes #994
Signed-off-by: Benjamin Somers <benjamin.somers@telecom-bretagne.eu>