### PR TITLE
preferences: option to automatically load commit template

### DIFF
--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -574,7 +574,6 @@ class Commit(ResetMode):
             core.unlink(tmp_file)
         if status == 0:
             super(Commit, self).do()
-            #  Check if template should be automatically loaded
             if context.cfg.get(prefs.AUTOTEMPLATE):
                 template_loader = LoadCommitMessageFromTemplate(context)
                 template_loader.do()

--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -574,7 +574,12 @@ class Commit(ResetMode):
             core.unlink(tmp_file)
         if status == 0:
             super(Commit, self).do()
-            self.model.set_commitmsg(self.new_commitmsg)
+            #  Check if template should be automatically loaded
+            if context.cfg.get(prefs.AUTOTEMPLATE):
+                template_loader = LoadCommitMessageFromTemplate(context)
+                template_loader.do()
+            else:
+                self.model.set_commitmsg(self.new_commitmsg)
 
         title = N_('Commit failed')
         Interaction.command(title, 'git commit', status, out, err)

--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -1563,7 +1563,12 @@ class OpenRepo(EditModel):
             self.fsmonitor.stop()
             self.fsmonitor.start()
             self.model.update_status()
-            self.model.set_commitmsg(self.new_commitmsg)
+            # Check if template should be loaded
+            if self.context.cfg.get(prefs.AUTOTEMPLATE):
+                template_loader = LoadCommitMessageFromTemplate(self.context)
+                template_loader.do()
+            else:
+                self.model.set_commitmsg(self.new_commitmsg)
             settings = Settings()
             settings.load()
             settings.add_recent(self.repo_path, prefs.maxrecent(self.context))

--- a/cola/models/prefs.py
+++ b/cola/models/prefs.py
@@ -9,6 +9,7 @@ from .. import utils
 from ..cmd import Command
 
 
+AUTOTEMPLATE = "cola.commit.autotemplate"
 BACKGROUND_EDITOR = 'cola.backgroundeditor'
 BLAME_VIEWER = 'cola.blameviewer'
 BOLD_HEADERS = 'cola.boldheaders'
@@ -48,6 +49,7 @@ HIDPI = 'cola.hidpi'
 class Defaults(object):
     """Read-only class for holding defaults that get overridden"""
     # These should match Git's defaults for git-defined values.
+    autotemplate = False
     blame_viewer = 'git gui blame'
     bold_headers = False
     check_conflicts = True

--- a/cola/widgets/prefs.py
+++ b/cola/widgets/prefs.py
@@ -148,7 +148,8 @@ class RepoFormWidget(FormWidget):
         self.add_row(N_('Merge Verbosity'), self.merge_verbosity)
         self.add_row(N_('Number of Diff Context Lines'), self.diff_context)
         self.add_row(N_('Summarize Merge Commits'), self.merge_summary)
-        self.add_row(N_('Automatically Load Commit Message Template'), self.autotemplate)
+        self.add_row(N_('Automatically Load Commit Message Template'),
+                     self.autotemplate)
         self.add_row(N_('Show Full Paths in the Window Title'), self.show_path)
         self.add_row(N_('Show Diffstat After Merge'), self.merge_diffstat)
         self.add_row(N_('Display Untracked Files'), self.display_untracked)

--- a/cola/widgets/prefs.py
+++ b/cola/widgets/prefs.py
@@ -124,6 +124,7 @@ class RepoFormWidget(FormWidget):
         self.diff_context = standard.SpinBox(value=5, mini=2, maxi=9995)
         self.merge_verbosity = standard.SpinBox(value=5, maxi=5)
         self.merge_summary = qtutils.checkbox(checked=True)
+        self.autotemplate = qtutils.checkbox(checked=False)
         self.merge_diffstat = qtutils.checkbox(checked=True)
         self.display_untracked = qtutils.checkbox(checked=True)
         self.show_path = qtutils.checkbox(checked=True)
@@ -147,6 +148,7 @@ class RepoFormWidget(FormWidget):
         self.add_row(N_('Merge Verbosity'), self.merge_verbosity)
         self.add_row(N_('Number of Diff Context Lines'), self.diff_context)
         self.add_row(N_('Summarize Merge Commits'), self.merge_summary)
+        self.add_row(N_('Automatically Load Commit Message Template'), self.autotemplate)
         self.add_row(N_('Show Full Paths in the Window Title'), self.show_path)
         self.add_row(N_('Show Diffstat After Merge'), self.merge_diffstat)
         self.add_row(N_('Display Untracked Files'), self.display_untracked)
@@ -155,6 +157,8 @@ class RepoFormWidget(FormWidget):
         self.add_row(N_('Autocomplete Paths'), self.autocomplete_paths)
 
         self.set_config({
+            prefs.AUTOTEMPLATE:
+                (self.autotemplate, Defaults.autotemplate),
             prefs.CHECKCONFLICTS:
                 (self.check_conflicts, Defaults.check_conflicts),
             prefs.DIFFCONTEXT: (self.diff_context, Defaults.diff_context),


### PR DESCRIPTION
- Add cola.commit.autotemplate constant in preferences
- Add checkbox in both "All repositories" and "Current repository"
- Load commit template if needed when opening new repository

Closes #735 