### PR TITLE
widgets: show server response with clickable links

### DIFF
--- a/cola/qtutils.py
+++ b/cola/qtutils.py
@@ -274,12 +274,8 @@ def link(url, text, palette=None):
     rgb_values = 'rgb(%s, %s, %s)' % (color.red(), color.green(), color.blue())
     scope = dict(rgb=rgb_values, text=text, url=url)
 
-    return """
-        <a style="font-style: italic; text-decoration: none; color: %(rgb)s;"
-            href="%(url)s">
-            %(text)s
-        </a>
-    """ % scope
+    return ('<a style="font-style: italic; text-decoration: none; '
+            'color: %(rgb)s;" href="%(url)s">%(text)s</a>' % scope)
 
 
 def add_completer(widget, items):
@@ -622,6 +618,8 @@ def default_size(parent, width, height, use_parent_height=True):
 def default_monospace_font():
     if utils.is_darwin():
         family = 'Monaco'
+    elif utils.is_win32():
+        family = 'Courier'
     else:
         family = 'Monospace'
     mfont = QtGui.QFont()

--- a/cola/qtutils.py
+++ b/cola/qtutils.py
@@ -266,6 +266,22 @@ def textbrowser(text=None):
     return widget
 
 
+def link(url, text, palette=None):
+    if palette is None:
+        palette = QtGui.QPalette()
+
+    color = palette.color(QtGui.QPalette.Foreground)
+    rgb_values = 'rgb(%s, %s, %s)' % (color.red(), color.green(), color.blue())
+    scope = dict(rgb=rgb_values, text=text, url=url)
+
+    return """
+        <a style="font-style: italic; text-decoration: none; color: %(rgb)s;"
+            href="%(url)s">
+            %(text)s
+        </a>
+    """ % scope
+
+
 def add_completer(widget, items):
     """Add simple completion to a widget"""
     completer = QtWidgets.QCompleter(items, widget)

--- a/cola/widgets/about.py
+++ b/cola/widgets/about.py
@@ -189,24 +189,8 @@ def version_text(context):
     """) % scope
 
 
-def link(url, text, palette=None):
-    if palette is None:
-        palette = QtGui.QPalette()
-
-    color = palette.color(QtGui.QPalette.Foreground)
-    rgb = 'rgb(%s, %s, %s)' % (color.red(), color.green(), color.blue())
-    scope = dict(rgb=rgb, text=text, url=url)
-
-    return """
-        <a style="font-style: italic; text-decoration: none; color: %(rgb)s;"
-            href="%(url)s">
-            %(text)s
-        </a>
-    """ % scope
-
-
 def mailto(email, text, palette):
-    return link('mailto:%s' % email, text, palette) + '<br>'
+    return qtutils.link('mailto:%s' % email, text, palette) + '<br>'
 
 
 def render_authors(authors):
@@ -337,7 +321,7 @@ def authors_text():
         dict(name='ochristi', title=N_('Developer')),
     )
     bug_url = 'https://github.com/git-cola/git-cola/issues'
-    bug_link = link(bug_url, bug_url)
+    bug_link = qtutils.link(bug_url, bug_url)
     scope = dict(bug_link=bug_link)
     prelude = N_("""
         <br>
@@ -403,7 +387,7 @@ def translators_text():
     )
 
     bug_url = 'https://github.com/git-cola/git-cola/issues'
-    bug_link = link(bug_url, bug_url)
+    bug_link = qtutils.link(bug_url, bug_url)
     scope = dict(bug_link=bug_link)
 
     prelude = N_("""

--- a/cola/widgets/branch.py
+++ b/cola/widgets/branch.py
@@ -18,6 +18,7 @@ from .. import hotkeys
 from .. import icons
 from .. import qtutils
 from .text import LineEdit
+from . import remotemessage
 
 
 def defer_fn(parent, title, fn, *args, **kwargs):
@@ -380,7 +381,8 @@ class BranchesTreeWidget(standard.TreeWidget):
         progress = standard.progress(
             N_('Executing action %s') % action, N_('Updating'), self)
         self.runtask.start(task, progress=progress,
-                           finish=self.git_action_completed)
+                           finish=self.git_action_completed,
+                           result=remotemessage.with_context(self.context))
 
     def git_action_completed(self, task):
         status, out, err = task.result

--- a/cola/widgets/remote.py
+++ b/cola/widgets/remote.py
@@ -16,6 +16,7 @@ from .. import qtutils
 from .. import utils
 from . import defs
 from . import standard
+from . import remotemessage
 
 
 FETCH = 'FETCH'
@@ -597,7 +598,8 @@ class RemoteActionDialog(standard.Dialog):
         task = ActionTask(self, model_action, remote, kwargs)
         self.runtask.start(task,
                            progress=self.progress,
-                           finish=self.action_completed)
+                           finish=self.action_completed,
+                           result=remotemessage.with_context(self.context))
 
     def action_completed(self, task):
         """Grab the results of the action and finish up"""

--- a/cola/widgets/remotemessage.py
+++ b/cola/widgets/remotemessage.py
@@ -20,6 +20,11 @@ def to_link(url):
     return qtutils.link(url, url)
 
 
+def escape(string):
+    """Escapes all occurrences of '<' and '>'"""
+    return string.replace('<', '&lt;').replace('>', '&gt;')
+
+
 def format_raw(string, start, end, offset=0):
     """Replace a part of a string and transform it to a link"""
     chars = list(string)
@@ -39,15 +44,17 @@ def format_links(string):
 
 def show(context, message):
     """Display a window if the remote sent a message"""
-    message_lines = message.split('\n')
+    message_lines = escape(message).split('\n')
     # Get lines starting with 'remote: '
     remote_lines = [line[8:] for line in message_lines
                     if line.startswith('remote: ')]
     if remote_lines:
-        # Transform new lines to HTML '<br>'
-        remote_message = '<br>'.join(remote_lines)
+        # Transform new lines to HTML '<br>' and render all white spaces
+        remote_message = '<body style="white-space: pre">' + \
+                             '<br>'.join(remote_lines) + \
+                         '</body>'
         view = RemoteMessage(context, format_links(remote_message),
-                             parent=qtutils.active_window())
+                             parent=context.view)
         view.show()
 
 
@@ -84,4 +91,4 @@ class RemoteMessage(standard.Dialog):
 
         qtutils.connect_button(self.close_button, self.close)
 
-        self.resize(defs.scale(600), defs.scale(400))
+        self.resize(defs.scale(720), defs.scale(400))

--- a/cola/widgets/remotemessage.py
+++ b/cola/widgets/remotemessage.py
@@ -1,0 +1,87 @@
+from __future__ import division, absolute_import, unicode_literals
+import re
+
+from qtpy.QtCore import Qt
+
+from .. import qtutils
+from ..i18n import N_
+from . import defs
+from . import standard
+
+
+URL_REGEX = re.compile('https?://'           # Protocol
+                       '([^/]+(:[^/]+)?@)?'  # Optional authentication
+                       '[\\w.-]+'            # Domain name
+                       '(:[0-9]+)?'          # Optional port
+                       '(/[^\\s]*)?')        # Optional path
+
+
+def to_link(url):
+    return qtutils.link(url, url)
+
+
+def format_raw(string, start, end, offset=0):
+    """Replace a part of a string and transform it to a link"""
+    chars = list(string)
+    chars[start+offset:end+offset] = to_link(string[start+offset:end+offset])
+    result = ''.join(chars)
+    return result, offset + len(result) - len(string)
+
+
+def format_links(string):
+    """Transform all links into HTML links"""
+    offset = 0
+    for url_match in URL_REGEX.finditer(string):
+        string, offset = format_raw(string, url_match.start(),
+                                    url_match.end(), offset)
+    return string
+
+
+def show(context, message):
+    """Display a window if the remote sent a message"""
+    message_lines = message.split('\n')
+    # Get lines starting with 'remote: '
+    remote_lines = [line[8:] for line in message_lines
+                    if line.startswith('remote: ')]
+    if remote_lines:
+        # Transform new lines to HTML '<br>'
+        remote_message = '<br>'.join(remote_lines)
+        view = RemoteMessage(context, format_links(remote_message),
+                             parent=qtutils.active_window())
+        view.show()
+
+
+def with_context(context):
+    """Helper function to pass to the `result` argument of RunTask.start"""
+    def wrapper(raw_message):
+        return show(context, raw_message[2])
+    return wrapper
+
+
+class RemoteMessage(standard.Dialog):
+    """Provides a dialog to display remote messages"""
+
+    def __init__(self, context, message, parent=None):
+        standard.Dialog.__init__(self, parent=parent)
+        self.context = context
+        self.model = context.model
+
+        self.setWindowTitle(N_('Remote message'))
+        if parent is not None:
+            self.setWindowModality(Qt.WindowModal)
+
+        self.text = qtutils.textbrowser(text=message)
+        # Set a monospace font, as some remote git messages include ASCII art
+        self.text.setFont(qtutils.default_monospace_font())
+
+        self.close_button = qtutils.close_button()
+        self.close_button.setDefault(True)
+
+        self.main_layout = qtutils.vbox(defs.no_margin, defs.spacing,
+                                        self.text,
+                                        self.close_button)
+        self.setLayout(self.main_layout)
+
+        qtutils.connect_button(self.close_button, self.close)
+
+        self.resize(defs.scale(600), defs.scale(400))


### PR DESCRIPTION
This commit allows to open a dialog when the remote server sends messages. Several changes are made:
- The `link` function is moved from `widgets.about` to `qtutils` to ease code reuse;
- The `self.runtask.start` function calls in `widgets.branch` are now given the `result` argument to trigger the dialog if a remote message is found;
- A new widget for the response dialog allows to show remote messages if lines starting with 'remote: ' are found in the output of the git command.

Closes #951
Signed-off-by: Benjamin Somers <benjamin.somers@telecom-bretagne.eu>