### PR TITLE
stash: Allow stashes to be renamed

### DIFF
--- a/cola/models/stash.py
+++ b/cola/models/stash.py
@@ -107,9 +107,9 @@ class SaveStash(cmds.ContextCommand):
 
     def do(self):
         if self.keep_index:
-            args = ['save', '--keep-index', self.stash_name]
+            args = ['push', '--keep-index', '-m', self.stash_name]
         else:
-            args = ['save', self.stash_name]
+            args = ['push', '-m', self.stash_name]
         status, out, err = self.git.stash(*args)
         if status == 0:
             Interaction.log_status(status, out, err)

--- a/cola/utils.py
+++ b/cola/utils.py
@@ -197,13 +197,6 @@ def strip_prefix(prefix, string):
     return string[len(prefix):]
 
 
-def sanitize(s):
-    """Removes shell metacharacters from a string."""
-    for c in """ \t!@#$%^&*()\\;,<>"'[]{}~|""":
-        s = s.replace(c, '_')
-    return s
-
-
 def tablength(word, tabwidth):
     """Return length of a word taking tabs into account
 

--- a/cola/widgets/stash.py
+++ b/cola/widgets/stash.py
@@ -1,7 +1,6 @@
 """Widgets for manipulating git stashes"""
 from __future__ import division, absolute_import, unicode_literals
 
-from qtpy import QtCore
 from qtpy.QtCore import Qt
 
 from ..i18n import N_
@@ -217,7 +216,7 @@ class StashView(standard.Dialog):
         context = self.context
         index = get(self.keep_index)
         cmds.do(stash.ApplyStash, context, selection, index, pop)
-        QtCore.QTimer.singleShot(1, self.accept)
+        self.update_from_model()
 
     def stash_save(self):
         """Saves the worktree in a stash
@@ -231,11 +230,6 @@ class StashView(standard.Dialog):
             parent=self)
         if not ok or not stash_name:
             return
-        if stash_name in self.names:
-            Interaction.critical(
-                N_('Error: Stash exists'),
-                N_('A stash named "%s" already exists') % stash_name)
-            return
         context = self.context
         keep_index = get(self.keep_index)
         stash_index = get(self.stash_index)
@@ -243,7 +237,7 @@ class StashView(standard.Dialog):
             cmds.do(stash.StashIndex, context, stash_name)
         else:
             cmds.do(stash.SaveStash, context, stash_name, keep_index)
-        QtCore.QTimer.singleShot(1, self.accept)
+        self.update_from_model()
 
     def stash_drop(self):
         """Drops the currently selected stash

--- a/cola/widgets/stash.py
+++ b/cola/widgets/stash.py
@@ -11,7 +11,6 @@ from ..qtutils import get
 from .. import cmds
 from .. import icons
 from .. import qtutils
-from .. import utils
 from . import defs
 from . import diff
 from . import standard
@@ -232,8 +231,6 @@ class StashView(standard.Dialog):
             parent=self)
         if not ok or not stash_name:
             return
-        # Sanitize the stash name
-        stash_name = utils.sanitize(stash_name)
         if stash_name in self.names:
             Interaction.critical(
                 N_('Error: Stash exists'),


### PR DESCRIPTION
These commits:
- Allow the user to rename a stash;
- Remove the superfluous constraints on stash names;
- Change the interface behaviour to something that feels more intuitive;
- Update the deprecated `git stash save` command to `git push -m`.