### PR TITLE
settings: fix issue with Recent repository count

### DIFF
--- a/cola/settings.py
+++ b/cola/settings.py
@@ -117,7 +117,7 @@ class Settings(object):
                 'path': path,
             }
         self.recent.insert(0, entry)
-        if len(self.recent) >= max_recent:
+        if len(self.recent) > max_recent:
             self.recent.pop()
 
     def remove_recent(self, path):


### PR DESCRIPTION
The Recent repository count setting did not work as expected due to an off-by-one error.

If the setting was set to 4 for instance, then git-cola would keep track of the last 3 repositories (meaning the settings file would have the information on 3 repositories, one of which is the currently opened repository). This was because a nonstrict inequality was used instead of a strict inequality during a check.

With this fix, the settings file correctly now correctly keeps track of the last 4 repositories.

Signed-off-by: Victor Gambier victor.gambier@imt-atlantique.net