### PR TITLE
Add option to compare SVGs in plain text

### DIFF
--- a/cola/models/prefs.py
+++ b/cola/models/prefs.py
@@ -37,6 +37,7 @@ SAVEWINDOWSETTINGS = 'cola.savewindowsettings'
 SHOW_PATH = 'cola.showpath'
 SORT_BOOKMARKS = 'cola.sortbookmarks'
 SPELL_CHECK = 'cola.spellcheck'
+SVG_PLAIN_TEXT = 'cola.svgplaintext'
 STATUS_INDENT = 'cola.statusindent'
 STATUS_SHOW_TOTALS = 'cola.statusshowtotals'
 THEME = 'cola.theme'
@@ -81,6 +82,7 @@ class Defaults(object):
     hidpi = hidpi.Option.AUTO
     status_indent = False
     status_show_totals = False
+    svg_plain_text = False
 
 
 def blame_viewer(context):
@@ -174,6 +176,11 @@ def maxrecent(context):
 def spellcheck(context):
     """Should we spellcheck commit messages?"""
     return context.cfg.get(SPELL_CHECK, default=Defaults.spellcheck)
+
+
+def plain_text_svg(context):
+    """Should we compare SVGs as text or as a rendered image?"""
+    return context.cfg.get(SVG_PLAIN_TEXT, default=Defaults.svg_plain_text)
 
 
 def expandtab(context):

--- a/cola/widgets/prefs.py
+++ b/cola/widgets/prefs.py
@@ -214,6 +214,7 @@ class SettingsFormWidget(FormWidget):
         self.sort_bookmarks = qtutils.checkbox()
         self.save_window_settings = qtutils.checkbox()
         self.check_spelling = qtutils.checkbox()
+        self.svg_plain_text = qtutils.checkbox()
         self.expandtab = qtutils.checkbox()
 
         self.add_row(N_('Fixed-Width Font'), self.fixed_font)
@@ -230,6 +231,7 @@ class SettingsFormWidget(FormWidget):
         self.add_row(N_('Keep *.orig Merge Backups'), self.keep_merge_backups)
         self.add_row(N_('Save GUI Settings'), self.save_window_settings)
         self.add_row(N_('Check spelling'), self.check_spelling)
+        self.add_row(N_('Compare SVG files in plain text'), self.svg_plain_text)
 
         self.set_config({
             prefs.SAVEWINDOWSETTINGS:
@@ -251,6 +253,7 @@ class SettingsFormWidget(FormWidget):
                 (self.keep_merge_backups, Defaults.merge_keep_backup),
             prefs.MERGETOOL: (self.mergetool, Defaults.mergetool),
             prefs.SPELL_CHECK: (self.check_spelling, Defaults.spellcheck),
+            prefs.SVG_PLAIN_TEXT: (self.svg_plain_text, Defaults.svg_plain_text)
         })
 
         # pylint: disable=no-member

--- a/cola/widgets/status.py
+++ b/cola/widgets/status.py
@@ -973,9 +973,10 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
         path = item.path
         deleted = item.deleted
         image = self.image_formats.ok(path)
+        svg_text = path.endswith(".svg") and prefs.plain_text_svg(context)
 
-        # Images are diffed differently
-        if image:
+        # Images are diffed differently. SVGs could be text or image diff.
+        if image and not svg_text:
             cmds.do(cmds.DiffImage, context, path, deleted,
                     staged, modified, unmerged, untracked)
         elif staged:


### PR DESCRIPTION
This adds a simple checkbox to **Preferences** under **Settings** to toggle between the text and image diffs for files that end with `.svg`. The default is **unchecked**.

In some projects, it is preferable to compare SVGs for XML changes, as opposed to its image output differences.

Closes #859.

![image](https://user-images.githubusercontent.com/13032135/72652904-95338480-3980-11ea-82c2-35ec53fbcc99.png)