### PR TITLE
cmds: speed up showing binary untracked files

### DIFF
--- a/cola/core.py
+++ b/cola/core.py
@@ -78,6 +78,8 @@ def decode(value, encoding=None, errors='strict'):
         result = None
     elif isinstance(value, ustr):
         result = UStr(value, ENCODING)
+    elif encoding == 'bytes':
+        result = value
     else:
         result = None
         if encoding is None:


### PR DESCRIPTION
Apparently, Qt's text renderer is pretty slow when text includes
unprintable characters (code points below 32), or many different code
points, or if code points are not part of any fonts. This is possibly
due to font selection fallback handling or so.

Selecting an untracked binary file  can make the git-cola GUI
unresponsive for up to 1 or 2 seconds or so, even if the file size is
well below the default read limit of 2 KB.

Fix this by accepting printable ASCII characters only. string.decode()
using the "ascii" encoding allows unprintable code points below 32, so
filter them manually.

Signed-off-by: wm4 <wm4@nowhere>