### PR TITLE
Remove workaround no longer needed in pynsist preamble

### DIFF
--- a/contrib/win32/pynsist-preamble.py
+++ b/contrib/win32/pynsist-preamble.py
@@ -1,10 +1,5 @@
-# TODO pynsist commands call it "installdir", entry points call it "scriptdir"
 import os
 
-try:
-    installdir = scriptdir
-except NameError:
-    pass
 pythondir = os.path.join(installdir, 'Python')
 path = os.environ.get('PATH', '')
 os.environ['PATH'] = os.pathsep.join([pythondir, pkgdir, path])  # noqa


### PR DESCRIPTION
Since a fix (https://github.com/takluyver/pynsist/pull/149 ) you made in Pynsist a couple of years ago, this workaround is no longer needed.

I suspect you also don't need to add `pythondir` to `PATH` any more - the command launchers do this already, and when launching from a shortcut that's the exe directory, which I think should achieve the same thing. But I haven't checked this carefully, so I'm not touching it at the moment.