### PR TITLE
Change /usr/share/appdata to /usr/share/metainfo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,8 +200,8 @@ uninstall:
 	$(RM) "$(DESTDIR)$(prefix)"/share/applications/git-cola.desktop
 	$(RM) "$(DESTDIR)$(prefix)"/share/applications/git-cola-folder-handler.desktop
 	$(RM) "$(DESTDIR)$(prefix)"/share/applications/git-dag.desktop
-	$(RM) "$(DESTDIR)$(prefix)"/share/appdata/git-dag.appdata.xml
-	$(RM) "$(DESTDIR)$(prefix)"/share/appdata/git-cola.appdata.xml
+	$(RM) "$(DESTDIR)$(prefix)"/share/metainfo/git-dag.appdata.xml
+	$(RM) "$(DESTDIR)$(prefix)"/share/metainfo/git-cola.appdata.xml
 	$(RM) "$(DESTDIR)$(prefix)"/share/icons/hicolor/scalable/apps/git-cola.svg
 	$(RM_R) "$(DESTDIR)$(prefix)"/share/doc/git-cola
 	$(RM_R) "$(DESTDIR)$(prefix)"/share/git-cola
@@ -210,7 +210,7 @@ uninstall:
 	$(RM_R) "$(DESTDIR)$(pythondir)"/cola
 	$(RMDIR) -p "$(DESTDIR)$(pythondir)" 2>/dev/null || true
 	$(RMDIR) "$(DESTDIR)$(prefix)"/share/applications 2>/dev/null || true
-	$(RMDIR) "$(DESTDIR)$(prefix)"/share/appdata 2>/dev/null || true
+	$(RMDIR) "$(DESTDIR)$(prefix)"/share/metainfo 2>/dev/null || true
 	$(RMDIR) "$(DESTDIR)$(prefix)"/share/doc 2>/dev/null || true
 	$(RMDIR) "$(DESTDIR)$(prefix)"/share/locale/*/LC_MESSAGES 2>/dev/null || true
 	$(RMDIR) "$(DESTDIR)$(prefix)"/share/locale/* 2>/dev/null || true

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ def _data_files():
         _app_path('share/git-cola/icons', '*.svg'),
         _app_path('share/git-cola/icons/dark', '*.png'),
         _app_path('share/git-cola/icons/dark', '*.svg'),
-        _app_path('share/appdata', '*.xml'),
+        _app_path('share/metainfo', '*.xml'),
         _app_path('share/applications', '*.desktop'),
         _app_path('share/doc/git-cola', '*.rst'),
         _app_path('share/doc/git-cola', '*.html'),


### PR DESCRIPTION
The latest AppStream standard changed its directory name to support not only apps but also libs, etc.