### PR TITLE
Use integer width for setting pen width

### DIFF
--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -1098,7 +1098,7 @@ class Commit(QtWidgets.QGraphicsItem):
     selected_outline_color = commit_selected_color.darker()
 
     commit_pen = QtGui.QPen()
-    commit_pen.setWidth(1.0)
+    commit_pen.setWidth(1)
     commit_pen.setColor(outline_color)
 
     def __init__(
@@ -1216,11 +1216,11 @@ class Label(QtWidgets.QGraphicsItem):
 
     head_pen = QtGui.QPen()
     head_pen.setColor(head_color.darker().darker())
-    head_pen.setWidth(1.0)
+    head_pen.setWidth(1)
 
     text_pen = QtGui.QPen()
     text_pen.setColor(QtGui.QColor(Qt.darkGray))
-    text_pen.setWidth(1.0)
+    text_pen.setWidth(1)
 
     alpha = 180
     head_color.setAlpha(alpha)


### PR DESCRIPTION
Just starting editing on Git Cola since it is a piece of software I use a lot, but thought I'd start with an easy fix. 

The [setWidth](https://doc.qt.io/qt-5/qpen.html#setWidth) for a QPen takes an integer width (in pixels). Passing in a float produces a warning when running the tests (that the implicit conversion may break later). 