### PR TITLE
Use remote.pushDefault if default branch is set

### DIFF
--- a/cola/widgets/remote.py
+++ b/cola/widgets/remote.py
@@ -90,6 +90,15 @@ def strip_remotes(remote_branches):
     return [branch for branch in branches if branch != 'HEAD']
 
 
+def get_default_remote(context):
+    """Get the name of the default remote to use for pushing.
+
+    e.g. 'origin', or whatever remote the branch is set to track
+
+    """
+    return gitcmds.upstream_remote(context) or 'origin'
+
+
 class ActionTask(qtutils.Task):
     """Run actions asynchronously"""
 
@@ -273,7 +282,7 @@ class RemoteActionDialog(standard.Dialog):
         )
         self.setLayout(self.main_layout)
 
-        default_remote = gitcmds.upstream_remote(context) or 'origin'
+        default_remote = get_default_remote(context)
 
         remotes = model.remotes
         if default_remote in remotes:

--- a/cola/widgets/remote.py
+++ b/cola/widgets/remote.py
@@ -93,10 +93,12 @@ def strip_remotes(remote_branches):
 def get_default_remote(context):
     """Get the name of the default remote to use for pushing.
 
-    e.g. 'origin', or whatever remote the branch is set to track
+    This will be the remote the branch is set to track, if it is set. If it
+    is not, remote.pushDefault will be used (or origin if not set)
 
     """
-    return gitcmds.upstream_remote(context) or 'origin'
+    upstream_remote = gitcmds.upstream_remote(context)
+    return upstream_remote or context.cfg.get('remote.pushDefault', default='origin')
 
 
 class ActionTask(qtutils.Task):

--- a/test/gitcmds_test.py
+++ b/test/gitcmds_test.py
@@ -3,6 +3,7 @@ import os
 import unittest
 
 from cola import gitcmds
+from cola.widgets.remote import get_default_remote
 
 from . import helper
 
@@ -48,6 +49,27 @@ class GitCmdsTestCase(helper.GitRepositoryTestCase):
         self.run_git('config', 'branch.main.remote', 'test')
         self.cfg.reset()
         self.assertEqual(gitcmds.upstream_remote(context), 'test')
+
+    def test_default_push(self):
+        """Test getting what default branch to push to"""
+        context = self.context
+
+        # no default push, no remote branch configured
+        self.assertEqual(get_default_remote(context), 'origin')
+
+        # default push set, no remote branch configured
+        self.run_git('config', 'remote.pushDefault', 'test')
+        self.cfg.reset()
+        self.assertEqual(get_default_remote(context), 'test')
+
+        # default push set, default remote branch configured
+        self.run_git('config', 'branch.main.remote', 'test2')
+        self.cfg.reset()
+        self.assertEqual(get_default_remote(context), 'test2')
+
+        # default push set, default remote branch configured, on different branch
+        self.run_git('checkout', '-b', 'other-branch')
+        self.assertEqual(get_default_remote(context), 'test')
 
     def test_tracked_branch(self):
         """Test tracked_branch()."""


### PR DESCRIPTION
If a remote.pushDefault is set then use that, rather than origin.

Fixes #1078

I would appreciate some advice on how/where to write a unit test for this new function. 