### PR TITLE
Replace startup dialog's bookmark list with icons instead of text list

### DIFF
--- a/cola/widgets/startup.py
+++ b/cola/widgets/startup.py
@@ -69,7 +69,7 @@ class StartupDialog(standard.Dialog):
         all_repos = bookmarks + recent
 
         added = set()
-        for repo in sorted(all_repos, key=lambda repo: repo['path'].lower()):
+        for repo in all_repos:
             if repo['path'] in added:
                 continue
             added.add(repo['path'])


### PR DESCRIPTION
+ Use an icon layout instead of the original text list. This reduces visual clutter from repeated path suffixes. The (minor) trade-off is that two repos with the same name will look the same.
+ Remove the sorting by path that StartupDialog performed. This lets the settings manage the sorting, and its behaviour seems more intuitive.
  + Bookmarks go first.
  + Recent repos go in reverse chronological order. This will visually separate same-name repos over time.
+ Add path tooltips to bookmarks

## Motivation

When I first started using Git Cola, the startup page felt a bit cluttered to me, so I finally decided to see if I could polish it.

## Pictures

Before:
![old-startup-dialog](https://user-images.githubusercontent.com/40313754/92947640-9b401d80-f49b-11ea-86ac-57ca58e0cf51.png)

After:
![new-startup-dialog](https://user-images.githubusercontent.com/40313754/92947650-9da27780-f49b-11ea-8bd6-1c989502804e.png)
