### PR TITLE
Fix Startup bookmark view not showing folders' short paths on launch

### DIFF
--- a/cola/widgets/startup.py
+++ b/cola/widgets/startup.py
@@ -95,6 +95,7 @@ class StartupDialog(standard.Dialog):
             item.setData(path, user_role)
             item.setIcon(directory_icon)
             item.setToolTip(path)
+            item.setText(self.short_paths.get(path, path))
             bookmarks_model.appendRow(item)
             items.append(item)
 


### PR DESCRIPTION
This does not affect the bookmark view if list mode is the user's startup preference.