### PR TITLE
Add better error responses from opening repositories in the startup dialog

### DIFF
--- a/cola/app.py
+++ b/cola/app.py
@@ -490,6 +490,9 @@ def new_worktree(context, repo, prompt):
             continue
 
         valid = model.set_worktree(gitdir)
+        if not valid:
+            standard.critical(N_('Error Opening Repository'),
+                              N_('Could not open %s.' % gitdir))
 
 
 def offer_to_create_repo(context, gitdir):

--- a/cola/app.py
+++ b/cola/app.py
@@ -483,7 +483,25 @@ def new_worktree(context, repo, prompt):
         gitdir = startup_dlg.find_git_repo()
         if not gitdir:
             sys.exit(core.EXIT_NOINPUT)
+
+        if not core.exists(os.path.join(gitdir, '.git')):
+            offer_to_create_repo(context, gitdir)
+            valid = model.set_worktree(gitdir)
+            continue
+
         valid = model.set_worktree(gitdir)
+
+
+def offer_to_create_repo(context, gitdir):
+    """Offer to create a new repo"""
+    title = N_('Repository Not Found')
+    text = N_('%s is not a Git repository.') % gitdir
+    informative_text = N_('Create a new repository at that location?')
+    if standard.confirm(title, text, informative_text, N_('Create')):
+        status, out, err = context.git.init(gitdir)
+        title = N_('Error Creating Repository')
+        if status != 0:
+            Interaction.command_error(title, 'git init', status, out, err)
 
 
 def async_update(context):

--- a/cola/widgets/standard.py
+++ b/cola/widgets/standard.py
@@ -973,11 +973,12 @@ def progress(title, text, parent):
     return ProgressDialog(title, text, parent)
 
 
-def question(title, text, default=True):
+def question(title, text, default=True, logo=None):
     """Launches a QMessageBox question with the provided title and message.
     Passing "default=False" will make "No" the default choice."""
     parent = qtutils.active_window()
-    logo = icons.from_style(QtWidgets.QStyle.SP_MessageBoxQuestion)
+    if logo is None:
+        logo = icons.from_style(QtWidgets.QStyle.SP_MessageBoxQuestion)
     msgbox = MessageBox(
         parent=parent,
         title=title,

--- a/cola/widgets/startup.py
+++ b/cola/widgets/startup.py
@@ -243,8 +243,31 @@ class StartupDialog(standard.Dialog):
             self.open_repo()
         else:
             self.repodir = self.bookmarks_model.data(index, Qt.UserRole)
-            if self.repodir:
-                self.accept()
+            if not self.repodir:
+                return
+            if not core.exists(self.repodir):
+                self.handle_broken_repo(index)
+                return
+            self.accept()
+
+    def handle_broken_repo(self, index):
+        settings = self.context.settings
+        all_repos = settings.bookmarks + settings.recent
+        repodir = self.bookmarks_model.data(index, Qt.UserRole)
+
+        repo = next(repo for repo in all_repos if repo['path'] == repodir)
+        title = N_('Repository Not Found')
+        text = N_('%s could not be opened. Remove from bookmarks?') \
+            % repo['path']
+        logo = icons.from_style(QtWidgets.QStyle.SP_MessageBoxWarning)
+        if standard.question(title, text, N_('Remove'), logo=logo):
+            self.context.settings.remove_bookmark(repo['path'], repo['name'])
+            self.context.settings.remove_recent(repo['path'])
+            self.context.settings.save()
+
+            item = self.bookmarks_model.item(index.row())
+            self.items.remove(item)
+            self.bookmarks_model.removeRow(index.row())
 
     def get_selected_bookmark(self):
         selected = self.bookmarks.selectedIndexes()


### PR DESCRIPTION
## Introduction 

Most errors from opening repositories in the startup dialog just silently fail.

This pull request adds messages for:
* Opening a folder that isn't a git repo, offering to create one for the user
* Failing to open a git repo
* Opening a bookmark that no longer exists, offering to remove it from the list

## Trying it out

1. Create an empty folder, then open it in the Startup dialog. Click "Create" to init a new repository and open it. 
2. Manually remove your read access to the repo's `.git`. Try to open it from the startup dialog again.
3. Manually delete the repository, then try to open it from the Startup dialog.

## Example

![example-message](https://user-images.githubusercontent.com/40313754/94114524-d3783080-fe8b-11ea-8a00-3518fb72a904.png)
