### PR TITLE
docs: fix simple typo, distuils -> distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ if sys.version_info[0] < 3:
     # pylint: disable=no-member
     sys.setdefaultencoding('utf-8')
 
-# Prevent distuils from changing "#!/usr/bin/env python" when
+# Prevent distutils from changing "#!/usr/bin/env python" when
 # --use-env-python is specified.
 try:
     sys.argv.remove('--use-env-python')


### PR DESCRIPTION
There is a small typo in setup.py.

Should read `distutils` rather than `distuils`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md