### PR TITLE
Fix test for signed commits

### DIFF
--- a/test/gitops_test.py
+++ b/test/gitops_test.py
@@ -14,7 +14,7 @@ class ColaBasicGitTestCase(helper.GitRepositoryTestCase):
         self.run_git('add', 'A', 'B')
 
         self.git.commit(m='initial commit')
-        log = self.run_git('log', '--pretty=oneline')
+        log = self.run_git('log', '--pretty=oneline', '--no-show-signature')
 
         self.assertEqual(len(log.splitlines()), 1)
 


### PR DESCRIPTION
If git is configured to sign commits, the signature will be shown by git log,
thus breaking this test. The --no-show-signature parameter avoids printing
the signature.