### PR TITLE
Allow cola to be started as a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ way to try the latest version.
     ./bin/git-cola
     ./bin/git-dag
 
+You can also start `cola` as a Python module if Python can find it.
+
+    cd git-cola
+    python -m cola
+    python -m cola dag
+
 Having git-cola's `bin/` directory in your path allows you to run
 `git cola` like a regular built-in Git command:
 

--- a/cola/__main__.py
+++ b/cola/__main__.py
@@ -1,0 +1,19 @@
+"""
+Run cola as a Python module.
+
+Usage:
+
+    python -m cola
+
+"""
+
+from cola import main
+
+
+def run():
+    """Start the command-line interface."""
+    main.main()
+
+
+if __name__ == "__main__":
+    run()

--- a/cola/__main__.py
+++ b/cola/__main__.py
@@ -7,6 +7,9 @@ Usage:
 
 """
 
+from __future__ import absolute_import, division, unicode_literals
+
+
 from cola import main
 
 


### PR DESCRIPTION
I took the easiest route (for me, on Windows) to get cola to run from a git checkout.

    python3.9 -m venv .venv
    .\.venv\scripts\activate
    pip install .
    pip install pyqt5

Then, I lacked an easy to find way to launch cola.

This offers such a way.  It allows to do:

    python -m cola