### PR TITLE
Start cola through console_script entry points

### DIFF
--- a/cola/__main__.py
+++ b/cola/__main__.py
@@ -8,12 +8,19 @@ Usage:
 """
 from __future__ import absolute_import, division, unicode_literals
 
+import sys
+
 from cola import main
 
 
 def run():
     """Start the command-line interface."""
     main.main()
+
+
+def run_dag():
+    args = ["dag"] + sys.argv[1:]
+    main.main(args)
 
 
 if __name__ == '__main__':

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,3 +39,10 @@ testing =
 	# local
 	PyQt5; python_version>='3.0'
 	PySide2; python_version=='2.7'
+
+[options.entry_points]
+console_scripts = 
+	cola = cola.__main__:run
+	dag = cola.__main__:run_dag
+	git-cola = cola.__main__:run
+	git-dag = cola.__main__:run_dag


### PR DESCRIPTION
This is related to #1119, it offers another additional way to start cola.

I'm not totally sure it won't cause any side effects, but to me this is a nice and modern way to start a Python program.

This makes use of [entry points](https://packaging.python.org/specifications/entry-points/).  On Linux these are Python shebanged files in Python's `bin` folder, on Windows these are small `.exe` files linked against `python.dll` in the `Scripts` folder.

Advantages:
* No need for Bash scripts on Windows.  Some users don't have Git Bash available.
* No need to search for a Python executable
* No need to track Python versions in the shebang
* Plays well with virtual environments and [pipx](https://github.com/pipxproject/pipx)
* Higher chance of the folder being already present in `$PATH`

In short, if the package is `pip`-installed then you use the entry point instead of a shell script or shebanged Python file.

Stuff to investigate:
* Do old releases of `pip` actually support these entry points?  This could be tested through Travis.
* What's the risk of users having `cola` twice in their `$PATH`?
* ... ?