### PR TITLE
Status widget: automatically select topmost header

### DIFF
--- a/cola/widgets/status.py
+++ b/cola/widgets/status.py
@@ -412,6 +412,9 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
                         reselect(j, current=True)
                         return
 
+        # No item was selected, select (topmost) header
+        self.select_header()
+
     def _restore_scrollbars(self):
         vscroll = self.verticalScrollBar()
         if vscroll and self.old_vscroll is not None:


### PR DESCRIPTION
Staging/unstaging files will in some cases clear the selection
of the Status widget. Consequently, the diff view is also blank.

With this patch the StatusTreeWidget._restore_selection will
automatically select the (topmost) header if no other item is
selected.

This fixes #1130