### PR TITLE
add `--includes` when reading user git config

### DIFF
--- a/cola/gitcfg.py
+++ b/cola/gitcfg.py
@@ -124,7 +124,6 @@ class GitConfig(observable.Observable):
         self._cache_key = None
         self._configs = []
         self._config_files = {}
-        self._context = context
         self._attr_cache = {}
         self._find_config_files()
 
@@ -213,7 +212,7 @@ class GitConfig(observable.Observable):
             return self._read_config_file(path)
 
         dest = {}
-        if version.check_git(self._context, 'config-includes'):
+        if version.check_git(self, 'config-includes'):
             args = ('--null', '--file', path, '--list', '--includes')
         else:
             args = ('--null', '--file', path, '--list')

--- a/cola/gitcfg.py
+++ b/cola/gitcfg.py
@@ -10,6 +10,7 @@ import struct
 from . import core
 from . import observable
 from . import utils
+from . import version
 from .compat import int_types
 from .git import STDOUT
 from .compat import ustr
@@ -123,6 +124,7 @@ class GitConfig(observable.Observable):
         self._cache_key = None
         self._configs = []
         self._config_files = {}
+        self._context = context
         self._attr_cache = {}
         self._find_config_files()
 
@@ -211,7 +213,10 @@ class GitConfig(observable.Observable):
             return self._read_config_file(path)
 
         dest = {}
-        args = ('--null', '--file', path, '--list')
+        if version.check_git(self._context, 'config-includes'):
+            args = ('--null', '--file', path, '--list', '--includes')
+        else:
+            args = ('--null', '--file', path, '--list')
         config_lines = self.git.config(*args)[STDOUT].split('\0')
         for line in config_lines:
             if not line:

--- a/cola/version.py
+++ b/cola/version.py
@@ -36,6 +36,8 @@ _versions = {
     'force-with-lease': '1.8.5',
     # git submodule update --recursive was introduced in 1.6.5
     'submodule-update-recursive': '1.6.5',
+    # git include.path pseudo-variable was introduced in 1.7.10
+    'config-includes': '1.7.10',
     # git for-each-ref --sort=version:refname
     'version-sort': '2.7.0',
     # Qt support for QT_AUTO_SCREEN_SCALE_FACTOR and QT_SCALE_FACTOR


### PR DESCRIPTION
Add `--includes` option only when reading user config.

From [`git config` doc](https://git-scm.com/docs/git-config#Documentation/git-config.txt---no-includes):

    --[no-]includes
    Respect include.* directives in config files when looking up values.
    Defaults to off when a specific file is given (e.g., using --file,
    --global, etc) and on when searching all config files.

Fix #1136 