### PR TITLE
read files included with include.path config

### DIFF
--- a/cola/gitcfg.py
+++ b/cola/gitcfg.py
@@ -211,7 +211,7 @@ class GitConfig(observable.Observable):
             return self._read_config_file(path)
 
         dest = {}
-        args = ('--null', '--file', path, '--list')
+        args = ('--null', '--file', path, '--list', '--includes')
         config_lines = self.git.config(*args)[STDOUT].split('\0')
         for line in config_lines:
             if not line:

--- a/cola/version.py
+++ b/cola/version.py
@@ -22,7 +22,8 @@ _versions = {
     # git diff learned --patience in 1.6.2
     # git mergetool learned --no-prompt in 1.6.2
     # git difftool moved out of contrib in git 1.6.3
-    'git': '1.6.3',
+    # git include.path pseudo-variable was introduced in 1.7.10
+    'git': '1.7.10',
     'python': '2.6',
     # new: git cat-file --filters --path=<path> SHA1
     # old: git cat-file --filters blob SHA1:<path>


### PR DESCRIPTION
Solve #1136

- set git minimal version to 1.7.10
- Fix #1136 - read files included in ~/.gitconfig

add `--includes` arg when reading git config

From [git config doc](https://git-scm.com/docs/git-config#Documentation/git-config.txt---no-includes):

    --[no-]includes:
    Respect include.* directives in config files when looking up values.
    Defaults to off when a specific file is given (e.g., using --file, --global,
    etc) and on when searching all config files.

Git version is `> 2.17` on Ubuntu Bionic, and `> 2.1.4` on Debian Jessie (oldoldstable), just for comparison.
