### PR TITLE
call git-cola-sequence-editor without python

### DIFF
--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -1830,7 +1830,7 @@ def unix_path(path, is_win32=utils.is_win32):
 def sequence_editor():
     """Set GIT_SEQUENCE_EDITOR for running git-cola-sequence-editor"""
     xbase = unix_path(resources.command('git-cola-sequence-editor'))
-    editor = core.list2cmdline([unix_path(sys.executable), xbase])
+    editor = core.list2cmdline([xbase])
     return editor
 
 


### PR DESCRIPTION
Currently the executable `git-cola-sequence-editor` is called always using python. However, some distros need to have this executable replaced with a wrapping script in order to inject the right environment variables. The wrapping script is a bash script and thus failed to be executed using Python. See https://github.com/NixOS/nixpkgs/issues/126131

For such cases it helps to run the executable as-is without explicitly calling Python.

I'm not sure whether this is wanted behavior in general, but this PR attempts to do this for `git-cola-sequence-editor`.