### PR TITLE
Diff: Allow partial stage/revert for untracked file

### DIFF
--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -2255,7 +2255,9 @@ class ShowUntracked(EditModel):
         super(ShowUntracked, self).__init__(context)
         self.new_filename = filename
         self.new_mode = self.model.mode_untracked
-        self.new_diff_text = self.read(filename)
+        self.new_diff_text = gitcmds.diff_helper(
+            self.context, filename=filename, cached=False, untracked=True
+        )
         self.new_diff_type = main.Types.TEXT
         self.new_file_type = main.Types.TEXT
 

--- a/cola/widgets/diff.py
+++ b/cola/widgets/diff.py
@@ -762,10 +762,11 @@ class DiffEditor(DiffTextEdit):
         enabled = False
         s = self.selection_model.selection()
         model = self.model
-        if s.modified and model.stageable():
-            if s.modified[0] in model.submodules:
+        if model.stageable():
+            item = s.modified[0] if s.modified else None
+            if item in model.submodules:
                 pass
-            elif s.modified[0] not in model.unstaged_deleted:
+            elif item not in model.unstaged_deleted:
                 enabled = True
         self.action_revert_selection.setEnabled(enabled)
 
@@ -812,8 +813,8 @@ class DiffEditor(DiffTextEdit):
                 self.stage_or_unstage.setText(N_('Unstage'))
             menu.addAction(self.stage_or_unstage)
 
-        if s.modified and model.stageable():
-            item = s.modified[0]
+        if model.stageable():
+            item = s.modified[0] if s.modified else None
             if item in model.submodules:
                 path = core.abspath(item)
                 action = menu.addAction(
@@ -953,8 +954,7 @@ class DiffEditor(DiffTextEdit):
 
     def apply_selection(self):
         model = self.model
-        s = self.selection_model.single_selection()
-        if model.stageable() and s.modified:
+        if model.stageable():
             self.process_diff_selection()
         elif model.unstageable():
             self.process_diff_selection(reverse=True)


### PR DESCRIPTION
Currently an untracked file needs to be staged first and then unwanted lines must be unstaged. This change will allow "Stage selected line" and "Revert selected lines..." to be used on untracked file.

The logic will be as followed:
When the user select "Stage selected line" on an untracked file, these selected line will be added to staging, and the rest of file will then be listed under modified. When the user select "Revert selected lines.." on an untracked file, those line will be deleted from the file

To generate the diff of the new file, dev null is used. os.devnull is used instead of hard-coding '/dev/null/'. This will ensure it will works in windows environment, where 'nul' is needed instead of '/dev/null'

The downside of using this approach is the return code. git diff will return `1` when used against new file or file outside of index. Alternate check condition is used by checking "new file mode" string from the output. This should be enough to differentiate it from genuine error such as filepath not found

Issue: #1084
Reported-By: mighty-d
Signed-off-by: mmargoliono