### PR TITLE
Diff: Fixed staged file diff in a commit-less repo

### DIFF
--- a/cola/gitcmds.py
+++ b/cola/gitcmds.py
@@ -417,8 +417,14 @@ def diff_helper(
     if ref and endref:
         argv.append('%s..%s' % (ref, endref))
     elif ref:
-        for r in utils.shell_split(ref.strip()):
-            argv.append(r)
+        ref_argvs = utils.shell_split(ref.strip())
+        if len(ref_argvs) > 1:
+            for r in ref_argvs:
+                argv.append(r)
+        elif len(ref_argvs) == 1:
+            has_valid_ref = rev_parse(context, ref) != ref
+            if has_valid_ref:
+                argv.append(ref)
     elif head and amending and cached:
         argv.append(head)
 


### PR DESCRIPTION
When there is no commit in the repo, there is no HEAD revision. Therefore the diff command returns an error (fatal: bad revision 'head'), and git-cola then use empty text as the diff fallback.

To fix the issue, the diff_helper is updated to check if `ref` exists, and if `ref` doesn't exist, we drop it and not pass it to the git diff. The check is done through the `rev_parse` wrapper in `gitcmds`, which will simply return back `ref`, when it is not in git.

When viewing the diff of a staged file in a commit-less repo, the ref would be 'HEAD'. Dropping 'HEAD' from parameter will make git compare the staged file against file in the working directory.

Issue: #1110
Reported-By: kyanres
Signed-off-by: mmargoliono