### PR TITLE
doc: note editor-awareness in diff screen, too

### DIFF
--- a/share/doc/git-cola/git-cola.rst
+++ b/share/doc/git-cola/git-cola.rst
@@ -126,7 +126,7 @@ configured.
 when editing files.  `gvim -f -o` uses splits.
 
 `git cola` is {vim, emacs, textpad, notepad++}-aware.
-When you select a line in the `grep` screen and press any of
+When you select a line in the diff or grep screens and press any of
 `Enter`, `Ctrl-e`, or the `Edit` button, you are taken to that exact line.
 
 The editor preference is saved in the `gui.editor` variable using


### PR DESCRIPTION
(Removing backticks around the "grep" because the other instance in this file doesn't have that either, and for the "diff" view they'd be out of place, and having them different here would look odd.)