### PR TITLE
Set caption default for opendir_dialog

### DIFF
--- a/cola/qtutils.py
+++ b/cola/qtutils.py
@@ -440,7 +440,7 @@ def open_files(title, directory=None, filters=''):
     return result[0]
 
 
-def opendir_dialog(caption, path):
+def opendir_dialog(path, caption='Browse...'):
     """Prompts for a directory path"""
 
     options = (


### PR DESCRIPTION
Changes the caption default value to 'Browse...' for opendir_dialog as per issue #1167. I think this will only impact systems that use Qt implemented file browsers, not system using the system default file browser.