### PR TITLE
about: use setWidth(int)

### DIFF
--- a/cola/widgets/about.py
+++ b/cola/widgets/about.py
@@ -36,7 +36,7 @@ class ExpandingTabBar(QtWidgets.QTabBar):
     """
 
     def tabSizeHint(self, tab_index):
-        width = self.parent().width() / max(1, self.count()) - 1
+        width = self.parent().width() // max(1, self.count()) - 1
         size = super(ExpandingTabBar, self).tabSizeHint(tab_index)
         size.setWidth(width)
         return size


### PR DESCRIPTION
Passing floats to setWidth() is not supported. It worked by accident
in older versions of PyQt.

This is a follow-up commit to 1b10542ec32c1ce798257a758975c564ff9ba893.