### PR TITLE
Double click no longer creates sub-windows in locked layout

### DIFF
--- a/cola/widgets/standard.py
+++ b/cola/widgets/standard.py
@@ -205,7 +205,8 @@ class MainWindowMixin(WidgetMixin):
 
     def update_dockwidget_lock_state(self):
         if self.lock_layout:
-            features = QDockWidget.DockWidgetClosable | QDockWidget.DockWidgetFloatable
+            #features = QDockWidget.DockWidgetClosable | QDockWidget.DockWidgetFloatable 
+            features = QDockWidget.DockWidgetClosable
         else:
             features = (
                 QDockWidget.DockWidgetClosable


### PR DESCRIPTION
References issue #1176 , where the issue creator would like to see double clicking the widget title bars not pop open into sub-windows when they are in locked layout mode. This makes widgets no longer able to be popped out in locked layout mode. I'm not sure if this is intended behavior, but since the issue hadn't been closed yet, here's an attempt at fixing it.