### PR TITLE
Keep track of file browser windows

### DIFF
--- a/cola/app.py
+++ b/cola/app.py
@@ -593,6 +593,7 @@ class ApplicationContext(object):
         self.selection = None  # selection.SelectionModel
         self.fsmonitor = None  # fsmonitor
         self.view = None  # QWidget
+        self.browser_windows = []  # list of browse.Browser
 
     def set_view(self, view):
         """Initialize view-specific members"""

--- a/cola/widgets/browse.py
+++ b/cola/widgets/browse.py
@@ -28,6 +28,9 @@ from . import standard
 def worktree_browser(context, parent=None, update=True, show=True):
     """Create a new worktree browser"""
     view = Browser(context, parent, update=update)
+    if parent is None:
+        context.browser_windows.append(view)
+        view.closed.connect(context.browser_windows.remove)
     model = GitRepoModel(context, view.tree)
     view.set_model(model)
     if update:

--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -885,6 +885,8 @@ class MainView(standard.MainWindow):
         """Save state in the settings"""
         commit_msg = self.commiteditor.commit_message(raw=True)
         self.model.save_commitmsg(msg=commit_msg)
+        for browser in list(self.context.browser_windows):
+            browser.close()
         standard.MainWindow.closeEvent(self, event)
 
     def create_view_menu(self):

--- a/cola/widgets/standard.py
+++ b/cola/widgets/standard.py
@@ -25,6 +25,8 @@ from . import defs
 class WidgetMixin(object):
     """Mix-in for common utilities and serialization of widget state"""
 
+    closed = Signal(QtWidgets.QWidget)
+
     def __init__(self):
         self._unmaximized_rect = {}
 
@@ -121,6 +123,7 @@ class WidgetMixin(object):
 
     def closeEvent(self, event):
         self.save_settings()
+        self.closed.emit(self)
         self.Base.closeEvent(self, event)
 
     def init_size(self, parent=None, settings=None, width=0, height=0):


### PR DESCRIPTION
Track open file browser windows via a new `ApplicationContext.browser_windows` attribute.  The context was chosen due to the fact that file browser windows can be opened from the toolbar, and toolbar commands only have access to the context.  In `MainView.closeEvent()`, close any open file browser windows to prevent them from keeping the application open when the user quits.

This change also ensures that there is a reachable reference to the `Browser` object to ensure that it isn't subject to inadvertent garbage collection.