### PR TITLE
No longer pass a parent to Channel in Task.__init__()

### DIFF
--- a/cola/app.py
+++ b/cola/app.py
@@ -514,7 +514,7 @@ def async_update(context):
 
     """
     update_status = partial(context.model.update_status, update_index=True)
-    task = qtutils.SimpleTask(context.view, update_status)
+    task = qtutils.SimpleTask(update_status)
     context.runtask.start(task)
 
 

--- a/cola/models/browse.py
+++ b/cola/models/browse.py
@@ -264,7 +264,7 @@ class GitRepoInfoTask(qtutils.Task):
     """Handles expensive git lookups for a path."""
 
     def __init__(self, context, parent, path, default_author):
-        qtutils.Task.__init__(self, parent)
+        qtutils.Task.__init__(self)
         self.context = context
         self.path = path
         self._parent = parent

--- a/cola/qtutils.py
+++ b/cola/qtutils.py
@@ -939,10 +939,10 @@ class Task(QtCore.QRunnable):
 
     """
 
-    def __init__(self, parent):
+    def __init__(self):
         QtCore.QRunnable.__init__(self)
 
-        self.channel = Channel(parent)
+        self.channel = Channel()
         self.result = None
         self.setAutoDelete(False)
 
@@ -962,8 +962,8 @@ class Task(QtCore.QRunnable):
 class SimpleTask(Task):
     """Run a simple callable as a task"""
 
-    def __init__(self, parent, fn, *args, **kwargs):
-        Task.__init__(self, parent)
+    def __init__(self, fn, *args, **kwargs):
+        Task.__init__(self)
 
         self.fn = fn
         self.args = args

--- a/cola/widgets/branch.py
+++ b/cola/widgets/branch.py
@@ -39,8 +39,8 @@ def add_branch_to_menu(menu, branch, remote_branch, remote, upstream, fn):
 class AsyncGitActionTask(qtutils.Task):
     """Run git action asynchronously"""
 
-    def __init__(self, parent, git_helper, action, args, kwarg):
-        qtutils.Task.__init__(self, parent)
+    def __init__(self, git_helper, action, args, kwarg):
+        qtutils.Task.__init__(self)
         self.git_helper = git_helper
         self.action = action
         self.args = args
@@ -393,7 +393,7 @@ class BranchesTreeWidget(standard.TreeWidget):
     def git_action_async(self, action, args, kwarg=None):
         if kwarg is None:
             kwarg = {}
-        task = AsyncGitActionTask(self, self.git_helper, action, args, kwarg)
+        task = AsyncGitActionTask(self, action, args, kwarg)
         progress = standard.progress(
             N_('Executing action %s') % action, N_('Updating'), self
         )

--- a/cola/widgets/clone.py
+++ b/cola/widgets/clone.py
@@ -19,16 +19,16 @@ from . import standard
 from . import text
 
 
-def clone(context, spawn=True, show=True, parent=None):
+def clone(context, spawn=True, show=True):
     """Clone a repository and spawn a new git-cola instance"""
     parent = qtutils.active_window()
     progress = standard.progress('', '', parent)
-    return clone_repo(context, parent, show, progress, task_finished, spawn)
+    return clone_repo(context, show, progress, task_finished, spawn)
 
 
-def clone_repo(context, parent, show, progress, finish, spawn):
+def clone_repo(context, show, progress, finish, spawn):
     """Clone a repository asynchronously with progress animation"""
-    fn = partial(start_clone_task, context, parent, progress, finish, spawn)
+    fn = partial(start_clone_task, context, progress, finish, spawn)
     prompt = prompt_for_clone(context, show=show)
     prompt.result.connect(fn)
     return prompt
@@ -55,20 +55,20 @@ def task_finished(task):
 
 
 def start_clone_task(
-    context, parent, progress, finish, spawn, url, destdir, submodules, shallow
+    context, progress, finish, spawn, url, destdir, submodules, shallow
 ):
     # Use a thread to update in the background
     runtask = context.runtask
     progress.set_details(N_('Clone Repository'), N_('Cloning repository at %s') % url)
-    task = CloneTask(context, url, destdir, submodules, shallow, spawn, parent)
+    task = CloneTask(context, url, destdir, submodules, shallow, spawn)
     runtask.start(task, finish=finish, progress=progress)
 
 
 class CloneTask(qtutils.Task):
     """Clones a Git repository"""
 
-    def __init__(self, context, url, destdir, submodules, shallow, spawn, parent):
-        qtutils.Task.__init__(self, parent)
+    def __init__(self, context, url, destdir, submodules, shallow, spawn):
+        qtutils.Task.__init__(self)
         self.context = context
         self.url = url
         self.destdir = destdir

--- a/cola/widgets/diff.py
+++ b/cola/widgets/diff.py
@@ -1084,7 +1084,7 @@ class DiffWidget(QtWidgets.QWidget):
         context = self.context
         self.diff.save_scrollbar()
         self.diff.set_loading_message()
-        task = DiffInfoTask(context, oid, filename, self)
+        task = DiffInfoTask(context, oid, filename)
         self.context.runtask.start(task, result=self.set_diff)
 
     def commits_selected(self, commits):
@@ -1172,8 +1172,8 @@ class TextLabel(QtWidgets.QLabel):
 
 
 class DiffInfoTask(qtutils.Task):
-    def __init__(self, context, oid, filename, parent):
-        qtutils.Task.__init__(self, parent)
+    def __init__(self, context, oid, filename):
+        qtutils.Task.__init__(self)
         self.context = context
         self.oid = oid
         self.filename = filename

--- a/cola/widgets/grep.py
+++ b/cola/widgets/grep.py
@@ -339,8 +339,8 @@ class GrepTextView(VimHintedPlainTextEdit):
 class PreviewTask(qtutils.Task):
     """Asynchronous task for loading file content"""
 
-    def __init__(self, parent, filename, line_number):
-        qtutils.Task.__init__(self, parent)
+    def __init__(self, filename, line_number):
+        qtutils.Task.__init__(self)
 
         self.content = ''
         self.filename = filename
@@ -368,7 +368,7 @@ class PreviewTextView(VimTextBrowser):
         """Preview the a file at the specified line number"""
 
         if filename != self.filename:
-            request = PreviewTask(self, filename, line_number)
+            request = PreviewTask(filename, line_number)
             self.runtask.start(request, finish=self.show_preview)
         else:
             self.scroll_to_line(line_number)

--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -1001,7 +1001,7 @@ class MainView(standard.MainWindow):
     def start(self, context):
         """Do the expensive "get_config_actions()" call in the background"""
         # Install .git-config-defined actions
-        task = qtutils.SimpleTask(self, self.get_config_actions)
+        task = qtutils.SimpleTask(self.get_config_actions)
         context.runtask.start(task)
 
     def get_config_actions(self):

--- a/cola/widgets/remote.py
+++ b/cola/widgets/remote.py
@@ -104,8 +104,8 @@ def get_default_remote(context):
 class ActionTask(qtutils.Task):
     """Run actions asynchronously"""
 
-    def __init__(self, parent, model_action, remote, kwargs):
-        qtutils.Task.__init__(self, parent)
+    def __init__(self, model_action, remote, kwargs):
+        qtutils.Task.__init__(self)
         self.model_action = model_action
         self.remote = remote
         self.kwargs = kwargs
@@ -631,7 +631,7 @@ class RemoteActionDialog(standard.Dialog):
         self.buttons.setEnabled(False)
 
         # Use a thread to update in the background
-        task = ActionTask(self, model_action, remote, kwargs)
+        task = ActionTask(model_action, remote, kwargs)
         self.runtask.start(task, progress=self.progress, finish=self.action_completed)
 
     def action_completed(self, task):

--- a/cola/widgets/standard.py
+++ b/cola/widgets/standard.py
@@ -993,8 +993,7 @@ def save_as(filename, title):
 
 
 def async_command(title, cmd, runtask):
-    parent = qtutils.active_window()
-    task = qtutils.SimpleTask(parent, partial(core.run_command, cmd))
+    task = qtutils.SimpleTask(partial(core.run_command, cmd))
     task.connect(partial(async_command_result, title, cmd))
     runtask.start(task)
 

--- a/cola/widgets/startup.py
+++ b/cola/widgets/startup.py
@@ -218,7 +218,7 @@ class StartupDialog(standard.Dialog):
     def clone_repo(self):
         context = self.context
         progress = standard.progress('', '', self)
-        clone.clone_repo(context, self, True, progress, self.clone_repo_done, False)
+        clone.clone_repo(context, True, progress, self.clone_repo_done, False)
 
     def clone_repo_done(self, task):
         if task.cmd and task.cmd.status == 0:


### PR DESCRIPTION
Currently, when a `Channel` for a `Task` is created, the `Channel` is given a parent.  If for some reason that parent gets deleted from the main thread while the task is running, the `Channel` will also be deleted at the C++ level, though it will still exist at the Python level.  Then once the task has completed and `Task.run()` tries to emit the .result signal on the `Channel,` a `RuntimeError` with the message `"wrapped C/C++ object of type Channel has been deleted"` will be raised.

Although this is unlikely to happen in practice it still represents a potential race condition that is better avoided.  This commit addresses the issue by no longer passing a parent when creating the `Channel` in `Task.__init__()`, instead relying on Python's garbage collection to clean up the `Channel` when it is no longer needed.