### PR TITLE
windows: do not exclude vcruntime140.dll

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,18 @@ requirement, but not needed at runtime.
 
 # Windows (Continued)
 
+## Microsoft Visual C++ 2015 Redistributable
+
+Earlier versions of Git Cola may have shipped without `vcruntime140.dll`  and may
+not run on machines that are missing this DLL.
+
+To fix this, download the
+[Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=52685)
+and install it
+
+Git Cola v4.0.0 and newer include this DLL and do not require this to be installed
+separately.
+
 ## Development
 
 In order to develop Git Cola on Windows you will need to install

--- a/pynsist.cfg
+++ b/pynsist.cfg
@@ -86,9 +86,7 @@ exclude = pkgs/PyQt5/Qt/bin/Qt5Bluetooth.dll
     pkgs/PyQt5/Qt/bin/concrt140.dll
     pkgs/PyQt5/Qt/bin/d3dcompiler_47.dll
     pkgs/PyQt5/Qt/bin/libeay32.dll
-    pkgs/PyQt5/Qt/bin/msvcp140.dll
     pkgs/PyQt5/Qt/bin/opengl32sw.dll
-    pkgs/PyQt5/Qt/bin/vcruntime140.dll
     pkgs/PyQt5/Qt/plugins/audio
     pkgs/PyQt5/Qt/plugins/generic
     pkgs/PyQt5/Qt/plugins/geometryloaders


### PR DESCRIPTION
Remove the Visual Studio C++ 2015 DLLs from the pynsist
exclusion list so that we can import Qt modules on Windows
machines that do not have these DLLs installed.

Closes #1196
Closes #1094
Signed-off-by: David Aguilar <davvid@gmail.com>