### PR TITLE
Fix insecure usage of NamedTemporaryFile

### DIFF
--- a/cola/utils.py
+++ b/cola/utils.py
@@ -287,7 +287,7 @@ def shell_split(s):
 
 def tmp_filename(label, suffix=''):
     label = 'git-cola-' + label.replace('/', '-').replace('\\', '-')
-    fd = tempfile.NamedTemporaryFile(prefix=label + '-', suffix=suffix)
+    fd = tempfile.NamedTemporaryFile(prefix=label + '-', suffix=suffix, delete=False)
     fd.close()
     return fd.name
 

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -50,14 +50,21 @@ def test_add_parents():
 
 
 def test_tmp_filename_gives_good_file():
-    first = utils.tmp_filename('test')
-    second = utils.tmp_filename('test')
+    try:
+        first = utils.tmp_filename('test')
+        assert core.exists(first)
+        assert os.path.basename(first).startswith('git-cola-test')
+    finally:
+        os.remove(first)
 
-    assert not core.exists(first)
-    assert not core.exists(second)
+    try:
+        second = utils.tmp_filename('test')
+        assert core.exists(second)
+        assert os.path.basename(second).startswith('git-cola-test')
+    finally:
+        os.remove(second)
+
     assert first != second
-    assert os.path.basename(first).startswith('git-cola-test')
-    assert os.path.basename(second).startswith('git-cola-test')
 
 
 def test_strip_one_abspath():
@@ -86,13 +93,19 @@ def test_strip_one_basename():
 
 def test_select_directory():
     filename = utils.tmp_filename('test')
-    expect = os.path.dirname(filename)
-    actual = utils.select_directory([filename])
-    assert expect == actual
+    try:
+        expect = os.path.dirname(filename)
+        actual = utils.select_directory([filename])
+        assert expect == actual
+    finally:
+        os.remove(filename)
 
 
 def test_select_directory_prefers_directories():
     filename = utils.tmp_filename('test')
-    expect = '.'
-    actual = utils.select_directory([filename, '.'])
-    assert expect == actual
+    try:
+        expect = '.'
+        actual = utils.select_directory([filename, '.'])
+        assert expect == actual
+    finally:
+        os.remove(filename)


### PR DESCRIPTION
In the `tmp_filename()` function, a temporary file was being created by `tempfile.NamedTemporaryFile()` and then immediately closed.  Because no `delete` argument was passed to `tempfile.NamedTemporaryFile(),` this meant the file was deleted as soon as it was closed.

Then when a caller of `tmp_filename()` opened a file using the file name returned by `tmp_filename()`, it would actually be creating a new file that did not have the same secure permissions as the file created by `tempfile.NamedTemporaryFile()`.

Fix this by passing `delete=False` to `tempfile.NamedTemporaryFile()`.

Signed-off-by: Daniel Harding <dharding@living180.net>