### PR TITLE
github/workflows: use a virtualenv to get a newer setuptools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
+          set -x
           sudo apt-get update
           sudo apt-get install \
               black \
@@ -45,6 +46,7 @@ jobs:
               pylint \
               python-is-python3 \
               python-pytest \
+              python-setuptools-scm \
               python3-pytest \
               python3-pytest-flake8
           # Runtime dependencies (required)
@@ -54,18 +56,22 @@ jobs:
           # Runtime dependencies (optional)
           sudo apt-get install \
               python3-send2trash
-          # Development environment
-          make requirements-dev
-          # These requirements are already satisfied by python3-send2trash.
-          # make requirements-optional
+          python -m venv --system-site-packages env
+          source env/bin/activate
+          export SETUPTOOLS_USE_DISTUTILS=stdlib
+          make develop
 
       - name: Build Translations
-        run: make i18n
+        run: |
+          source env/bin/activate
+          export SETUPTOOLS_USE_DISTUTILS=stdlib
+          make i18n
 
       - name: Run Unit Tests
         run: |
           git config --global user.name "Git Cola"
           git config --global user.email git-cola@localhost
+          export SETUPTOOLS_USE_DISTUTILS=stdlib
           make test
 
       - name: Run Linter

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,16 +140,23 @@ jobs:
 
       - name: Install Dependencies
         run: |
+          set -x
           brew install sphinx-doc
           brew install git-cola
+          $(brew --prefix python3)/bin/python3 -m venv --system-site-packages env
+          source env/bin/activate
+          make requirements-dev
+          export SETUPTOOLS_USE_DISTUTILS=stdlib
+          make develop
 
       - name: Build Bundle
         run: |
+          set -x
+          source env/bin/activate
+          export SETUPTOOLS_USE_DISTUTILS=stdlib
           mkdir build
           make \
-            PYTHON=$(brew --prefix python3)/bin/python3 \
-            PYTHON_CONFIG=$(brew --prefix python3)/bin/python3-config \
-            SPHINXBUILD=$(brew --prefix sphinx-doc)/bin/sphinx-build \
+            PYTHON_CONFIG=python3-config \
             git-cola.app
           mv git-cola.app build/
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ all::
 
 # Development
 # -----------
+# make develop                  # python setup.py develop ~ one-time virtualenv development setup
 # make V=1                      # generate files; V=1 increases verbosity
 # make test [flags=...]         # run tests; flags=-x fails fast, --ff failed first
 # make test V=2                 # V=2 increases test verbosity
@@ -91,8 +92,7 @@ endif
 # These values can be overridden on the command-line or via config.mak
 prefix = $(HOME)
 bindir = $(prefix)/bin
-python_code := "import sys; print('%s.%s' % (sys.version_info[0], sys.version_info[1]))"
-python_version := $(shell $(PYTHON) -c $(python_code))
+python_version := $(shell $(PYTHON) -c 'import sys; print("%s.%s" % sys.version_info[:2])')
 python_lib = python$(python_version)/site-packages
 pythondir = $(prefix)/lib/$(python_lib)
 # DESTDIR =
@@ -109,9 +109,6 @@ cola_dist := $(cola_base)-$(cola_version)
 SETUP ?= $(PYTHON) setup.py
 
 build_args += build
-ifdef USE_ENV_PYTHON
-    build_args += --use-env-python
-endif
 
 install_args += install
 ifdef DESTDIR
@@ -292,6 +289,12 @@ format::
 	$(GIT) ls-files -- '*.py' | \
 	$(GREP) -v ^qtpy | \
 	$(XARGS) $(BLACK) --skip-string-normalization
+
+# Run "make develop" from inside a newly created virtualenv to setup the build system
+# using "python setup.py develop".
+.PHONY: develop
+develop::
+	$(SETUP) develop
 
 .PHONY: requirements
 requirements::

--- a/extras/__init__.py
+++ b/extras/__init__.py
@@ -4,6 +4,6 @@ try:
     from setuptools.command.build import build as build_base
 except ImportError:
     try:
-        from setuptools._distutils.command.build import build as build_base
+        from setuptools._distutils.command.build import build as build_base  # noqa
     except ImportError:
-        from distutils.command.build import build as build_base
+        from distutils.command.build import build as build_base  # noqa

--- a/extras/build_util.py
+++ b/extras/build_util.py
@@ -3,7 +3,8 @@ import os
 try:
     from shutil import which  # pylint: disable=unused-import
 except ImportError:
-    from distutils.spawn import find_executable as which  # pylint: disable=unused-import
+    # pylint: disable=unused-import
+    from distutils.spawn import find_executable as which  # noqa
 
 
 def encode(string):

--- a/pynsist.cfg
+++ b/pynsist.cfg
@@ -4,7 +4,7 @@
 name = git-cola
 version = 3.12.0
 entry_point = cola.main:shortcut_launch
-icon = share/git-cola/icons/git-cola.ico
+icon = cola/icons/git-cola.ico
 extra_preamble = contrib/win32/pynsist-preamble.py
 
 # We might want to pursue shell integration, which would at minimum require a
@@ -19,7 +19,7 @@ format = bundled
 
 [Shortcut git-dag]
 entry_point = cola.dag:shortcut_launch
-icon = share/git-cola/icons/git-cola.ico
+icon = cola/icons/git-cola.ico
 extra_preamble = contrib/win32/pynsist-preamble.py
 
 [Command git-cola]

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -2,7 +2,7 @@
 
 ## Build tools
 build; python_version >= '3.0'
-setuptools>=42.0.0
+setuptools>=42
 setuptools_scm[toml] >= 3.4.1
 wheel
 


### PR DESCRIPTION
The setuptools in Ubuntu 20.04 is too old. Activate a newer
one using a Python virtualenv.

Signed-off-by: David Aguilar <davvid@gmail.com>