### PR TITLE
Support for Custom Themes

### DIFF
--- a/cola/themes.py
+++ b/cola/themes.py
@@ -1,5 +1,7 @@
 """Themes generators"""
 from __future__ import absolute_import, division, print_function, unicode_literals
+import os
+import sys
 
 from qtpy import QtGui
 
@@ -7,11 +9,13 @@ from .i18n import N_
 from .widgets import defs
 from . import icons
 from . import qtutils
+from . import resources
 
 
 class EStylesheet(object):
     DEFAULT = 1
     FLAT = 2
+    CUSTOM = 3  # Files located in ~/.config/git-cola/themes/*.qss
 
 
 class Theme(object):
@@ -25,7 +29,9 @@ class Theme(object):
         self.main_color = main_color
 
     def build_style_sheet(self, app_palette):
-        if self.style_sheet == EStylesheet.FLAT:
+        if self.style_sheet == EStylesheet.CUSTOM:
+            return self.style_sheet_custom(app_palette)
+        elif self.style_sheet == EStylesheet.FLAT:
             return self.style_sheet_flat()
         else:
             return self.style_sheet_default(app_palette)
@@ -521,9 +527,28 @@ class Theme(object):
             focus=focus,
         )
 
+    def style_sheet_custom(self, app_palette):
+        """Get custom style sheet.
+        File name is saved in variable self.name.
+        If user has deleted file, use default style"""
+
+        # check if path exists
+        filepath = resources.config_home('themes', self.name + '.qss')
+        if not os.path.exists(filepath):
+            return self.style_sheet_default(app_palette)
+
+        try:
+            with open(filepath) as fp:
+                return fp.read()
+        except (IOError, OSError) as err:
+            sys.stderr.write(
+                'warning: unable to read custom theme %s: %s\n' % (filepath, err)
+            )
+            return self.style_sheet_default(app_palette)
+
 
 def get_all_themes():
-    return [
+    themes = [
         Theme('default', N_('Default'), False, EStylesheet.DEFAULT, None),
         Theme(
             'flat-light-blue', N_('Flat light blue'), False, EStylesheet.FLAT, '#5271cc'
@@ -552,6 +577,19 @@ def get_all_themes():
             'flat-dark-green', N_('Flat dark green'), True, EStylesheet.FLAT, '#42a65c'
         ),
     ]
+
+    # check if themes path exists in user folder
+    path = resources.config_home('themes')
+    if not os.path.exists(path):
+        return themes
+
+    # get only files with extension .qss
+    for root, dirs, files in os.walk(path):
+        for file in files:
+            name, ext = os.path.splitext(file)
+            if ext == '.qss':
+                themes.append(Theme(name, N_(name), False, EStylesheet.CUSTOM, None))
+    return themes
 
 
 def options():

--- a/share/doc/git-cola/git-cola.rst
+++ b/share/doc/git-cola/git-cola.rst
@@ -537,6 +537,15 @@ You may also want to customize the diff colors when using a dark theme::
 
 Please see `#760 <https://github.com/git-cola/git-cola/issues/760>`_ for more details.
 
+Custom Themes
+-------------
+To create your own custom theme for Git Cola just create a QSS file and put it in
+``~/.config/themes/``. You can add as many files as you want. Each file will become
+an option in ``Menu -> File -> Preferences -> Appearance -> GUI theme``.
+
+Some examples can be found here `Qt Style Sheets Examples <https://doc.qt.io/qt-5/stylesheet-examples.html>`_.
+
+
 CONFIGURATION VARIABLES
 =======================
 These variables can be set using `git config` or from the settings.


### PR DESCRIPTION
User can create a `.qss` file in `~/.config/git-cola/themes/`. `.qss`
would contain Qt Style Sheet format to set colors for Qt widgets. The
file name becomes the style name.