### PR TITLE
Error thrown when changing boolean preference

### DIFF
--- a/cola/models/prefs.py
+++ b/cola/models/prefs.py
@@ -227,7 +227,7 @@ class PreferencesModel(QtCore.QObject):
             self.config.set_repo(config, value)
         else:
             self.config.set_user(config, value)
-        self.config_updated.emit(source, config, value)
+        self.config_updated.emit(source, config, str(value))
 
     def get_config(self, source, config):
         """Get a configured value"""


### PR DESCRIPTION
This error is thrown when changing a boolean preference, such as "Insert spaces instead of tabs".

![image](https://user-images.githubusercontent.com/13763067/170815728-847d13ee-61f3-4ff3-971b-897dcb241f71.png)
