### PR TITLE
prefs: consult $VISUAL on edit when gui.editor is not set, too

### DIFF
--- a/cola/models/prefs.py
+++ b/cola/models/prefs.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
+import os
 import sys
 
 from qtpy import QtCore
@@ -118,7 +119,7 @@ def display_untracked(context):
 
 def editor(context):
     """Return the configured editor"""
-    app = context.cfg.get(EDITOR, default=Defaults.editor)
+    app = context.cfg.get(EDITOR, default=fallback_editor())
     return _remap_editor(app)
 
 
@@ -126,6 +127,11 @@ def background_editor(context):
     """Return the configured non-blocking background editor"""
     app = context.cfg.get(BACKGROUND_EDITOR, default=editor(context))
     return _remap_editor(app)
+
+
+def fallback_editor():
+    """Return a fallback editor for cases where one is not configured"""
+    return os.getenv('VISUAL', Defaults.editor)
 
 
 def _remap_editor(app):

--- a/cola/widgets/prefs.py
+++ b/cola/widgets/prefs.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
-import os
 
 from qtpy import QtCore
 from qtpy import QtWidgets
@@ -15,6 +14,7 @@ from ..compat import ustr
 from ..i18n import N_
 from ..models import prefs
 from ..models.prefs import Defaults
+from ..models.prefs import fallback_editor
 
 
 def preferences(context, model=None, parent=None):
@@ -248,7 +248,7 @@ class SettingsFormWidget(FormWidget):
                 prefs.MAXRECENT: (self.maxrecent, Defaults.maxrecent),
                 prefs.SORT_BOOKMARKS: (self.sort_bookmarks, Defaults.sort_bookmarks),
                 prefs.DIFFTOOL: (self.difftool, Defaults.difftool),
-                prefs.EDITOR: (self.editor, os.getenv('VISUAL', Defaults.editor)),
+                prefs.EDITOR: (self.editor, fallback_editor()),
                 prefs.HISTORY_BROWSER: (
                     self.historybrowser,
                     prefs.default_history_browser(),


### PR DESCRIPTION
Per our docs:
> The environment variable `$VISUAL` is consulted when no editor has been configured.

`$VISUAL` was only ever used as the default for the configuration parameter in the preferences UI, i.e. it was not consulted when invoking the editor (e.g. without ever going to the preferences). In that sense, the behavior arguably didn't match the doc. Change to consult it in both.