### PR TITLE
fix(prefs): do not write `cola.spellcheck` config on start

### DIFF
--- a/cola/widgets/commitmsg.py
+++ b/cola/widgets/commitmsg.py
@@ -534,7 +534,7 @@ class CommitMessageEditor(QtWidgets.QFrame):
         spellcheck = self.description.spellcheck
         cfg = self.context.cfg
 
-        if cfg.get_user(prefs.SPELL_CHECK) != enabled:
+        if prefs.spellcheck(self.context) != enabled:
             cfg.set_user(prefs.SPELL_CHECK, enabled)
         if enabled and not self.spellcheck_initialized:
             # Add our name to the dictionary


### PR DESCRIPTION
When the `cola.spellcheck` config item has not been previously set, simply starting up the app -- no need to actually do anything at all -- ends up writing its default value to the git config. This is mostly harmless, but also unnecessary clutter of the git config with defaults.

Fix by taking the built in default into account when checking if it should be written, not only the current configured value (which might be unset).