### PR TITLE
enable window icon on wayland (on supported desktop environments)

### DIFF
--- a/cola/app.py
+++ b/cola/app.py
@@ -193,6 +193,7 @@ class ColaApplication(object):
         self._install_hidpi_config()
         self._app = ColaQApplication(context, list(argv))
         self._app.setWindowIcon(icons.cola())
+        self._app.setDesktopFileName("git-cola")
         self._install_style(gui_theme)
 
     def _install_style(self, theme_str):


### PR DESCRIPTION
kde for example still shows a window icon but on wayland, this only
works if the icon can be retrieved from the .desktop file. the name of
the .dektop file needs to be set from the application.

Signed-off-by: Martin Gysel <me@bearsh.org>