### PR TITLE
Add Open Worktree command to context menu of Status Widget

### DIFF
--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -1683,24 +1683,37 @@ class OpenDefaultApp(ContextCommand):
         core.fork([self.launcher] + self.filenames)
 
 
-class OpenParentDir(OpenDefaultApp):
+class OpenDir(OpenDefaultApp):
+    """Open directories using the OS default."""
+
+    @staticmethod
+    def name():
+        return N_('Open Directory')
+
+    @property
+    def _dirnames(self):
+        return self.filenames
+
+    def do(self):
+        dirnames = self._dirnames
+        if not dirnames:
+            return
+        # An empty dirname defaults to CWD.
+        dirs = [(dirname or core.getcwd()) for dirname in dirnames]
+        core.fork([self.launcher] + dirs)
+
+
+class OpenParentDir(OpenDir):
     """Open parent directories using the OS default."""
 
     @staticmethod
     def name():
         return N_('Open Parent Directory')
 
-    def __init__(self, context, filenames):
-        OpenDefaultApp.__init__(self, context, filenames)
-
-    def do(self):
-        if not self.filenames:
-            return
+    @property
+    def _dirnames(self):
         dirnames = list(set([os.path.dirname(x) for x in self.filenames]))
-        # os.path.dirname() can return an empty string so we fallback to
-        # the current directory
-        dirs = [(dirname or core.getcwd()) for dirname in dirnames]
-        core.fork([self.launcher] + dirs)
+        return dirnames
 
 
 class OpenNewRepo(ContextCommand):

--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -1716,6 +1716,18 @@ class OpenParentDir(OpenDir):
         return dirnames
 
 
+class OpenWorktree(OpenDir):
+    """Open worktree directory using the OS default."""
+
+    @staticmethod
+    def name():
+        return N_('Open Worktree')
+
+    def __init__(self, context, __):
+        dirnames = [context.git.worktree()]
+        super(OpenWorktree, self).__init__(context, dirnames)
+
+
 class OpenNewRepo(ContextCommand):
     """Launches git-cola on a repo."""
 

--- a/cola/i18n/git-cola.pot
+++ b/cola/i18n/git-cola.pot
@@ -1503,6 +1503,9 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
+msgid "Open Directory"
+msgstr ""
+
 msgid "Open Git Repository..."
 msgstr ""
 
@@ -1516,6 +1519,9 @@ msgid "Open Recent"
 msgstr ""
 
 msgid "Open Using Default Application"
+msgstr ""
+
+msgid "Open Worktree"
 msgstr ""
 
 msgid "Open in New Window"

--- a/cola/i18n/ru.po
+++ b/cola/i18n/ru.po
@@ -1620,6 +1620,9 @@ msgstr "Число строк в контексте сравнения"
 msgid "Open"
 msgstr "Открыть"
 
+msgid "Open Directory"
+msgstr "Открыть каталог"
+
 msgid "Open Git Repository..."
 msgstr "Открыть Git репозиторий..."
 
@@ -1635,6 +1638,9 @@ msgstr "Открыть последний"
 
 msgid "Open Using Default Application"
 msgstr "Открыть, используя приложение по умолчанию"
+
+msgid "Open Worktree"
+msgstr "Открыть рабочий каталог"
 
 msgid "Open in New Window"
 msgstr "Открыть в новом окне"

--- a/cola/widgets/common.py
+++ b/cola/widgets/common.py
@@ -52,6 +52,19 @@ def parent_dir_action(context, parent, fn):
     return action
 
 
+def worktree_dir_action(context, parent, *keys):
+    """Open the repository worktree -> QAction"""
+    action = cmd_action(
+        parent,
+        cmds.OpenWorktree,
+        context,
+        lambda: None, # nop
+        *keys
+    )
+    action.setIcon(icons.folder())
+    return action
+
+
 def refresh_action(context, parent):
     """Refresh the repository state -> QAction"""
     return qtutils.add_action(

--- a/cola/widgets/status.py
+++ b/cola/widgets/status.py
@@ -193,6 +193,8 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
                 context, self, self.selected_group
             )
 
+            self.worktree_dir_action = common.worktree_dir_action(context, self)
+
         self.terminal_action = common.terminal_action(
             context, self, self.selected_group
         )
@@ -683,6 +685,9 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
 
         if self.terminal_action is not None:
             menu.addAction(self.terminal_action)
+
+        if not utils.is_win32():
+            menu.addAction(self.worktree_dir_action)
 
         self._add_copy_actions(menu)
 


### PR DESCRIPTION
Note, I don't really realize why analogue commands (`default_app_action`, `parent_dir_action`) are forbidden for `win32`.
I forbid the new command too because of that.``