### PR TITLE
stash: correctly show stashes containing slashes

### DIFF
--- a/cola/models/stash.py
+++ b/cola/models/stash.py
@@ -30,7 +30,7 @@ class StashModel(object):
     def stash_info(self, revids=False, names=False):
         """Parses "git stash list" and returns a list of stashes."""
         stashes = self.stash_list(r'--format=%gd/%aD/%s')
-        split_stashes = [s.split('/', 3) for s in stashes if s]
+        split_stashes = [s.split('/', 2) for s in stashes if s]
         stashes = ['{0}: {1}'.format(s[0], s[2]) for s in split_stashes]
         revids = [s[0] for s in split_stashes]
         author_dates = [s[1] for s in split_stashes]

--- a/test/stash_model_test.py
+++ b/test/stash_model_test.py
@@ -1,0 +1,34 @@
+# pylint: disable=redefined-outer-name
+from cola.models.stash import StashModel
+
+from . import helper
+from .helper import app_context
+
+
+# These assertions make flake8 happy. It considers them unused imports otherwise.
+assert app_context is not None
+
+
+def test_stash_info_for_message_without_slash(app_context):
+    helper.commit_files()
+    helper.write_file('A', 'change')
+    helper.run_git('stash', 'save', 'some message')
+    assert StashModel(app_context).stash_info()[0] \
+        == [r'stash@{0}: On main: some message']
+
+
+def test_stash_info_for_message_with_slash(app_context):
+    helper.commit_files()
+    helper.write_file('A', 'change')
+    helper.run_git('stash', 'save', 'some message/something')
+    assert StashModel(app_context).stash_info()[0] \
+        == [r'stash@{0}: On main: some message/something']
+
+
+def test_stash_info_on_branch_with_slash(app_context):
+    helper.commit_files()
+    helper.run_git('checkout', '-b', 'feature/a')
+    helper.write_file('A', 'change')
+    helper.run_git('stash', 'save', 'some message')
+    assert StashModel(app_context).stash_info()[0] \
+        == [r'stash@{0}: On feature/a: some message']


### PR DESCRIPTION
### Issue
If the branch name or message of a stash contained a slash then it was incorrectly displayed.

### Solution
The maxsplit argument of str.split() is the maximum amount of splits that are done.
So you end up with at most maxsplit+1 elements.
We want to end up with at most 3 elements so it needs to be set to 2.