### PR TITLE
Fix a crash on some context menu calls

### DIFF
--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -129,7 +129,7 @@ class MainModel(QtCore.QObject):
 
     def stageable(self):
         """Whether staging should be allowed."""
-        return self.partially_stageable() or self.mode == self.modes_untracked
+        return self.partially_stageable() or self.mode == self.mode_untracked
 
     def all_branches(self):
         return self.local_branches + self.remote_branches

--- a/test/main_model_test.py
+++ b/test/main_model_test.py
@@ -77,6 +77,11 @@ def test_untracked(app_context):
     assert app_context.model.untracked == ['C']
 
 
+def test_stageable(app_context):
+    """Test the 'stageable' attribute."""
+    assert not app_context.model.stageable()
+
+
 def test_remotes(app_context):
     """Test the 'remote' attribute."""
     helper.run_git('remote', 'add', 'origin', '.')


### PR DESCRIPTION
The crash is easily reproducible. Create a new repository and store a binary file in there. Then call the context menu of that file in git-cola.

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/cola/widgets/status.py", line 659, in contextMenuEvent
    menu = self._create_context_menu()
  File "/usr/lib/python3.10/site-packages/cola/widgets/status.py", line 678, in _create_context_menu
    self._create_unstaged_context_menu(menu, s)
  File "/usr/lib/python3.10/site-packages/cola/widgets/status.py", line 834, in _create_unstaged_context_menu
    if self._model.stageable():
  File "/usr/lib/python3.10/site-packages/cola/models/main.py", line 132, in stageable
    return self.partially_stageable() or self.mode == self.modes_untracked
AttributeError: 'MainModel' object has no attribute 'modes_untracked'. Did you mean: 'mode_untracked'?
```

