### PR TITLE
Fix a typo in `MD5`

### DIFF
--- a/docs/git-cola.rst
+++ b/docs/git-cola.rst
@@ -1174,7 +1174,7 @@ patched Python 3.6 used by CentOS8/RHEL8 (and possibly others).
 
 Git Cola uses the ``hashlib.md5`` function and adheres to the FIPS security
 mode when available. Git Cola does not use the MD5 value for security purposes.
-MD% is used only for the purposes of implementing the ``cola/gravatar.py``
+MD5 is used only for the purposes of implementing the ``cola/gravatar.py``
 Gravatar client.
 
 LINKS


### PR DESCRIPTION
This converts an uppercase 5 (`%`) to a lowercase 5 (`5`). :wink: 