### PR TITLE
Fix GitHub Actions run failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         # Repository checked out under $GITHUB_WORKSPACE
 
       - name: Install Dependencies
@@ -22,7 +22,7 @@ jobs:
         run: make prefix="build" install
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: git-cola-run${{github.run_number}}-${{runner.os}}
           path: build/
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         # Repository checked out under $GITHUB_WORKSPACE
 
       - name: Install Dependencies
@@ -81,17 +81,17 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         # Repository checked out under $GITHUB_WORKSPACE
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
           architecture: 'x64'
 
       - name: Pip Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
             path: ~\AppData\Local\pip\Cache
             key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements/requirements*.txt') }}
@@ -116,7 +116,7 @@ jobs:
           mv git-cola*.exe git-cola-run${{github.run_number}}.exe
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: git-cola-run${{github.run_number}}-${{runner.os}}
           path: build\nsis\git-cola*.exe
@@ -126,7 +126,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         # Repository checked out under $GITHUB_WORKSPACE
 
       - name: Install Dependencies
@@ -145,7 +145,7 @@ jobs:
           mv git-cola.app build/
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: git-cola-run${{github.run_number}}-${{runner.os}}
           path: build/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,8 +45,7 @@ jobs:
               flake8 \
               pylint \
               python-is-python3 \
-              python-pytest \
-              python-setuptools-scm \
+              python3-setuptools-scm \
               python3-pytest \
               python3-pytest-flake8
           # Runtime dependencies (required)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
+          pip install wheel
           pip install --requirement requirements/requirements.txt
           pip install --requirement requirements/requirements-dev.txt
           pip install --requirement requirements/requirements-maint.txt
@@ -135,6 +136,7 @@ jobs:
           brew install git-cola
           python3 -m venv env
           source env/bin/activate
+          python -m pip install wheel
           make requirements-dev
 
       - name: Build Bundle

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,11 +21,14 @@ jobs:
       - name: Build
         run: make prefix="build" install
 
+      - name: Zip Artifact
+        run: zip artifact.zip build/* -r
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
           name: git-cola-run${{github.run_number}}-${{runner.os}}
-          path: build/
+          path: artifact.zip
 
   test:
     name: 'Test'
@@ -146,8 +149,11 @@ jobs:
           make git-cola.app
           mv git-cola.app build/
 
+      - name: Zip Artifact
+        run: zip artifact.zip build/* -r
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
           name: git-cola-run${{github.run_number}}-${{runner.os}}
-          path: build/
+          path: artifact.zip

--- a/.pylintrc
+++ b/.pylintrc
@@ -59,7 +59,22 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=assignment-from-none,bad-continuation,bad-option-value,consider-using-dict-comprehension,consider-using-set-comprehension,fixme,wrong-import-position,invalid-name,missing-docstring,no-else-return,too-many-instance-attributes,useless-object-inheritance,super-with-arguments,raise-missing-from,duplicate-code
+disable=
+    assignment-from-none,
+    bad-continuation,
+    bad-option-value,
+    consider-using-dict-comprehension,
+    consider-using-set-comprehension,
+    duplicate-code,
+    fixme,
+    invalid-name,
+    missing-docstring,
+    no-else-return,
+    raise-missing-from,
+    super-with-arguments,
+    too-many-instance-attributes,
+    useless-object-inheritance,
+    wrong-import-position
 
 [REPORTS]
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -66,7 +66,6 @@ disable=
     assignment-from-none,
     bad-continuation,
     bad-option-value,
-    consider-using-dict-comprehension,
     consider-using-set-comprehension,
     consider-using-with,
     duplicate-code,

--- a/.pylintrc
+++ b/.pylintrc
@@ -66,7 +66,6 @@ disable=
     assignment-from-none,
     bad-continuation,
     bad-option-value,
-    consider-using-set-comprehension,
     consider-using-with,
     duplicate-code,
     fixme,

--- a/.pylintrc
+++ b/.pylintrc
@@ -77,7 +77,6 @@ disable=
     too-many-instance-attributes,
     unspecified-encoding,
     useless-object-inheritance,
-    wrong-import-position
 
 [REPORTS]
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -68,6 +68,7 @@ disable=
     bad-option-value,
     consider-using-dict-comprehension,
     consider-using-set-comprehension,
+    consider-using-with,
     duplicate-code,
     fixme,
     invalid-name,

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,8 @@
 [MASTER]
 
+# Specify what version of Python to evaluate code against.
+py-version = 2.7
+
 # Specify a configuration file.
 #rcfile=
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -77,6 +77,7 @@ disable=
     raise-missing-from,
     super-with-arguments,
     too-many-instance-attributes,
+    unspecified-encoding,
     useless-object-inheritance,
     wrong-import-position
 

--- a/cola/compat.py
+++ b/cola/compat.py
@@ -15,7 +15,7 @@ PY_VERSION_MAJOR = PY_VERSION[0]
 PY2 = PY_VERSION_MAJOR == 2
 PY3 = PY_VERSION_MAJOR >= 3
 PY26_PLUS = PY2 and sys.version_info[1] >= 6
-WIN32 = sys.platform == 'win32' or sys.platform == 'cygwin'
+WIN32 = sys.platform in {'win32', 'cygwin'}
 ENCODING = 'utf-8'
 
 

--- a/cola/core.py
+++ b/cola/core.py
@@ -347,7 +347,7 @@ def _win32_find_exe(exe):
 
 
 # Portability wrappers
-if sys.platform == 'win32' or sys.platform == 'cygwin':
+if sys.platform in {'win32', 'cygwin'}:
     fork = _fork_win32
 else:
     fork = _fork_posix

--- a/cola/fsmonitor.py
+++ b/cola/fsmonitor.py
@@ -258,12 +258,10 @@ if AVAILABLE == 'inotify':
             context = self.context
             try:
                 if self._worktree is not None:
-                    tracked_dirs = set(
-                        [
-                            os.path.dirname(os.path.join(self._worktree, path))
-                            for path in gitcmds.tracked_files(context)
-                        ]
-                    )
+                    tracked_dirs = {
+                        os.path.dirname(os.path.join(self._worktree, path))
+                        for path in gitcmds.tracked_files(context)
+                    }
                     self._refresh_watches(
                         tracked_dirs,
                         self._worktree_wd_to_path_map,

--- a/cola/gitcfg.py
+++ b/cola/gitcfg.py
@@ -368,7 +368,7 @@ class GitConfig(QtCore.QObject):
         """
         prefix = len('guitool.%s.' % name)
         guitools = self.find('guitool.%s.*' % name)
-        return dict([(key[prefix:], value) for (key, value) in guitools.items()])
+        return {key[prefix:]: value for (key, value) in guitools.items()}
 
     def get_guitool_names(self):
         guitools = self.find('guitool.*.cmd')

--- a/cola/gravatar.py
+++ b/cola/gravatar.py
@@ -118,7 +118,9 @@ class GravatarLabel(QtWidgets.QLabel):
             relocated = location != request_location
         else:
             relocated = False
-        no_error = qtutils.enum_value(QtNetwork.QNetworkReply.NetworkError.NoError)
+        no_error = qtutils.enum_value(
+            QtNetwork.QNetworkReply.NetworkError.NoError  # pylint: disable=no-member
+        )
         if reply.error() == no_error:
             if relocated:
                 # We could do get_url(parse.unquote(location)) to

--- a/cola/qtutils.py
+++ b/cola/qtutils.py
@@ -304,9 +304,7 @@ def prompt_n(msg, inputs):
             long_value = k + v
 
     metrics = QtGui.QFontMetrics(dialog.font())
-    min_width = metrics.width(long_value) + 100
-    if min_width > 720:
-        min_width = 720
+    min_width = min(720, metrics.width(long_value) + 100)
     dialog.setMinimumWidth(min_width)
 
     ok_b = ok_button(msg, enabled=False)

--- a/cola/qtutils.py
+++ b/cola/qtutils.py
@@ -1097,7 +1097,7 @@ class ImageFormats(object):
         # portability: python3 data() returns bytes, python2 returns str
         decode = core.decode
         formats = [decode(x.data()) for x in formats_qba]
-        self.extensions = set(['.' + fmt for fmt in formats])
+        self.extensions = {'.' + fmt for fmt in formats}
 
     def ok(self, filename):
         _, ext = os.path.splitext(filename)

--- a/cola/sequenceeditor.py
+++ b/cola/sequenceeditor.py
@@ -43,7 +43,7 @@ COMMANDS = (
     FIXUP,
     SQUASH,
 )
-COMMAND_IDX = dict([(cmd_, idx_) for idx_, cmd_ in enumerate(COMMANDS)])
+COMMAND_IDX = {cmd_: idx_ for idx_, cmd_ in enumerate(COMMANDS)}
 ABBREV = {
     'p': PICK,
     'r': REWORD,

--- a/cola/sequenceeditor.py
+++ b/cola/sequenceeditor.py
@@ -157,14 +157,14 @@ class Editor(QtWidgets.QWidget):
 
         self.rebase_button = qtutils.create_button(
             text=core.getenv('GIT_COLA_SEQ_EDITOR_ACTION', N_('Rebase')),
-            tooltip=N_('Accept changes and rebase\n' 'Shortcut: Ctrl+Enter'),
+            tooltip=N_('Accept changes and rebase\nShortcut: Ctrl+Enter'),
             icon=icons.ok(),
             default=True,
         )
 
         self.extdiff_button = qtutils.create_button(
             text=N_('Launch Diff Tool'),
-            tooltip=N_('Launch external diff tool\n' 'Shortcut: Ctrl+D'),
+            tooltip=N_('Launch external diff tool\nShortcut: Ctrl+D'),
         )
         self.extdiff_button.setEnabled(False)
 

--- a/cola/sequenceeditor.py
+++ b/cola/sequenceeditor.py
@@ -495,7 +495,7 @@ class RebaseTreeWidget(standard.DraggableTreeWidget):
             self.move_rows.emit(sel_idx, idx)
 
     def move(self, src_idxs, dst_idx):
-        moved_items = list()
+        moved_items = []
         src_base = sorted(src_idxs)[0]
         for idx in reversed(sorted(src_idxs)):
             item = self.invisibleRootItem().takeChild(idx)

--- a/cola/utils.py
+++ b/cola/utils.py
@@ -309,7 +309,7 @@ def is_darwin():
 
 def is_win32():
     """Return True on win32"""
-    return sys.platform == 'win32' or sys.platform == 'cygwin'
+    return sys.platform in {'win32', 'cygwin'}
 
 
 def launch_default_app(paths):

--- a/cola/version.py
+++ b/cola/version.py
@@ -3,6 +3,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import sys
 
+from .git import STDOUT
+from .decorators import memoize
+from ._version import VERSION
+
 try:
     if sys.version_info < (3, 8):
         import importlib_metadata as metadata
@@ -16,9 +20,6 @@ if __name__ == '__main__':
     srcdir = os.path.dirname(os.path.dirname(__file__))
     sys.path.insert(1, srcdir)
 
-from .git import STDOUT  # noqa
-from .decorators import memoize  # noqa
-from ._version import VERSION  # noqa
 
 # minimum version requirements
 _versions = {

--- a/cola/widgets/commitmsg.py
+++ b/cola/widgets/commitmsg.py
@@ -89,7 +89,7 @@ class CommitMessageEditor(QtWidgets.QFrame):
         self.description.set_dictionary(cfg.get('cola.dictionary', None))
         self.description.menu_actions.extend(menu_actions)
 
-        commit_button_tooltip = N_('Commit staged changes\n' 'Shortcut: Ctrl+Enter')
+        commit_button_tooltip = N_('Commit staged changes\nShortcut: Ctrl+Enter')
         self.commit_button = qtutils.create_button(
             text=N_('Commit@@verb'), tooltip=commit_button_tooltip, icon=icons.commit()
         )
@@ -437,7 +437,7 @@ class CommitMessageEditor(QtWidgets.QFrame):
             )
             if self.model.modified:
                 informative_text = N_(
-                    'Would you like to stage and ' 'commit all modified files?'
+                    'Would you like to stage and commit all modified files?'
                 )
                 if not Interaction.confirm(
                     N_('Stage and commit?'),

--- a/cola/widgets/createbranch.py
+++ b/cola/widgets/createbranch.py
@@ -250,7 +250,7 @@ class CreateBranchDialog(standard.Dialog):
         if not branch or not revision:
             Interaction.critical(
                 N_('Missing Data'),
-                N_('Please provide both a branch ' 'name and revision expression.'),
+                N_('Please provide both a branch name and revision expression.'),
             )
             return
         if branch in existing_branches:
@@ -264,7 +264,7 @@ class CreateBranchDialog(standard.Dialog):
 
         if check_branch:
             msg = N_(
-                'Resetting "%(branch)s" to "%(revision)s" ' 'will lose commits.'
+                'Resetting "%(branch)s" to "%(revision)s" will lose commits.'
             ) % dict(branch=branch, revision=revision)
             if ffwd_only:
                 Interaction.critical(N_('Branch Exists'), msg)

--- a/cola/widgets/diff.py
+++ b/cola/widgets/diff.py
@@ -42,7 +42,7 @@ class DiffSyntaxHighlighter(QtGui.QSyntaxHighlighter):
 
     DIFF_FILE_HEADER_START_RGX = re.compile(r'diff --git a/.* b/.*')
     DIFF_HUNK_HEADER_RGX = re.compile(
-        r'(?:@@ -[0-9,]+ \+[0-9,]+ @@)|' r'(?:@@@ (?:-[0-9,]+ ){2}\+[0-9,]+ @@@)'
+        r'(?:@@ -[0-9,]+ \+[0-9,]+ @@)|(?:@@@ (?:-[0-9,]+ ){2}\+[0-9,]+ @@@)'
     )
     BAD_WHITESPACE_RGX = re.compile(r'\s+$')
 

--- a/cola/widgets/diff.py
+++ b/cola/widgets/diff.py
@@ -485,8 +485,8 @@ class Viewer(QtWidgets.QFrame):
     def render_side_by_side(self):
         # Side-by-side lineup comp
         pixmaps = self.pixmaps
-        width = sum([pixmap.width() for pixmap in pixmaps])
-        height = max([pixmap.height() for pixmap in pixmaps])
+        width = sum(pixmap.width() for pixmap in pixmaps)
+        height = max(pixmap.height() for pixmap in pixmaps)
         image = create_image(width, height)
 
         # Paint each pixmap
@@ -505,8 +505,8 @@ class Viewer(QtWidgets.QFrame):
         if len(pixmaps) == 1:
             return pixmaps[0]
 
-        width = max([pixmap.width() for pixmap in pixmaps])
-        height = max([pixmap.height() for pixmap in pixmaps])
+        width = max(pixmap.width() for pixmap in pixmaps)
+        height = max(pixmap.height() for pixmap in pixmaps)
         image = create_image(width, height)
 
         painter = create_painter(image)

--- a/cola/widgets/gitignore.py
+++ b/cola/widgets/gitignore.py
@@ -52,7 +52,7 @@ class AddToGitIgnore(Dialog):
         )
 
         self.radio_in_repo = qtutils.radio(text=N_('Add to .gitignore'), checked=True)
-        self.radio_local = qtutils.radio(text=N_('Add to local ' '.git/info/exclude'))
+        self.radio_local = qtutils.radio(text=N_('Add to local .git/info/exclude'))
         self.location_radio_group = qtutils.buttongroup(
             self.radio_in_repo, self.radio_local
         )

--- a/cola/widgets/remote.py
+++ b/cola/widgets/remote.py
@@ -185,7 +185,7 @@ class RemoteActionDialog(standard.Dialog):
 
         text = N_('No fast-forward')
         tooltip = N_(
-            'Create a merge commit even when the merge resolves as a ' 'fast-forward'
+            'Create a merge commit even when the merge resolves as a fast-forward'
         )
         self.no_ff_checkbox = qtutils.checkbox(
             checked=False, text=text, tooltip=tooltip
@@ -203,7 +203,7 @@ class RemoteActionDialog(standard.Dialog):
         self.tags_checkbox = qtutils.checkbox(text=N_('Include tags '))
 
         tooltip = N_(
-            'Remove remote-tracking branches that no longer ' 'exist on the remote'
+            'Remove remote-tracking branches that no longer exist on the remote'
         )
         self.prune_checkbox = qtutils.checkbox(text=N_('Prune '), tooltip=tooltip)
 

--- a/cola/widgets/startup.py
+++ b/cola/widgets/startup.py
@@ -75,7 +75,7 @@ class StartupDialog(standard.Dialog):
         directory_icon = icons.directory()
         user_role = Qt.UserRole
         normalize = display.normalize_path
-        paths = set([normalize(repo['path']) for repo in all_repos])
+        paths = {normalize(repo['path']) for repo in all_repos}
         short_paths = display.shorten_paths(paths)
         self.short_paths = short_paths
 

--- a/cola/widgets/status.py
+++ b/cola/widgets/status.py
@@ -600,7 +600,7 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
 
     def _set_unmerged(self, items):
         """Adds items to the 'Unmerged' subtree."""
-        deleted_set = set([path for path in items if not core.exists(path)])
+        deleted_set = {path for path in items if not core.exists(path)}
         with qtutils.BlockSignals(self):
             self._set_subtree(
                 items, UNMERGED_IDX, N_('Unmerged'), deleted_set=deleted_set


### PR DESCRIPTION
GitHub has updated ubuntu-latest to use Ubuntu 22.04. This release affects CI because some apt packages are no longer available for install, and a new pylint version is reporting additional lint warnings. However, while reviewing CI output, additional issues were identified and fixed.

This PR introduces these changes:

* Resolve `apt install` of packages that are renamed or unavailable on Ubuntu Jammy
* Resolve or disable pylint warnings that are showing up with newer pylint versions
* Re-enable and resolve several pylint warnings that were previously disabled
* Update GitHub Action versions to resolve multiple deprecation warnings
* Resolve pip deprecation warnings by installing wheel prior to installing Python dependencies
* Resolve severe CI artifact upload performance problems by zipping build directories
  (CI runs now take 6 minutes instead of 22 minutes)

Fixes #1277

> ## NOTE
>
> I recommend reviewing this PR commit-by-commit. All changes are self-contained and logically grouped, and reviewing individual commits might make it easier to review.

----

Previous successful CI runs showed these version numbers:

```
python -B -m pylint --version
pylint 2.4.4
astroid 2.3.3
Python 3.8.10 (default, Jun 22 2022, 20:18:18) 
```

CI is now failing with these newer versions:

```
python -B -m pylint --version
pylint 2.12.2
astroid 2.9.3
Python 3.10.6 (main, Nov  2 2022, 18:53:38) [GCC 11.3.0]
```

In addition, on my local box I'm seeing these versions, which output more new errors:

```
python -B -m pylint --version
pylint 2.15.8
astroid 2.12.13
Python 3.11.1 (main, Dec 12 2022, 18:09:30) [GCC 11.3.0]
```
