### PR TITLE
Add shortcut for filtering repositories in bookmarks widget and main widget

### DIFF
--- a/cola/hotkeys.py
+++ b/cola/hotkeys.py
@@ -51,6 +51,7 @@ AMEND = hotkey(Qt.CTRL | Qt.Key_M)
 MERGE = hotkey(Qt.CTRL | Qt.SHIFT | Qt.Key_M)
 PUSH = hotkey(Qt.CTRL | Qt.Key_P)
 PULL = hotkey(Qt.CTRL | Qt.SHIFT | Qt.Key_P)
+OPEN_REPO_SEARCH = hotkey(Qt.ALT | Qt.Key_P)
 # Q-Z
 QUIT = hotkey(Qt.CTRL | Qt.Key_Q)
 REFRESH = hotkey(Qt.CTRL | Qt.Key_R)

--- a/cola/widgets/bookmarks.py
+++ b/cola/widgets/bookmarks.py
@@ -124,6 +124,10 @@ class BookmarksWidget(QtWidgets.QFrame):
         self.quick_switcher.filter_input.switcher_selection_move.connect(
             self.tree.keyPressEvent
         )
+        # escape key has pressed while focusing on input field
+        self.quick_switcher.filter_input.switcher_escape.connect(
+            self.close_switcher_input_field
+        )
         # some key except moving key has pressed while focusing on list view
         self.tree.switcher_text.connect(self.switcher_text_inputted)
 
@@ -162,6 +166,9 @@ class BookmarksWidget(QtWidgets.QFrame):
     def toggle_switcher_input_field(self):
         visible = self.quick_switcher.filter_input.isVisible()
         self.enable_switcher_input_field(not visible)
+
+    def close_switcher_input_field(self):
+        self.enable_switcher_input_field(False)
 
     def enable_switcher_input_field(self, visible):
         filter_input = self.quick_switcher.filter_input

--- a/cola/widgets/bookmarks.py
+++ b/cola/widgets/bookmarks.py
@@ -125,7 +125,7 @@ class BookmarksWidget(QtWidgets.QFrame):
             self.tree.keyPressEvent
         )
         # some key except moving key has pressed while focusing on list view
-        self.tree.switcher_text.connect(self.quick_switcher.filter_input.keyPressEvent)
+        self.tree.switcher_text.connect(self.switcher_text_inputted)
 
     def reload_bookmarks(self):
         # Called once after the GUI is initialized
@@ -138,9 +138,6 @@ class BookmarksWidget(QtWidgets.QFrame):
         selection = tree.selectionModel()
         selection.selectionChanged.connect(tree.item_selection_changed)
         tree.doubleClicked.connect(tree.tree_double_clicked)
-
-        first_idx = model.index(0, 0)
-        selection.select(first_idx, QtCore.QItemSelectionModel.Select)
 
     def tree_item_selection_changed(self):
         enabled = bool(self.tree.selected_item())
@@ -172,6 +169,13 @@ class BookmarksWidget(QtWidgets.QFrame):
         filter_input.setVisible(visible)
         if not visible:
             filter_input.clear()
+
+    def switcher_text_inputted(self, event):
+        # default selection for first index
+        first_proxy_idx = self.quick_switcher.proxy_model.index(0, 0)
+        self.tree.setCurrentIndex(first_proxy_idx)
+
+        self.quick_switcher.filter_input.keyPressEvent(event)
 
 
 def disable_rename(_path, _name, _new_name):

--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -17,6 +17,7 @@ from ..models import prefs
 from ..qtutils import get
 from .. import cmds
 from .. import core
+from .. import display
 from .. import guicmds
 from .. import git
 from .. import gitcmds
@@ -55,6 +56,7 @@ from . import search
 from . import standard
 from . import status
 from . import stash
+from . import switcher
 from . import toolbar
 
 
@@ -596,6 +598,13 @@ class MainView(standard.MainWindow):
 
         self.reset_layout_action = add_action(
             self, N_('Reset Layout'), self.reset_layout
+        )
+
+        self.quick_repository_search = add_action(
+            self,
+            N_('Open Repository Quick Searcch'),
+            self.open_quick_repository_search,
+            hotkeys.OPEN_REPO_SEARCH,
         )
 
         # Create the application menu
@@ -1185,7 +1194,7 @@ class MainView(standard.MainWindow):
         self.dag = dag.git_dag(self.context, existing_view=self.dag)
 
     def show_cursor_position(self, rows, cols):
-        display = '%02d:%02d' % (rows, cols)
+        display_content = '%02d:%02d' % (rows, cols)
         css = """
             <style>
             .good {
@@ -1213,8 +1222,52 @@ class MainView(standard.MainWindow):
             cls = 'first-warning'
         else:
             cls = 'good'
-        div = '<div class="%s">%s</div>' % (cls, display)
+        div = '<div class="%s">%s</div>' % (cls, display_content)
         self.position_label.setText(css + div)
+
+    def open_quick_repository_search(self):
+        settings = self.context.settings
+        items = settings.bookmarks + settings.recent
+
+        if items:
+            cfg = self.context.cfg
+            default_repo = cfg.get('cola.defaultrepo')
+
+            entries = QtGui.QStandardItemModel()
+            added = set()
+            normalize = display.normalize_path
+            star_icon = icons.star()
+            folder_icon = icons.folder()
+
+            for item in items:
+                key = normalize(item['path'])
+                if key in added:
+                    continue
+
+                name = item['name']
+                if default_repo == item['path']:
+                    icon = star_icon
+                else:
+                    icon = folder_icon
+
+                entry = switcher.switcher_item(key, icon, name)
+                entries.appendRow(entry)
+                added.add(key)
+
+            parent = qtutils.active_window()
+            title = N_('Quick Repository Search')
+            place_holder = N_('Search repository by name...')
+            switcher.switcher_inner_view(
+                self.context,
+                entries,
+                title,
+                place_holder=place_holder,
+                enter_action=self.open_repository_from_quick_selection,
+                parent=parent,
+            )
+
+    def open_repository_from_quick_selection(self, item):
+        cmds.do(cmds.OpenRepo, self.context, item.key)
 
 
 class FocusProxy(object):

--- a/cola/widgets/switcher.py
+++ b/cola/widgets/switcher.py
@@ -122,6 +122,8 @@ class SwitcherInnerView(Switcher):
         self.filter_input.switcher_selection_move.connect(
             self.switcher_list.keyPressEvent
         )
+        # escape key pressed while focusing on input field
+        self.filter_input.switcher_escape.connect(self.close_widget)
         # some key except moving key has pressed while focusing on list view
         self.switcher_list.switcher_inner_text.connect(self.filter_input.keyPressEvent)
 
@@ -145,6 +147,9 @@ class SwitcherInnerView(Switcher):
         item = self.switcher_list.model().itemFromIndex(index)
         if item:
             self.enter_action(item)
+        self.close()
+
+    def close_widget(self):
         self.close()
 
 
@@ -179,6 +184,7 @@ class SwitcherLineEdit(text.LineEdit):
     # while focusing on this line edit widget
     switcher_selection_move = Signal(QtGui.QKeyEvent)
     switcher_visible = Signal(bool)
+    switcher_escape = Signal()
 
     def __init__(self, place_holder=None, parent=None):
         text.LineEdit.__init__(self, parent=parent)
@@ -197,7 +203,9 @@ class SwitcherLineEdit(text.LineEdit):
         selection_moving_keys = moving_keys()
         pressed_key = event.key()
 
-        if pressed_key in selection_moving_keys:
+        if pressed_key == Qt.Key_Escape:
+            self.switcher_escape.emit()
+        elif pressed_key in selection_moving_keys:
             self.switcher_selection_move.emit(event)
         else:
             super().keyPressEvent(event)

--- a/cola/widgets/switcher.py
+++ b/cola/widgets/switcher.py
@@ -1,6 +1,8 @@
 """Provides quick switcher"""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import re
+
 from qtpy import QtCore
 from qtpy import QtGui
 from qtpy.QtCore import Qt
@@ -82,7 +84,8 @@ class Switcher(standard.Dialog):
 
     def filter_input_changed(self):
         input_text = self.filter_input.text()
-        self.proxy_model.setFilterRegExp(input_text)
+        pattern = '.*'.join(re.escape(c) for c in input_text)
+        self.proxy_model.setFilterRegExp(pattern)
 
 
 class SwitcherInnerView(Switcher):
@@ -157,7 +160,8 @@ class SwitcherOuterView(Switcher):
 
     def filter_input_changed(self):
         input_text = self.filter_input.text()
-        self.proxy_model.setFilterRegExp(input_text)
+        pattern = '.*'.join(re.escape(c) for c in input_text)
+        self.proxy_model.setFilterRegExp(pattern)
 
         # set invisible when input field get empty
         if input_text == '':

--- a/cola/widgets/switcher.py
+++ b/cola/widgets/switcher.py
@@ -125,6 +125,10 @@ class SwitcherInnerView(Switcher):
         # some key except moving key has pressed while focusing on list view
         self.switcher_list.switcher_inner_text.connect(self.filter_input.keyPressEvent)
 
+        # default selection for first index
+        first_proxy_idx = self.proxy_model.index(0, 0)
+        self.switcher_list.setCurrentIndex(first_proxy_idx)
+
     def resizeEvent(self, _event):
         parent = self.parent()
         if parent is None:

--- a/cola/widgets/switcher.py
+++ b/cola/widgets/switcher.py
@@ -1,0 +1,168 @@
+"""Provides quick switcher"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from qtpy import QtCore
+from qtpy import QtGui
+from qtpy.QtCore import Qt
+from qtpy.QtCore import Signal
+
+from .. import qtutils
+from ..widgets import defs
+from ..widgets import standard
+from ..widgets import text
+
+
+def switcher(
+    context, entries, title, place_holder=None, enter_action=None, parent=None
+):
+    widget = SwitcherDialog(context, entries, title, place_holder, enter_action, parent)
+    widget.show()
+    return widget
+
+
+def switcher_item(key, icon=None, name=None):
+    return SwitcherListItem(key, icon, name)
+
+
+class SwitcherDialog(standard.Dialog):
+    """
+    Quick switcher dialog class. This contains input field, filter proxy model and quick
+    switcher list view(OPTIONALLY by show_lsit).
+
+    list_fitlered signal is for the event that user input strings to input field and
+    filtered items by proxy model.
+    switcher_selection_move signal is for the event that selecttion move key like UP,
+    DOWN has pressed.
+    These signals will only be emitted when this class does not have switcher_list
+    class.
+    """
+
+    def __init__(
+        self, context, entries, title, place_holder=None, enter_action=None, parent=None
+    ):
+        standard.Dialog.__init__(self, parent=parent)
+        self.setModal(False)
+        self.setWindowTitle(title)
+
+        self.context = context
+        self.entries = entries
+        self.enter_action = enter_action
+
+        self.filter_input = SwitcherLineEdit(place_holder=place_holder, parent=self)
+
+        self.proxy_model = SwitcherSortFilterProxyModel(entries, parent=self)
+
+        if enter_action:
+            self.switcher_list = SwitcherTreeView(
+                self.proxy_model, self.enter_selected_item, parent=self
+            )
+        else:
+            self.switcher_list = None
+
+        self.filter_input.switcher_selection_move.connect(self.switcher_selection_moved)
+        self.filter_input.textChanged.connect(self.filter_input_changed)
+
+        self.main_layout = qtutils.vbox(
+            defs.no_margin, defs.spacing, self.filter_input, self.switcher_list
+        )
+        self.setLayout(self.main_layout)
+
+    def resizeEvent(self, event):
+        parent = self.parent()
+        if parent is None:
+            return
+        left = parent.x()
+        width = parent.width()
+        center_x = left + width // 2
+        x = center_x - self.width() // 2
+        y = parent.y()
+
+        self.move(x, y)
+
+    def filter_input_changed(self):
+        text = self.filter_input.text()
+        self.proxy_model.setFilterRegExp(text)
+
+    def switcher_selection_moved(self, event):
+        if self.switcher_list:
+            self.switcher_list.keyPressEvent(event)
+
+    def enter_selected_item(self, index):
+        item = self.switcher_list.model().itemFromIndex(index)
+        if item:
+            self.enter_action(item)
+        self.close()
+
+
+class SwitcherLineEdit(text.LineEdit):
+    """Quick switcher input line class"""
+
+    switcher_selection_move = Signal(QtGui.QKeyEvent)
+
+    def __init__(self, place_holder=None, parent=None):
+        text.LineEdit.__init__(self, parent=parent)
+        if place_holder:
+            self.setPlaceholderText(place_holder)
+
+    def keyPressEvent(self, event):
+        selection_move_keys = [
+            Qt.Key_Enter,
+            Qt.Key_Return,
+            Qt.Key_Up,
+            Qt.Key_Down,
+            Qt.Key_Home,
+            Qt.Key_End,
+            Qt.Key_PageUp,
+            Qt.Key_PageDown,
+        ]
+
+        pressed_key = event.key()
+        if pressed_key in selection_move_keys:
+            self.switcher_selection_move.emit(event)
+        else:
+            super().keyPressEvent(event)
+
+
+class SwitcherSortFilterProxyModel(QtCore.QSortFilterProxyModel):
+    """Filtering class for candidate items."""
+
+    def __init__(self, entries, parent=None):
+        QtCore.QSortFilterProxyModel.__init__(self, parent)
+
+        self.entries = entries
+
+        self.setDynamicSortFilter(True)
+        self.setSourceModel(entries)
+        self.setFilterCaseSensitivity(Qt.CaseInsensitive)
+
+    def itemFromIndex(self, index):
+        return self.entries.itemFromIndex(self.mapToSource(index))
+
+
+class SwitcherTreeView(standard.TreeView):
+    """Tree view class for showing proxy items in SwitcherSortFilterProxyModel"""
+
+    def __init__(self, entries, enter_action, parent=None):
+        standard.TreeView.__init__(self, parent)
+
+        self.setHeaderHidden(True)
+        self.setModel(entries)
+
+        self.activated.connect(enter_action)
+        self.doubleClicked.connect(enter_action)
+        self.entered.connect(enter_action)
+
+
+class SwitcherListItem(QtGui.QStandardItem):
+    """Item class for SwitcherTreeView and SwitcherSortFilterProxyModel"""
+
+    def __init__(self, key, icon=None, name=None):
+        QtGui.QStandardItem.__init__(self)
+
+        self.key = key
+        if not name:
+            name = key
+
+        self.setText(name)
+        if icon:
+            self.setIcon(icon)

--- a/test/switcher_test.py
+++ b/test/switcher_test.py
@@ -1,0 +1,27 @@
+"""Test Quick Switcher"""
+# pylint: disable=redefined-outer-name
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from cola import icons
+from cola.widgets import switcher
+
+
+def test_switcher_item_with_only_key():
+    """item text would be key by building item without name"""
+    key = 'item-key'
+    actual = switcher.switcher_item(key)
+
+    assert actual.key == key
+    assert actual.text() == key
+
+
+def test_switcher_item_with_key_name_icon():
+    """item text would be name by building item with key and name"""
+    key = 'item-key'
+    name = 'item-name'
+    icon = icons.folder()
+
+    actual = switcher.switcher_item(key, icon, name)
+
+    assert actual.key == key
+    assert actual.text() == name


### PR DESCRIPTION
Add repository name filtering component by [QSortFilterProxyModel](https://doc.qt.io/qtforpython/PySide6/QtCore/QSortFilterProxyModel.html). `Switcher` class in `cola/widgets/switcher.py` inherits it.

> NOTE
> - In this sentence, I use a word `moving key`. It means "selection move key like `UP`/`DOWN`".
> All moving keys is in `selection_move_keys` variable.
>

## Filtering Class

For versatility and make it reusable, impmlemented `Switcher` class to be able to be with it's list view or without it.
By passing candidate items which is or inherits `QStandardItemModel`, this can filter them by item name in it.

In this PR, I implemented to filter repositories. But, for example, if `QStandardItemModel` like "file" or "commit" passed, this can filter them.

I'll explain with-view/without-view class details below.

### with-view class(`SwitcherInnerView`)

This contains "input field"(`self.filter_input`) and "candidate items list view"(`self.switcher_list`) in one widget.

### without-view class(`SwitcherOuterView`)

This will show only "input field". So, this class only do filtering candidate items by `self.proxy_model`.

When some characters inputted to the field, this just filters model(`self.proxy_model`).
By sharing model between view class in other widget class and `SwitcherOuterView`, the candidate items will be filtered even though the view class is in other class.

- To notify selection change event happended(moving key has pressed) while focusing on *input field*, this will emit `switcher_selection_move` signal.
- To notify that some character has benn inputted while focusing on *bookmamarks tree view*, this will emit `switcher_text` signal.

These are to be able to do input text and select item without changing focus.

## Changes

### Filtering repositories in bookmarks(recent) widget on main widget

- used `SwitcherOuterView`. That means this only shows input field and uses the original `BookmarksTreeView` class(but changed `TeeWidget` to `TreeView` for sharing model).
- by pressing some key except for move key while bookmarks(recent) widget is focused, input field will be showd and filter items by inputted text.

### Global shortcut for filtering repositories on main widget

- used `SwitcherInnerView`. That means one dialog(`SwitcherInnerView`) contains input field and candidate items view.
- Enter/Double click/Activated will open selected repository.
- `ctrl/command+p` has already mapped to Pull action, mapped this widget opening to `Alt+p`.

checked `make check`
improves #1090

Thank you!

