### PR TITLE
Use "remove" icon for Unstage menu item

### DIFF
--- a/cola/widgets/diff.py
+++ b/cola/widgets/diff.py
@@ -780,8 +780,10 @@ class DiffEditor(DiffTextEdit):
         if model.stageable() or model.unstageable():
             if model.stageable():
                 self.stage_or_unstage.setText(N_('Stage'))
+                self.stage_or_unstage.setIcon(icons.add())
             else:
                 self.stage_or_unstage.setText(N_('Unstage'))
+                self.stage_or_unstage.setIcon(icons.remove())
             menu.addAction(self.stage_or_unstage)
 
         if model.partially_stageable():


### PR DESCRIPTION
Prior to this commit, the Unstage menu item in the `DiffEditor` context menu for a staged file would have an "add" icon ("+") even though the "Unstage Diff Hunk" menu item right below it has a "remove" icon ("-"). Update the code to dynamically switch the icon for the `.stage_or_unstage` menu item between "add" or "remove" depending on whether the file is modified or staged.