### PR TITLE
Clean up dev and tox requirements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,8 +49,7 @@ jobs:
               pylint \
               python-is-python3 \
               python3-setuptools-scm \
-              python3-pytest \
-              python3-pytest-flake8
+              python3-pytest
           # Runtime dependencies (required)
           sudo apt-get install \
               python3-qtpy \

--- a/Makefile
+++ b/Makefile
@@ -277,11 +277,10 @@ check::
 	$(FLAKE8) $(FLAKE8_FLAGS) $(flags) $(file)
 	$(PYLINT) $(PYLINT_FLAGS) --output-format=colorized $(flags) $(file)
 else
-# NOTE: flake8 is not part of "make check" because the pytest-flake8 plugin runs flake8
-# checks during "make test" via pytest.
 check:: all
 check:: test
 check:: doc
+check:: flake8
 check:: pylint
 endif
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 norecursedirs=dist build .tox .eggs env*
-addopts=--doctest-modules --flake8
+addopts=--doctest-modules
 doctest_optionflags=ALLOW_UNICODE ELLIPSIS
 filterwarnings=
     # https://github.com/pytest-dev/pytest/issues/6928

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -9,7 +9,6 @@ wheel
 ## pylint, flake8 checkers are used by "make check".
 flake8
 pylint>=2.14.0
-PyYAML
 
 ## pytest packages are used by the "make test" test suite.
 pytest>=3.6

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -8,11 +8,10 @@ wheel
 
 ## pylint, flake8 checkers are used by "make check".
 flake8
-mock
 pylint>=2.14.0
 PyYAML
 
-## mock and pytest packages are used by the "make test" test suite.
+## pytest packages are used by the "make test" test suite.
 pytest>=3.6
 pytest-cov
 

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -15,7 +15,6 @@ PyYAML
 ## mock and pytest packages are used by the "make test" test suite.
 pytest>=3.6
 pytest-cov
-pytest-black-multipy
 
 ## Build and install documentation using "make doc" and "make install-doc".
 jaraco.packaging >= 9

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -15,7 +15,6 @@ PyYAML
 ## mock and pytest packages are used by the "make test" test suite.
 pytest>=3.6
 pytest-cov
-pytest-flake8
 pytest-black-multipy
 
 ## Build and install documentation using "make doc" and "make install-doc".

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,6 @@ testing =
 	# upstream
 	pytest >= 3.5, !=3.7.3
 	pytest-checkdocs >= 1.2.3
-	pytest-flake8
 	pytest-black >= 0.3.7; \
 		# workaround for jaraco/skeleton#22
 		python_implementation != "PyPy"

--- a/test/helper.py
+++ b/test/helper.py
@@ -4,12 +4,9 @@ import shutil
 import stat
 import tempfile
 
-import pytest
+from unittest.mock import Mock, patch  # noqa pylint: disable=unused-import
 
-try:
-    from unittest.mock import Mock, patch  # noqa pylint: disable=unused-import
-except ImportError:
-    from mock import Mock, patch  # noqa pylint: disable=unused-import
+import pytest
 
 from cola import core
 from cola import git

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,12 @@
 [tox]
 minversion = 3.2
 envlist = python
-# Ensure that a late version of pip is used even on tox-venv.
-requires =
-	tox-pip-version>=0.0.6
 
 [testenv]
 sitepackages = true
 deps =
     -rrequirements/requirements.txt
     -rrequirements/requirements-dev.txt
-pip_version = pip
 whitelist_externals =
     make
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ tox_pip_extensions_ext_venv_update = true
 # Ensure that a late version of pip is used even on tox-venv.
 requires =
 	tox-pip-version>=0.0.6
-	tox-venv
 
 [testenv]
 sitepackages = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 minversion = 3.2
 envlist = python
-# https://github.com/jaraco/skeleton/issues/6
-tox_pip_extensions_ext_venv_update = true
 # Ensure that a late version of pip is used even on tox-venv.
 requires =
 	tox-pip-version>=0.0.6


### PR DESCRIPTION
Remove obsolete and unneeded packages from `tox.ini` and `requirements-dev.txt`.  Also drop `pylint-flake8` since it is essentially abandoned upstream, doesn't work with pytest>=7.0 (released February 2022) or flake8>=5.0 (released in July 2022) and instead simply invoke `flake8` directly.