### PR TITLE
Correct PyQt version that pip installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Git Cola is a powerful Git GUI with a slick and intuitive user interface.
 
 Git Cola uses QtPy, so you can choose between PyQt6, PyQt5 and PySide2 by setting
 the `QT_API` environment variable to `pyqt6`, `pyqt5` or `pyside2` as desired.
-`qtpy` defaults to `pyqt6` and falls back to `pyqt6` and `pyside2` if `pyqt5`
+`qtpy` defaults to `pyqt5` and falls back to `pyqt6` and `pyside2` if `pyqt5`
 is not installed.
 
 Any of the following Python Qt libraries must be installed:
@@ -126,6 +126,7 @@ One way to install the latest released version is to use `venv` (virtualenv) and
 This installs [git-cola from pypi.org](https://pypi.org/project/git-cola/).
 
     python3 -m venv --system-site-packages env3
+    ./env3/bin/pip install PyQt$(echo $(qmake -query QT_VERSION) | head -c 1)==$(qmake -query QT_VERSION)
     ./env3/bin/pip install git-cola
     ./env3/bin/git-cola
 


### PR DESCRIPTION
On a system where the Qt version is 5.13.2 "./env3/bin/pip install git-cola" installs PyQt in the version 5.15.9 (the latest). Subsequent "./env3/bin/git-cola" doesn't open the app window and causes following error to appear "No Qt bindings could be found". This patch fixes the issue by installing the PyQt version matching the Qt version on the system.