### PR TITLE
prefs: add log date format to preferences for git-dag

### DIFF
--- a/cola/models/dag.py
+++ b/cola/models/dag.py
@@ -3,6 +3,7 @@ import json
 
 from .. import core
 from .. import utils
+from ..models import prefs
 
 # put summary at the end b/c it can contain
 # any number of funky characters, including the separator
@@ -273,7 +274,12 @@ class RepoReader(object):
 
         self.reset()
         ref_args = utils.shell_split(self.params.ref)
-        cmd = self._cmd + ['-%d' % self.params.count] + ref_args
+        cmd = (
+            self._cmd
+            + ['-%d' % self.params.count]
+            + ref_args
+            + ['--date=%s' % prefs.logdate(self.context)]
+        )
         self._proc = core.start_command(cmd)
 
         while True:

--- a/cola/models/prefs.py
+++ b/cola/models/prefs.py
@@ -30,6 +30,7 @@ HIDPI = 'cola.hidpi'
 HISTORY_BROWSER = 'gui.historybrowser'
 ICON_THEME = 'cola.icontheme'
 LINEBREAK = 'cola.linebreak'
+LOGDATE = 'cola.logdate'
 MAXRECENT = 'cola.maxrecent'
 MERGE_DIFFSTAT = 'merge.diffstat'
 MERGE_KEEPBACKUP = 'merge.keepbackup'
@@ -51,6 +52,34 @@ TABWIDTH = 'cola.tabwidth'
 TEXTWIDTH = 'cola.textwidth'
 USER_EMAIL = 'user.email'
 USER_NAME = 'user.name'
+
+
+class DateFormat(object):
+    DEFAULT = 'default'
+    RELATIVE = 'relative'
+    LOCAL = 'local'
+    ISO = 'iso8601'
+    ISO_STRICT = 'iso8601-strict'
+    RFC = 'rfc2822'
+    SHORT = 'short'
+    RAW = 'raw'
+    HUMAN = 'human'
+    UNIX = 'unix'
+
+
+def date_formats():
+    return [
+        DateFormat.DEFAULT,
+        DateFormat.RELATIVE,
+        DateFormat.LOCAL,
+        DateFormat.ISO,
+        DateFormat.ISO_STRICT,
+        DateFormat.RFC,
+        DateFormat.SHORT,
+        DateFormat.RAW,
+        DateFormat.HUMAN,
+        DateFormat.UNIX,
+    ]
 
 
 class Defaults(object):
@@ -94,6 +123,7 @@ class Defaults(object):
     patches_directory = 'patches'
     status_indent = False
     status_show_totals = False
+    logdate = DateFormat.DEFAULT
 
 
 def blame_viewer(context):
@@ -208,6 +238,11 @@ def history_browser(context):
 def linebreak(context):
     """Should we word-wrap lines in the commit message editor?"""
     return context.cfg.get(LINEBREAK, default=Defaults.linebreak)
+
+
+def logdate(context):
+    """Return the configured log date format"""
+    return context.cfg.get(LOGDATE, default=Defaults.logdate)
 
 
 def maxrecent(context):

--- a/cola/widgets/prefs.py
+++ b/cola/widgets/prefs.py
@@ -141,6 +141,10 @@ class RepoFormWidget(FormWidget):
         self.tabwidth = standard.SpinBox(value=8, maxi=42)
         self.textwidth = standard.SpinBox(value=72, maxi=150)
 
+        self.logdate = qtutils.combo(prefs.date_formats())
+        tooltip = N_('This value is passed to git log --date')
+        self.logdate.setToolTip(tooltip)
+
         tooltip = N_('Detect conflict markers in unmerged files')
         self.check_conflicts = qtutils.checkbox(checked=True, tooltip=tooltip)
 
@@ -160,6 +164,7 @@ class RepoFormWidget(FormWidget):
         self.add_row(N_('Email Address'), self.email)
         self.add_row(N_('Tab Width'), self.tabwidth)
         self.add_row(N_('Text Width'), self.textwidth)
+        self.add_row(N_('Log Date Format'), self.logdate)
         self.add_row(N_('Merge Verbosity'), self.merge_verbosity)
         self.add_row(N_('Number of Diff Context Lines'), self.diff_context)
         self.add_row(N_('Patches Directory'), self.patches_directory)
@@ -196,6 +201,7 @@ class RepoFormWidget(FormWidget):
                     Defaults.display_untracked,
                 ),
                 prefs.ENABLE_GRAVATAR: (self.enable_gravatar, Defaults.enable_gravatar),
+                prefs.LOGDATE: (self.logdate, Defaults.logdate),
                 prefs.MERGE_DIFFSTAT: (self.merge_diffstat, Defaults.merge_diffstat),
                 prefs.MERGE_SUMMARY: (self.merge_summary, Defaults.merge_summary),
                 prefs.MERGE_VERBOSITY: (self.merge_verbosity, Defaults.merge_verbosity),

--- a/docs/git-cola.rst
+++ b/docs/git-cola.rst
@@ -762,6 +762,14 @@ Defaults to `true`.  This setting is configured using the `Preferences`
 dialog, but it can be toggled for one-off usage using the commit message
 editor's options sub-menu.
 
+cola.logdate
+------------
+Set the default date-time mode for the DAG display. This value is
+passed to `git log --date=<format>`.
+See `git log(1) <https://git-scm.com/docs/git-log#Documentation/git-log.txt---dateltformatgt>`_
+for details.
+
+
 cola.maxrecent
 --------------
 `git cola` caps the number of recent repositories to avoid cluttering


### PR DESCRIPTION
I've added the log date format pref discussed in #1312.
