### PR TITLE
Prevent double-hyphen in git-dag doc

### DIFF
--- a/docs/git-dag.rst
+++ b/docs/git-dag.rst
@@ -15,21 +15,21 @@ graphical interface.
 OPTIONS
 =======
 
---prompt
---------
+``--prompt``
+------------
 Prompt for a Git repository instead of using the current directory.
 
--r, --repo <path>
------------------
+``-r, --repo <path>``
+---------------------
 Run `git dag` on the git repository in `<path>`.
 Defaults to the current directory.
 
---version
----------
+``--version``
+-------------
 Print the `git dag` version and exit.
 
--h, --help
-----------
+``-h, --help``
+--------------
 Show usage and optional arguments.
 
 Log Options


### PR DESCRIPTION
like it was done in commit 85d7fdb by @kurtmckee for git-cola.rst

---

The double-hyphen at the [docs](https://git-cola.readthedocs.io/en/latest/git-dag.html#log-options)  or in the manpage `man git dag`  can easily mixed up with a single hyphen. At first I used a single hyphen and was confused about the error message I got.