### PR TITLE
Disable pylint when running in pre-commit CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,12 @@
 # Run `pre-commit autoupdate` to update tool versions.
 
+ci:
+  skip:
+    # pylint's pre-commit documentation states it only works when running locally.
+    # https://pylint.pycqa.org/en/latest/user_guide/installation/pre-commit-integration.html
+    # Therefore, the pylint pre-commit hook is disabled when running in pre-commit CI.
+    - pylint
+
 exclude: qtpy/|test/fixtures/|\.rtf$|PkgInfo$
 
 repos:


### PR DESCRIPTION
`main` is showing pre-commit.ci failures when running the `pylint` hook.

I didn't realize it before, but pylint's documentation states that [pylint can only be used in local pre-commit runs](https://pylint.pycqa.org/en/latest/user_guide/installation/pre-commit-integration.html).

This PR disables pylint in pre-commit.ci but allows it to continue running locally.