### PR TITLE
starting with sphinx 7.2.0, root is a pathlib.Path not a string anymore

### DIFF
--- a/extras/sphinxtogithub/sphinxtogithub.py
+++ b/extras/sphinxtogithub/sphinxtogithub.py
@@ -97,7 +97,7 @@ class DirectoryHandler:
     def __init__(self, name, root, renamer):
         self.name = name
         self.new_name = name[1:]
-        self.root = root + os.sep
+        self.root = str(root)
         self.renamer = renamer
 
     def path(self):


### PR DESCRIPTION
so convert it to a string, the trailing os.sep is not needed. os.path.join which is used to join paths, expects string and inserts the os.sep.

See-also: sphinx-doc/sphinx#11526
See-also: sphinx-doc/sphinx#11608