### PR TITLE
GUI: Stop making newly-created buttons immediately visible

### DIFF
--- a/cola/qtutils.py
+++ b/cola/qtutils.py
@@ -736,7 +736,7 @@ def tool_button():
     return button
 
 
-def create_action_button(tooltip=None, icon=None, visible=True):
+def create_action_button(tooltip=None, icon=None, visible=None):
     """Create a small toolbutton for use in dock title widgets"""
     button = tool_button()
     if tooltip is not None:
@@ -744,7 +744,8 @@ def create_action_button(tooltip=None, icon=None, visible=True):
     if icon is not None:
         button.setIcon(icon)
         button.setIconSize(QtCore.QSize(defs.small_icon, defs.small_icon))
-    button.setVisible(visible)
+    if visible is not None:
+        button.setVisible(visible)
     return button
 
 


### PR DESCRIPTION
On Windows, making a newly-created button visible causes a new window to open containing only the new button.

Testing shows that the buttons will be visible in whatever dock they are ultimately assigned to when the main git-cola window opens even if `.setVisible(True)` is not called first.

Therefore, the call to `.setVisible()` seems to be unnecessary.

Fixes #1329