### PR TITLE
Remove pylint as a pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,5 @@
 # Run `pre-commit autoupdate` to update tool versions.
 
-ci:
-  skip:
-    # pylint's pre-commit documentation states it only works when running locally.
-    # https://pylint.pycqa.org/en/latest/user_guide/installation/pre-commit-integration.html
-    # Therefore, the pylint pre-commit hook is disabled when running in pre-commit CI.
-    - pylint
-
 exclude: qtpy/|test/fixtures/|\.rtf$|PkgInfo$
 
 repos:
@@ -30,16 +23,3 @@ repos:
       - id: brunette
         args:
           - --config=setup.cfg
-
-  - repo: https://github.com/pylint-dev/pylint
-    rev: v2.17.5
-    hooks:
-      - id: pylint
-        pass_filenames: false
-        additional_dependencies:
-          - pyqt5
-          - pytest
-        args:
-          - --rcfile=.pylintrc
-          - cola
-          - test


### PR DESCRIPTION
pylint previously appeared to work in pre-commit _because I had a virtual environment activated_ with all dependencies installed.

Once the virtual environment was deactivated, the pylint pre-commit hook began failing just as it did in CI.

This makes the pylint pre-commit hook too untenable in CI _and_ in general local use, so this PR removes it entirely.