### PR TITLE
allow smaller font size for hidpi

### DIFF
--- a/cola/widgets/prefs.py
+++ b/cola/widgets/prefs.py
@@ -248,7 +248,7 @@ class SettingsFormWidget(FormWidget):
         FormWidget.__init__(self, context, model, parent)
 
         self.fixed_font = QtWidgets.QFontComboBox()
-        self.font_size = standard.SpinBox(value=12, mini=8, maxi=192)
+        self.font_size = standard.SpinBox(value=12, mini=6, maxi=192)
 
         self.maxrecent = standard.SpinBox(maxi=99)
         self.tabwidth = standard.SpinBox(maxi=42)


### PR DESCRIPTION
Allow using smaller fonts. This can be useful for large HiDPI screens. For example, my Windows machine's screen's pixel density is 105 and the display scaling is set to 150% in 2160p. This makes the size of a 8 pt font too large. It can also vary depending on the Qt backend being used (DirectDraw vs xcb, etc.).

Perhaps there's some sense in lowering it even a bit further but that's enough changes for one day.

As usual, thank you for this wonderful software. The ability to edit diffs before reverting will surely come in handy.