### PR TITLE
remove translation of git jargon from Czech, Spanish and French

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,8 @@ translated into a localized string.
 The translation message files are the `*.po` files in the `cola/i18n/` directory.
 Adding a new translation entails creating a new language-specific `.po` file.
 
+Please note - it is preferred that git command jargon will be left untranslated. 
+
 When new (untranslated) strings are added to the project, the `git-cola.pot`
 base template and the language-specific message files need to be updated with
 the new strings.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ translated into a localized string.
 The translation message files are the `*.po` files in the `cola/i18n/` directory.
 Adding a new translation entails creating a new language-specific `.po` file.
 
-Please note - it is preferred that git command jargon will be left untranslated. 
+Please note - it is preferred that git command jargon will be left untranslated.
 
 When new (untranslated) strings are added to the project, the `git-cola.pot`
 base template and the language-specific message files need to be updated with

--- a/cola/i18n/cs.po
+++ b/cola/i18n/cs.po
@@ -423,11 +423,11 @@ msgstr ""
 
 #: cola/cmds.py:162
 msgid "Abort Cherry-Pick"
-msgstr ""
+msgstr "Abort Cherry-Pick"
 
 #: cola/cmds.py:156 cola/widgets/main.py:334
 msgid "Abort Cherry-Pick..."
-msgstr ""
+msgstr "Abort Cherry-Pick..."
 
 #: cola/cmds.py:193
 msgid "Abort Merge"
@@ -627,11 +627,11 @@ msgstr "Vždy vytvořit zápis sloučení, je-li povoleno, a to i v případě, 
 
 #: cola/cmds.py:221
 msgid "Amend"
-msgstr "Pozměnit"
+msgstr "Amend"
 
 #: cola/widgets/commitmsg.py:463
 msgid "Amend Commit"
-msgstr "Pozměnit zápis"
+msgstr "Amend Commit"
 
 #: cola/widgets/commitmsg.py:110 cola/widgets/main.py:194
 msgid "Amend Last Commit"
@@ -643,7 +643,7 @@ msgstr "Pozměnit uveřejněný zápis?"
 
 #: cola/widgets/main.py:1157
 msgid "Amending"
-msgstr "Pozměnit"
+msgstr "Amending"
 
 #: cola/widgets/cfgactions.py:151
 msgid ""
@@ -744,7 +744,7 @@ msgstr ""
 
 #: cola/cmds.py:545 cola/widgets/status.py:282
 msgid "Blame..."
-msgstr "Blame…"
+msgstr "Blame..."
 
 #: cola/widgets/prefs.py:347
 msgid "Bold on dark headers instead of italic"
@@ -889,7 +889,7 @@ msgstr ""
 
 #: cola/guicmds.py:62 cola/widgets/branch.py:222
 msgid "Checkout"
-msgstr "Přepnout"
+msgstr "Checkout"
 
 #: cola/widgets/createbranch.py:130
 msgid "Checkout After Creation"
@@ -901,7 +901,7 @@ msgstr "Přepnout větev"
 
 #: cola/widgets/dag.py:414
 msgid "Checkout Detached HEAD"
-msgstr "Přepnout odpojené hlavní"
+msgstr "Checkout Detached HEAD"
 
 #: cola/cmds.py:480 cola/cmds.py:518
 msgid "Checkout Files"
@@ -929,19 +929,19 @@ msgstr ""
 
 #: cola/widgets/main.py:576
 msgid "Checkout..."
-msgstr "Přepnout…"
+msgstr "Checkout..."
 
 #: cola/widgets/dag.py:387 cola/widgets/search.py:79
 msgid "Cherry Pick"
-msgstr "Sloučit selektivně"
+msgstr "Cherry Pick"
 
 #: cola/guicmds.py:73
 msgid "Cherry-Pick Commit"
-msgstr "Sloučit konkrétní nahrání"
+msgstr "Cherry-Pick Commit"
 
 #: cola/widgets/main.py:328
 msgid "Cherry-Pick..."
-msgstr "Selektivně sloučit…"
+msgstr "Cherry-Pick..."
 
 #: cola/cmds.py:584
 msgid "Cherry-pick failed"
@@ -1671,7 +1671,7 @@ msgstr "Chyba: nedaří se nalézt šablonu nahrání"
 
 #: cola/widgets/stash.py:235
 msgid "Error: Stash exists"
-msgstr "Chyba: Odklad existuje"
+msgstr "Chyba: Stash existuje"
 
 #: cola/cmds.py:1732
 msgid "Error: Unconfigured commit template"
@@ -1762,15 +1762,15 @@ msgstr "Oblíbené"
 
 #: cola/widgets/remote.py:673
 msgid "Fetch"
-msgstr "Vyzvednout"
+msgstr "Fetch"
 
 #: cola/widgets/createbranch.py:127
 msgid "Fetch Tracking Branch"
-msgstr "Vyzvednout sledovanou větev"
+msgstr "Fetch Tracking Branch"
 
 #: cola/widgets/action.py:63 cola/widgets/main.py:387
 msgid "Fetch..."
-msgstr "Vyzvednout (fetch)…"
+msgstr "Fetch..."
 
 #: cola/widgets/main.py:588
 msgid "File Browser..."
@@ -1926,11 +1926,11 @@ msgstr "Vynutit vyzvednutí?"
 
 #: cola/widgets/remote.py:625
 msgid "Force Push"
-msgstr "Vynutit odeslání"
+msgstr "Force Push"
 
 #: cola/widgets/remote.py:619
 msgid "Force Push?"
-msgstr "Vynutit odeslání?"
+msgstr "Force Push?"
 
 #: cola/widgets/remote.py:616
 #, python-format
@@ -1940,7 +1940,7 @@ msgstr "Vynutit vyzvednutí z %s?"
 #: cola/widgets/remote.py:624
 #, python-format
 msgid "Force push to %s?"
-msgstr "Vynutit odeslání do %s?"
+msgstr "Force push do %s?"
 
 #: cola/widgets/status.py:1376
 msgid "Format String"
@@ -2115,7 +2115,7 @@ msgstr "Ponechat *.orig zálohy začlenění"
 
 #: cola/widgets/stash.py:71
 msgid "Keep Index"
-msgstr "Zachovat index"
+msgstr "Keep Index"
 
 #: cola/widgets/main.py:477
 msgid "Keyboard Shortcuts"
@@ -2587,20 +2587,20 @@ msgstr ""
 
 #: cola/widgets/branch.py:247 cola/widgets/remote.py:728
 msgid "Pull"
-msgstr "Stáhnout si"
+msgstr "Pull"
 
 #: cola/widgets/action.py:65 cola/widgets/main.py:397
 msgid "Pull..."
-msgstr "Stáhnout si (pull)…"
+msgstr "Pull..."
 
 #: cola/widgets/branch.py:253 cola/widgets/remote.py:593
 #: cola/widgets/remote.py:698
 msgid "Push"
-msgstr "Odeslat"
+msgstr "Push"
 
 #: cola/widgets/action.py:64 cola/widgets/main.py:392
 msgid "Push..."
-msgstr "Odeslat (push)…"
+msgstr "Push..."
 
 #: cola/guicmds.py:252
 msgid "Quick Open Repository"

--- a/cola/i18n/es.po
+++ b/cola/i18n/es.po
@@ -648,11 +648,11 @@ msgstr "Siempre utilizar un \"merge commit\" cuando este habilitado, incluso cua
 
 #: cola/cmds.py:221
 msgid "Amend"
-msgstr "Corregir"
+msgstr "Amend"
 
 #: cola/widgets/commitmsg.py:463
 msgid "Amend Commit"
-msgstr "Corregir commit"
+msgstr "Amend commit"
 
 #: cola/widgets/commitmsg.py:110 cola/widgets/main.py:194
 msgid "Amend Last Commit"
@@ -664,7 +664,7 @@ msgstr "¿Corregir el commit publicado?"
 
 #: cola/widgets/main.py:1157
 msgid "Amending"
-msgstr "Corrigiendo"
+msgstr "Amending"
 
 #: cola/widgets/cfgactions.py:151
 msgid ""
@@ -765,7 +765,7 @@ msgstr "Responsables de las rutas seleccionadas"
 
 #: cola/cmds.py:545 cola/widgets/status.py:282
 msgid "Blame..."
-msgstr "Responsable..."
+msgstr "Blame..."
 
 #: cola/widgets/prefs.py:347
 msgid "Bold on dark headers instead of italic"
@@ -1783,15 +1783,15 @@ msgstr "Favoritos"
 
 #: cola/widgets/remote.py:673
 msgid "Fetch"
-msgstr "Extraer (Fetch)"
+msgstr "Fetch"
 
 #: cola/widgets/createbranch.py:127
 msgid "Fetch Tracking Branch"
-msgstr "Extraer (Fetch) la rama en seguimiento"
+msgstr "Fetch Tracking Branch"
 
 #: cola/widgets/action.py:63 cola/widgets/main.py:387
 msgid "Fetch..."
-msgstr "Extraer (Fetch)..."
+msgstr "Fetch..."
 
 #: cola/widgets/main.py:588
 msgid "File Browser..."
@@ -2139,7 +2139,7 @@ msgstr "Conservar Merge Backups *.orig"
 
 #: cola/widgets/stash.py:71
 msgid "Keep Index"
-msgstr "Mantener Index"
+msgstr "Keep Index"
 
 #: cola/widgets/main.py:477
 msgid "Keyboard Shortcuts"

--- a/cola/i18n/fr.po
+++ b/cola/i18n/fr.po
@@ -417,7 +417,7 @@ msgstr "Un crochet doit être spécifié à « %s »"
 #: cola/widgets/stash.py:236
 #, python-format
 msgid "A stash named \"%s\" already exists"
-msgstr "Un remisage nommé « %s » existe déjà"
+msgstr "Un stash nommé « %s » existe déjà"
 
 #: cola/widgets/cfgactions.py:82 cola/widgets/main.py:622
 msgid "Abort"
@@ -647,11 +647,11 @@ msgstr "Toujours créer un commit fusionné quand cela est possible, même si la
 
 #: cola/cmds.py:221
 msgid "Amend"
-msgstr "Correction"
+msgstr "Amend"
 
 #: cola/widgets/commitmsg.py:463
 msgid "Amend Commit"
-msgstr "Corriger le commit"
+msgstr "Amend Commit"
 
 #: cola/widgets/commitmsg.py:110 cola/widgets/main.py:194
 msgid "Amend Last Commit"
@@ -663,7 +663,7 @@ msgstr "Corriger le commit publié ?"
 
 #: cola/widgets/main.py:1157
 msgid "Amending"
-msgstr "Correction"
+msgstr "Amending"
 
 #: cola/widgets/cfgactions.py:151
 msgid ""
@@ -764,7 +764,7 @@ msgstr "Visionner les chemins sélectionnés"
 
 #: cola/cmds.py:545 cola/widgets/status.py:282
 msgid "Blame..."
-msgstr "Visionner..."
+msgstr "Blame..."
 
 #: cola/widgets/prefs.py:347
 msgid "Bold on dark headers instead of italic"
@@ -909,19 +909,19 @@ msgstr "Vérifier si un commit a été publié avant qu'il soit corriger"
 
 #: cola/guicmds.py:62 cola/widgets/branch.py:222
 msgid "Checkout"
-msgstr "Emprunter"
+msgstr "Checkout"
 
 #: cola/widgets/createbranch.py:130
 msgid "Checkout After Creation"
-msgstr "Emprunt après création"
+msgstr "Checkout après création"
 
 #: cola/guicmds.py:62 cola/widgets/dag.py:410
 msgid "Checkout Branch"
-msgstr "Emprunter la branche"
+msgstr "Checkout la branche"
 
 #: cola/widgets/dag.py:414
 msgid "Checkout Detached HEAD"
-msgstr "Emprunter le HEAD détaché"
+msgstr "Checkout le HEAD détaché"
 
 #: cola/cmds.py:480 cola/cmds.py:518
 msgid "Checkout Files"
@@ -949,19 +949,19 @@ msgstr ""
 
 #: cola/widgets/main.py:576
 msgid "Checkout..."
-msgstr "Emprunter..."
+msgstr "Checkout..."
 
 #: cola/widgets/dag.py:387 cola/widgets/search.py:79
 msgid "Cherry Pick"
-msgstr "Copier"
+msgstr "Cherry Pick"
 
 #: cola/guicmds.py:73
 msgid "Cherry-Pick Commit"
-msgstr "Copier commit"
+msgstr "Cherry-Pick Commit"
 
 #: cola/widgets/main.py:328
 msgid "Cherry-Pick..."
-msgstr "Copier..."
+msgstr "Cherry-Pick..."
 
 #: cola/cmds.py:584
 msgid "Cherry-pick failed"
@@ -1651,7 +1651,7 @@ msgstr "Erreur lors de la création de l'élément distant « %s »"
 
 #: cola/models/stash.py:197
 msgid "Error creating stash"
-msgstr "Erreur lors de la création du rétablissement"
+msgstr "Erreur lors de la création du stash"
 
 #: cola/cmds.py:1126
 #, python-format
@@ -1691,7 +1691,7 @@ msgstr "Erreur : impossible de trouver un modèle de commit"
 
 #: cola/widgets/stash.py:235
 msgid "Error: Stash exists"
-msgstr "Erreur : le remisage existe"
+msgstr "Erreur : le Stash existe"
 
 #: cola/cmds.py:1732
 msgid "Error: Unconfigured commit template"
@@ -1782,15 +1782,15 @@ msgstr "Favoris"
 
 #: cola/widgets/remote.py:673
 msgid "Fetch"
-msgstr "Récupération"
+msgstr "Fetch"
 
 #: cola/widgets/createbranch.py:127
 msgid "Fetch Tracking Branch"
-msgstr "Récupérer la branche suivie"
+msgstr "Fetch Tracking Branch"
 
 #: cola/widgets/action.py:63 cola/widgets/main.py:387
 msgid "Fetch..."
-msgstr "Récupérer..."
+msgstr "Fetch..."
 
 #: cola/widgets/main.py:588
 msgid "File Browser..."
@@ -2138,7 +2138,7 @@ msgstr "Conserver les sauvegardes de fusion *.orig"
 
 #: cola/widgets/stash.py:71
 msgid "Keep Index"
-msgstr "Conserver l'index"
+msgstr "Keep Index"
 
 #: cola/widgets/main.py:477
 msgid "Keyboard Shortcuts"
@@ -2617,20 +2617,20 @@ msgstr "Réviser les entrées manquantes"
 
 #: cola/widgets/branch.py:247 cola/widgets/remote.py:728
 msgid "Pull"
-msgstr "Tirer"
+msgstr "Pull"
 
 #: cola/widgets/action.py:65 cola/widgets/main.py:397
 msgid "Pull..."
-msgstr "Tirer..."
+msgstr "Pull..."
 
 #: cola/widgets/branch.py:253 cola/widgets/remote.py:593
 #: cola/widgets/remote.py:698
 msgid "Push"
-msgstr "Pousser"
+msgstr "Push"
 
 #: cola/widgets/action.py:64 cola/widgets/main.py:392
 msgid "Push..."
-msgstr "Pousser..."
+msgstr "Push..."
 
 #: cola/guicmds.py:252
 msgid "Quick Open Repository"

--- a/test/i18n_test.py
+++ b/test/i18n_test.py
@@ -57,11 +57,11 @@ def test_translates_random_english():
 
 def test_translate_push_pull_french():
     i18n.install('fr_FR')
-    expect = 'Tirer'
+    expect = 'Pull'
     actual = N_('Pull')
     assert expect == actual
 
-    expect = 'Pousser'
+    expect = 'Push'
     actual = N_('Push')
     assert expect == actual
 


### PR DESCRIPTION
changes were made based on [1343](https://github.com/git-cola/git-cola/pull/1343)