### PR TITLE
Configure automatic updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
-# Run `pre-commit autoupdate` to update tool versions.
+ci:
+  autoupdate_schedule: monthly
 
 exclude: qtpy/|test/fixtures/|\.rtf$|PkgInfo$
 


### PR DESCRIPTION
This PR introduces the following changes:

* Add a Dependabot configuration that will submit PRs to update GitHub action on a monthly basis (for example, a PR will be opened to update `actions/checkout@v3` to `v4` if this merges)
* Modify the pre-commit configuration to submit update PRs on a monthly basis (the default is weekly)