### PR TITLE
Resolve pyupgrade pre-commit hook failures

### DIFF
--- a/cola/models/stash.py
+++ b/cola/models/stash.py
@@ -120,7 +120,7 @@ class RenameStash(cmds.ContextCommand):
     """Rename the stash"""
 
     def __init__(self, context, stash_index, stash_name):
-        super(RenameStash, self).__init__(context)
+        super().__init__(context)
         self.context = context
         self.stash_index = stash_index
         self.stash_name = stash_name

--- a/cola/widgets/remotemessage.py
+++ b/cola/widgets/remotemessage.py
@@ -1,4 +1,3 @@
-from __future__ import division, absolute_import, unicode_literals
 import re
 
 from qtpy.QtCore import Qt


### PR DESCRIPTION
pyupgrade identified two opportunities for Python 3.6+ syntax usage. I simply ran `pre-commit run -a` to address the issue.

This should resolve existing CI failures.