### PR TITLE
Remarks to commits in rebase sequence editor

### DIFF
--- a/cola/gitcmds.py
+++ b/cola/gitcmds.py
@@ -69,7 +69,6 @@ def diff_index_filenames(context, ref):
 
 def diff_filenames(context, *args):
     """Return a list of filenames that have been modified"""
-    git = context.git
     out = diff_tree(context, *args)[STDOUT]
     return _parse_diff_filenames(out)
 

--- a/cola/i18n/ru.po
+++ b/cola/i18n/ru.po
@@ -4207,6 +4207,15 @@ msgstr ""
 msgid "yyyy-MM-dd"
 msgstr ""
 
+msgid "Remarks"
+msgstr "Пометки"
+
+msgid "Toggle remark"
+msgstr "Переключить пометку"
+
+msgid "Toggle remark of touching commits"
+msgstr "Переключить пометку затрагивающих коммитов"
+
 #~ msgid ""
 #~ "\n"
 #~ "\n"

--- a/cola/sequenceeditor.py
+++ b/cola/sequenceeditor.py
@@ -334,6 +334,17 @@ class Editor(QtWidgets.QWidget):
         self.tree.refit()
         self.tree.select_first()
 
+    def save(self, string):
+        """Save the instruction sheet"""
+        try:
+            core.write(self.filename, string)
+            status = 0
+        except (OSError, ValueError) as exc:
+            msg, details = utils.format_exception(exc)
+            sys.stderr.write(msg + '\n\n' + details)
+            status = 128
+        return status
+
     # actions
     def cancel(self):
         if self.cancel_action == 'save':
@@ -350,17 +361,6 @@ class Editor(QtWidgets.QWidget):
         status = self.save(sequencer_instructions)
         self.status = status
         self.exit.emit(status)
-
-    def save(self, string):
-        """Save the instruction sheet"""
-        try:
-            core.write(self.filename, string)
-            status = 0
-        except (OSError, ValueError) as exc:
-            msg, details = utils.format_exception(exc)
-            sys.stderr.write(msg + '\n\n' + details)
-            status = 128
-        return status
 
 
 # pylint: disable=too-many-ancestors

--- a/cola/sequenceeditor.py
+++ b/cola/sequenceeditor.py
@@ -329,7 +329,7 @@ class Editor(QtWidgets.QWidget):
         self.tree.select_first()
 
         self.working = True
-        Thread(target = self.poll_touched_paths_main).start()
+        Thread(target=self.poll_touched_paths_main).start()
 
     # actions
     def cancel(self):
@@ -446,9 +446,10 @@ class RebaseTreeWidget(standard.DraggableTreeWidget):
             qtutils.add_action(
                 self,
                 r,
-                lambda remark = r: self.toggle_remark(remark),
-                hotkeys.hotkey(Qt.CTRL | getattr(Qt, "Key_" + r))
-            ) for r in map(str, range(10))
+                lambda remark=r: self.toggle_remark(remark),
+                hotkeys.hotkey(Qt.CTRL | getattr(Qt, 'Key_' + r)),
+            )
+            for r in map(str, range(10))
         )
 
         # pylint: disable=no-member
@@ -571,11 +572,7 @@ class RebaseTreeWidget(standard.DraggableTreeWidget):
         self.toggle_remark_of_items(remark, items)
 
     def toggle_remark_of_items(self, remark, items):
-        logic_or = reduce(
-            lambda res, item: res or remark in item.remarks,
-            items,
-            False
-        )
+        logic_or = reduce(lambda res, item: res or remark in item.remarks, items, False)
         if logic_or:
             for item in items:
                 item.remove_remark(remark)
@@ -774,7 +771,7 @@ class RebaseTreeWidgetItem(QtWidgets.QTreeWidgetItem):
 
     def set_remarks(self, remarks):
         self.remarks = remarks
-        self.setText(4, "".join(remarks))
+        self.setText(4, ''.join(remarks))
 
     def set_command(self, command):
         """Set the item to a different command, no-op for exec items"""

--- a/cola/sequenceeditor.py
+++ b/cola/sequenceeditor.py
@@ -259,6 +259,13 @@ class Editor(QtWidgets.QWidget):
 
         self.tree.toggle_remark_of_items(remark, touching_items)
 
+    def external_diff(self):
+        items = self.tree.selected_items()
+        if not items:
+            return
+        item = items[0]
+        difftool.diff_expression(self.context, self, item.oid + '^!', hide_expr=True)
+
     # helpers
 
     def paths_touched_by_oid(self, oid):
@@ -354,13 +361,6 @@ class Editor(QtWidgets.QWidget):
             sys.stderr.write(msg + '\n\n' + details)
             status = 128
         return status
-
-    def external_diff(self):
-        items = self.tree.selected_items()
-        if not items:
-            return
-        item = items[0]
-        difftool.diff_expression(self.context, self, item.oid + '^!', hide_expr=True)
 
 
 # pylint: disable=too-many-ancestors

--- a/cola/sequenceeditor.py
+++ b/cola/sequenceeditor.py
@@ -227,6 +227,9 @@ class Editor(QtWidgets.QWidget):
         insns = core.read(self.filename)
         self.parse_sequencer_instructions(insns)
 
+        # Assume that the tree is filled at this point.
+        Thread(target=self.poll_touched_paths_main).start()
+
     # signal callbacks
     def commits_selected(self, commits):
         self.extdiff_button.setEnabled(bool(commits))
@@ -317,8 +320,6 @@ class Editor(QtWidgets.QWidget):
         self.tree.decorate(self.tree.items())
         self.tree.refit()
         self.tree.select_first()
-
-        Thread(target=self.poll_touched_paths_main).start()
 
     # actions
     def cancel(self):

--- a/cola/sequenceeditor.py
+++ b/cola/sequenceeditor.py
@@ -241,12 +241,6 @@ class Editor(QtWidgets.QWidget):
     def commits_selected(self, commits):
         self.extdiff_button.setEnabled(bool(commits))
 
-    def poll_touched_paths_main(self):
-        for item in self.tree.items():
-            if not self.working:
-                return
-            self.paths_touched_by_oid(item.oid)
-
     def remark_toggled_for_files(self, remark, filenames):
         filenames = set(filenames)
 
@@ -277,6 +271,12 @@ class Editor(QtWidgets.QWidget):
         self.oid_to_paths[oid] = paths
 
         return paths
+
+    def poll_touched_paths_main(self):
+        for item in self.tree.items():
+            if not self.working:
+                return
+            self.paths_touched_by_oid(item.oid)
 
     def parse_sequencer_instructions(self, insns):
         idx = 1

--- a/cola/sequenceeditor.py
+++ b/cola/sequenceeditor.py
@@ -241,17 +241,6 @@ class Editor(QtWidgets.QWidget):
     def commits_selected(self, commits):
         self.extdiff_button.setEnabled(bool(commits))
 
-    def paths_touched_by_oid(self, oid):
-        try:
-            return self.oid_to_paths[oid]
-        except KeyError:
-            pass
-
-        paths = changed_files(self.context, oid)
-        self.oid_to_paths[oid] = paths
-
-        return paths
-
     def poll_touched_paths_main(self):
         for item in self.tree.items():
             if not self.working:
@@ -277,6 +266,18 @@ class Editor(QtWidgets.QWidget):
         self.tree.toggle_remark_of_items(remark, touching_items)
 
     # helpers
+
+    def paths_touched_by_oid(self, oid):
+        try:
+            return self.oid_to_paths[oid]
+        except KeyError:
+            pass
+
+        paths = changed_files(self.context, oid)
+        self.oid_to_paths[oid] = paths
+
+        return paths
+
     def parse_sequencer_instructions(self, insns):
         idx = 1
         re_comment_char = re.escape(self.comment_char)

--- a/cola/sequenceeditor.py
+++ b/cola/sequenceeditor.py
@@ -160,7 +160,7 @@ class MainWindow(standard.MainWindow):
 
         self.status = status
 
-        super(MainWindow, self).closeEvent(event)
+        super().closeEvent(event)
 
 
 class Editor(QtWidgets.QWidget):

--- a/cola/sequenceeditor.py
+++ b/cola/sequenceeditor.py
@@ -209,9 +209,9 @@ class Editor(QtWidgets.QWidget):
 
         # `git` calls are too expensive.
         # When user toggles a remark of all commits touching selected paths
-        # for a first time, the GUI freezes for a while on a big enough
-        # sequence.
-        # So, a cache is used (commit ID to paths tuple).
+        # the GUI freezes for a while on a big enough sequence.
+        # So, a cache is used (commit ID to paths tuple) to avoid freezing
+        # during consequent work.
         self.oid_to_paths = {}
         # A thread fills this cache in background to reduce the first
         # run freezing.

--- a/cola/sequenceeditor.py
+++ b/cola/sequenceeditor.py
@@ -531,11 +531,9 @@ class RebaseTreeWidget(standard.DraggableTreeWidget):
         menu.addAction(self.toggle_enabled_action)
         menu.addSeparator()
         menu.addAction(self.copy_oid_action)
-        if len(items) > 1:
-            self.copy_oid_action.setDisabled(True)
+        self.copy_oid_action.setDisabled(len(items) > 1)
         menu.addAction(self.external_diff_action)
-        if len(items) > 1:
-            self.external_diff_action.setDisabled(True)
+        self.external_diff_action.setDisabled(len(items) > 1)
         menu.exec_(self.mapToGlobal(event.pos()))
 
 

--- a/cola/sequenceeditor.py
+++ b/cola/sequenceeditor.py
@@ -211,9 +211,11 @@ class Editor(QtWidgets.QWidget):
         # for a first time, the GUI freezes for a while on a big enough
         # sequence.
         # So, a cache is used (commit ID to paths tuple).
+        self.oid_to_paths = {}
         # A thread fills this cache in background to reduce the first
         # run freezing.
-        self.oid_to_paths = {}
+        # This flag stops it.
+        self.working = True
 
         qtutils.connect_button(self.rebase_button, self.rebase)
         qtutils.connect_button(self.extdiff_button, self.external_diff)
@@ -328,7 +330,6 @@ class Editor(QtWidgets.QWidget):
         self.tree.refit()
         self.tree.select_first()
 
-        self.working = True
         Thread(target=self.poll_touched_paths_main).start()
 
     # actions

--- a/cola/sequenceeditor.py
+++ b/cola/sequenceeditor.py
@@ -257,8 +257,8 @@ class Editor(QtWidgets.QWidget):
     def poll_touched_paths_main(self):
         for item in self.tree.items():
             if not self.working:
-                # TODO: This does not work if user kills the window using a
-                #       cross (X) button on the window title.
+                # FIXME: This does not work if user kills the window using a
+                #        cross (X) button on the window title.
                 return
             self.paths_touched_by_oid(item.oid)
 

--- a/cola/sequenceeditor.py
+++ b/cola/sequenceeditor.py
@@ -18,6 +18,7 @@ from cola import hotkeys
 from cola import icons
 from cola import qtutils
 from cola import utils
+from cola.gitcmds import changed_files
 from cola.i18n import N_
 from cola.models import dag
 from cola.models import prefs
@@ -206,7 +207,7 @@ class Editor(QtWidgets.QWidget):
         self.filewidget.files_selected.connect(self.diff.files_selected)
         self.filewidget.remark_toggled.connect(self.remark_toggled_for_files)
 
-        # `git.show` is too expensive.
+        # `git` calls are too expensive.
         # When user toggles a remark of all commits touching selected paths
         # for a first time, the GUI freezes for a while on a big enough
         # sequence.
@@ -236,20 +237,7 @@ class Editor(QtWidgets.QWidget):
         except KeyError:
             pass
 
-        status, out, _ = self.context.git.show(
-            oid, z=True, numstat=True, oneline=True, no_renames=True
-        )
-
-        if status != 0:
-            return ()
-
-        paths = [f for f in out.rstrip('\0').split('\0') if f]
-        if paths:
-            # Skip over the summary on the first line.
-            paths = paths[1:]
-
-        # Drop numbers. Only path is needed.
-        paths = tuple(f.split()[-1] for f in paths)
+        paths = changed_files(self.context, oid)
         self.oid_to_paths[oid] = paths
 
         return paths

--- a/cola/sequenceeditor.py
+++ b/cola/sequenceeditor.py
@@ -334,8 +334,14 @@ class Editor(QtWidgets.QWidget):
         self.tree.refit()
         self.tree.select_first()
 
-    def save(self, string):
+    def save(self, string=None):
         """Save the instruction sheet"""
+
+        if string is None:
+            lines = [item.value() for item in self.tree.items()]
+            # sequencer instructions
+            string = '\n'.join(lines) + '\n'
+
         try:
             core.write(self.filename, string)
             status = 0
@@ -356,9 +362,7 @@ class Editor(QtWidgets.QWidget):
         self.exit.emit(status)
 
     def rebase(self):
-        lines = [item.value() for item in self.tree.items()]
-        sequencer_instructions = '\n'.join(lines) + '\n'
-        status = self.save(sequencer_instructions)
+        status = self.save()
         self.status = status
         self.exit.emit(status)
 

--- a/cola/widgets/filelist.py
+++ b/cola/widgets/filelist.py
@@ -46,9 +46,10 @@ class FileWidget(TreeWidget):
                 qtutils.add_action(
                     self,
                     r,
-                    lambda remark = r: self.toggle_remark(remark),
-                    hotkeys.hotkey(Qt.CTRL | getattr(Qt, "Key_" + r))
-                ) for r in map(str, range(10))
+                    lambda remark=r: self.toggle_remark(remark),
+                    hotkeys.hotkey(Qt.CTRL | getattr(Qt, 'Key_' + r)),
+                )
+                for r in map(str, range(10))
             )
         else:
             self.toggle_remark_actions = tuple()
@@ -124,9 +125,7 @@ class FileWidget(TreeWidget):
         menu.addAction(self.launch_difftool_action)
         menu.addAction(self.launch_editor_action)
         if self.toggle_remark_actions:
-            menu_toggle_remark = menu.addMenu(
-                N_('Toggle remark of touching commits')
-            )
+            menu_toggle_remark = menu.addMenu(N_('Toggle remark of touching commits'))
             tuple(map(menu_toggle_remark.addAction, self.toggle_remark_actions))
         menu.exec_(self.mapToGlobal(event.pos()))
 


### PR DESCRIPTION
When rebasing big enough branches (100+ commits), it's a challenge to
join related commits into groups and to move the groups.
This PR adds a feature into rebase sequence editor that allows to add
simple remarks (digits [0-9]) to commits to visually highlight them.
A remark can be added to single commit or to all commits those touch a file.

Highlighting of commits touching a file requires expensive calls to
underlying `git`.
So, a cache for intermediate results is provided.
The cache is filled in background by a `Thread` to reduce first use GUI freeze
experience.

Russian translation for new menu items is also added.
But, it's is added manually because I have troubles with installing
the `garden` tool.
