### PR TITLE
Add AppStream developer name

### DIFF
--- a/share/metainfo/git-cola.appdata.xml
+++ b/share/metainfo/git-cola.appdata.xml
@@ -4,6 +4,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <name>Git Cola</name>
+  <developer_name>David Aguilar</developer_name>
   <summary>Sleek and powerful Git GUI</summary>
   <description>
     <p>

--- a/share/metainfo/git-dag.appdata.xml
+++ b/share/metainfo/git-dag.appdata.xml
@@ -4,6 +4,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <name>Git DAG</name>
+  <developer_name>David Aguilar</developer_name>
   <description>
     <p>
       git-dag is an advanced git DAG visualizer


### PR DESCRIPTION
https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name is now mandatory so all the builds at https://github.com/flathub/com.github.git_cola.git-cola/pulls currently fail.