### PR TITLE
resources: search for commands sibling to the running script

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,12 @@ Usability, bells and whistles
 * The `cola.refreshonfocus` and `cola.inotify` configuration settings are now accessible
   from the `git cola config` settings dialog.
 
+Fixes
+-----
+* The `git-cola-sequence-editor` Rebase Editor will now be found correctly
+  in more situatios on Windows.
+  (`#1385 <https://github.com/git-cola/git-cola/issues/1385>`_)
+
 
 .. _v4.6.1:
 

--- a/cola/resources.py
+++ b/cola/resources.py
@@ -1,6 +1,5 @@
 """Functions for finding cola resources"""
 import os
-from os.path import dirname
 import webbrowser
 
 from . import core
@@ -17,15 +16,17 @@ if _package.endswith(os.path.join('site-packages', 'cola')):
     # Unix release tree
     # __file__ = '$prefix/lib/pythonX.Y/site-packages/cola/__file__.py'
     # _package = '$prefix/lib/pythonX.Y/site-packages/cola'
-    _prefix = dirname(dirname(dirname(dirname(_package))))
+    _prefix = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.dirname(_package)))
+    )
 elif _package.endswith(os.path.join('pkgs', 'cola')):
     # Windows release tree
     # __file__ = $installdir/pkgs/cola
-    _prefix = dirname(dirname(_package))
+    _prefix = os.path.dirname(os.path.dirname(_package))
 else:
     # this is the source tree
     # __file__ = '$prefix/cola/__file__.py'
-    _prefix = dirname(_package)
+    _prefix = os.path.dirname(_package)
 
 
 def get_prefix():


### PR DESCRIPTION
When Cola is installed directly into C:\Python3.12 on Windows
then the correct path to git-cola-sequence-editor was not being used.
    
Look in the same director as the current sprint when attempting to
find git-cola-sequence-editor. This makes cola rely less on the
physical structure of the install tree by checking for locations
relative to itself.
    
Closes: #1385
