### PR TITLE
widgets: add an "Unstage" option to the context menu for unmerged files

### DIFF
--- a/cola/widgets/status.py
+++ b/cola/widgets/status.py
@@ -872,6 +872,11 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
         )
         action.setShortcut(hotkeys.STAGE_SELECTION)
 
+        menu.addAction(
+            icons.remove(),
+            N_('Unstage Selected'),
+            cmds.run(cmds.Unstage, context, self.unstaged()),
+        )
         menu.addAction(self.launch_editor_action)
         menu.addAction(self.view_history_action)
         menu.addAction(self.view_blame_action)


### PR DESCRIPTION
When merging patches, if you want to cache only a partial change for a file that has already been manually resolved on merge, in previous versions you had to stage the entire file, then find it among the other already staged files. With "Unstage" you can easily find the file in "Modified" then specifically stage just the line or hunk to be patched.