### PR TITLE
widgets: avoid some crashes when cwd is not found

### DIFF
--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -1106,7 +1106,10 @@ class MainView(standard.MainWindow):
         is_applying_patch = self.model.is_applying_patch
         is_cherry_picking = self.model.is_rebasing
 
-        curdir = core.getcwd()
+        try:
+            curdir = core.getcwd()
+        except FileNotFoundError:
+            return
         msg = N_('Repository: %s') % curdir
         msg += '\n'
         msg += N_('Branch: %s') % curbranch

--- a/cola/widgets/standard.py
+++ b/cola/widgets/standard.py
@@ -180,7 +180,12 @@ class MainWindowMixin(WidgetMixin):
             else:
                 settings = context.settings
                 settings.load()
-            settings.add_recent(core.getcwd(), prefs.maxrecent(context))
+            try:
+                cwd = core.getcwd()
+            except FileNotFoundError:
+                pass
+            else:
+                settings.add_recent(cwd, prefs.maxrecent(context))
         return WidgetMixin.save_settings(self, settings=settings)
 
     def apply_state(self, state):


### PR DESCRIPTION
This is an untested monkey patch to possibly fix some crashes that occur when cola's current working directory gets deleted from underneath it.

I see this every now and then, and these two are the first ones that I managed to reproduce immediately when attempting to reproduce. They might not be the best ways to fix the issues (or fix them in the first place), but if nothing else, they flag where the crashes occurred for me.