### PR TITLE
main: fix incorrect proxy detection result in KDE

### DIFF
--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -720,6 +720,6 @@ def autodetect_proxy_kde(kreadconfig, scheme):
     ]
     status, out, err = core.run_command(cmd)
     if status == 0:
-        proxy = out.strip()
+        proxy = out.strip().replace(' ', ':')
         return proxy
     return None


### PR DESCRIPTION
The output of the `kreadconfig*` command regarding the kioslaverc/Proxy Settings/http(s)Proxy
configuration is in the following format:

```
HOST PORT
```

which is not the expected format of the value of the `proxy` variable:

```
HOST:PORT
```

Do a simple text replacement to fix it.

Fixes #1450.

Signed-off-by: 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com>