### PR TITLE
main: fix incorrect proxy detection in KDE when proxy is disabled globally

### DIFF
--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -716,10 +716,22 @@ def autodetect_proxy_kde(kreadconfig, scheme):
         '--group',
         'Proxy Settings',
         '--key',
-        f'{scheme}Proxy',
+        f'ProxyType',
     ]
     status, out, err = core.run_command(cmd)
-    if status == 0:
-        proxy = out.strip().replace(' ', ':')
-        return proxy
+    if status == 0 and out.strip() == '1':
+        cmd = [
+            kreadconfig,
+            '--file',
+            'kioslaverc',
+            '--group',
+            'Proxy Settings',
+            '--key',
+            f'{scheme}Proxy',
+        ]
+        status, out, err = core.run_command(cmd)
+        if status == 0:
+            proxy = out.strip().replace(' ', ':')
+            return proxy
+        return None
     return None

--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -716,7 +716,7 @@ def autodetect_proxy_kde(kreadconfig, scheme):
         '--group',
         'Proxy Settings',
         '--key',
-        f'ProxyType',
+        'ProxyType',
     ]
     status, out, err = core.run_command(cmd)
     if status == 0 and out.strip() == '1':


### PR DESCRIPTION
When the proxy is disabled globally in the System Settings in KDE the proxy host and address settings may still be preserved in the kioslaverc/Proxy Settings/*Proxy configuration settings.

Check the kioslaverc/Proxy Settings/httpProxy setting's value and return None when it is not set to "1"(meaning that the "Use manually specified proxy configuration" mode isn't selected).

Fixes #1452.