### PR TITLE
Support VSCode and Cursor for opening at specific line number

### DIFF
--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -1588,6 +1588,8 @@ class Edit(ContextCommand):
                 '*textpad*': [f'{filename}({self.line_number},0)'],
                 '*notepad++*': ['-n%s' % self.line_number, filename],
                 '*subl*': [f'{filename}:{self.line_number}'],
+                '*code*': [f'--goto {filename}:{self.line_number}'],
+                '*cursor*': [f'--goto {filename}:{self.line_number}'],
             }
 
             use_line_numbers = False


### PR DESCRIPTION
[VSCode](https://code.visualstudio.com/docs/configure/command-line) and Cursor (fork of VSCode) use the following flag to open a file at a specific line number:

```
-g or --goto	When used with file:line{:character}, opens a file at a specific line and optional character position
```

I didn't test git-cola with these changes, I just tested I could open files ok as per the docs for those editors.

Only thing I'm not sure about, is the use of wildcards around the names of the editors. I did this to match how it was done for other editors. But I'm concerned this might match potentially other lesser well known editors, particularly any that would have "code" in their name. Can we drop the wildcards?