### PR TITLE
diff: clarify revert target in revert lines prompt

### DIFF
--- a/cola/widgets/diff.py
+++ b/cola/widgets/diff.py
@@ -1345,7 +1345,7 @@ class DiffEditor(DiffTextEdit):
                     'This operation drops uncommitted changes.\n'
                     'These changes cannot be recovered.'
                 ),
-                N_('Revert the uncommitted changes?'),
+                N_('Revert uncommitted changes from the selected lines?'),
                 ok_text,
                 default=True,
                 icon=icons.undo(),


### PR DESCRIPTION
When reverting changes for selected lines, I find myself often wanting to make **sure** that I'm reverting only the lines, and not all changes in the selected file let alone all files. This information is available in the prompt title, but it's not a place where I first look for it, if ever (well I do now because some time back I learned to look there). This adds it to the prompt question so it's more prominently available.

Untested, and I suppose translation files will need updating as well. Let me know if that's needed (currently on the GH web UI.)