### PR TITLE
metadata: Tidy up

### DIFF
--- a/share/metainfo/git-cola.appdata.xml
+++ b/share/metainfo/git-cola.appdata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
+<component type="desktop-application">
   <id>git-cola.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
@@ -19,6 +19,8 @@
     </screenshot>
   </screenshots>
   <url type="homepage">https://git-cola.github.io/</url>
+  <url type="bugtracker">https://github.com/git-cola/git-cola/issues</url>
+  <url type="vcs-browser">https://github.com/git-cola/git-cola/issues</url>
   <releases>
     <release version="4.17.0" date="2025-12-30" />
     <release version="4.16.1" date="2025-11-12" />


### PR DESCRIPTION
- Use desktop-application as the component type
- Add bugtracker and vcs-browser URLs

More information: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines