### PR TITLE
Add optional preference to remember upstream checkbox in Push dialog

### DIFF
--- a/cola/models/prefs.py
+++ b/cola/models/prefs.py
@@ -43,6 +43,7 @@ ICON_THEME = 'cola.icontheme'
 INOTIFY = 'cola.inotify'
 INOTIFY_DELAY = 'cola.inotifydelay'
 NOTIFY_ON_PUSH = 'cola.notifyonpush'
+REMEMBER_PUSH_TRACKING_CHECKBOX = 'cola.rememberpushtrackingcheckbox'
 LINEBREAK = 'cola.linebreak'
 LOAD_COMMITMSG_COUNT = 'cola.loadcommitmsgcount'
 LOGDATE = 'cola.logdate'
@@ -164,6 +165,7 @@ class Defaults:
     inotify_delay = 888
     load_commitmsg_count = 10
     notifyonpush = False
+    remember_push_tracking_checkbox = False
     linebreak = True
     maxrecent = 8
     mergetool = difftool
@@ -358,6 +360,12 @@ def notify_on_push(context) -> bool:
     """Return whether to notify upon push or not"""
     default = Defaults.notifyonpush
     return context.cfg.get(NOTIFY_ON_PUSH, default=default)
+
+
+def remember_push_tracking_checkbox(context) -> bool:
+    """Return whether to remember the Push dialog tracking checkbox state"""
+    default = Defaults.remember_push_tracking_checkbox
+    return context.cfg.get(REMEMBER_PUSH_TRACKING_CHECKBOX, default=default)
 
 
 def linebreak(context) -> bool:

--- a/cola/widgets/prefs.py
+++ b/cola/widgets/prefs.py
@@ -323,6 +323,10 @@ class SettingsFormWidget(FormWidget):
         self.resize_browser_columns = qtutils.checkbox(checked=False)
         tooltip = N_('Emit notifications when commits are pushed.')
         self.notifyonpush = qtutils.checkbox(checked=False, tooltip=tooltip)
+        tooltip = N_('Remember the last "Set upstream" checkbox value in Push dialog')
+        self.remember_push_tracking_checkbox = qtutils.checkbox(
+            checked=False, tooltip=tooltip
+        )
 
         tooltip = N_('Use "aspell" as the spelling dictionary source')
         self.aspell_enabled = qtutils.checkbox(tooltip=tooltip)
@@ -369,6 +373,10 @@ class SettingsFormWidget(FormWidget):
             N_('Check Published Commits when Amending'), self.check_published_commits
         )
         self.add_row(N_('Notify on Push'), self.notifyonpush)
+        self.add_row(
+            N_('Remember "Set upstream tracking" checkbox in Push dialog'),
+            self.remember_push_tracking_checkbox,
+        )
         self.add_row(N_('Verbosity Level'), self.verbosity)
 
         self.add_row('', QtWidgets.QLabel())
@@ -426,6 +434,10 @@ class SettingsFormWidget(FormWidget):
             prefs.SPELL_CHECK: (self.check_spelling, Defaults.spellcheck),
             prefs.MOUSE_ZOOM: (self.mouse_zoom, Defaults.mouse_zoom),
             prefs.NOTIFY_ON_PUSH: (self.notifyonpush, Defaults.notifyonpush),
+            prefs.REMEMBER_PUSH_TRACKING_CHECKBOX: (
+                self.remember_push_tracking_checkbox,
+                Defaults.remember_push_tracking_checkbox,
+            ),
             prefs.VERBOSITY: (self.verbosity, Defaults.verbosity),
         })
 

--- a/cola/widgets/remote.py
+++ b/cola/widgets/remote.py
@@ -802,6 +802,7 @@ class RemoteActionDialog(standard.Dialog):
         self.progress.setMaximumHeight(
             self.action_button.height() - defs.small_margin * 2
         )
+        self.remember_action_state()
 
         # Use a thread to update in the background
         task = ActionTask(model_action, remote, kwargs)
@@ -850,6 +851,10 @@ class RemoteActionDialog(standard.Dialog):
             message += N_('Have you rebased/pulled lately?')
 
         Interaction.critical(self.windowTitle(), message=message, details=details)
+
+    def remember_action_state(self):
+        """Persist any action-specific settings prior to executing an action"""
+        return None
 
     def export_state(self):
         """Export persistent settings"""
@@ -931,6 +936,8 @@ class Fetch(RemoteActionDialog):
 class Push(RemoteActionDialog):
     """Push to remote repositories"""
 
+    UPSTREAM_STATE_KEY = 'upstream'
+
     def __init__(self, context, parent=None):
         super().__init__(context, PUSH, N_('Push'), parent=parent, icon=icons.push())
 
@@ -940,6 +947,8 @@ class Push(RemoteActionDialog):
         state['force'] = get(self.force_checkbox)
         state['prompt'] = get(self.prompt_checkbox)
         state['tags'] = get(self.tags_checkbox)
+        if prefs.remember_push_tracking_checkbox(self.context):
+            state['upstream'] = get(self.upstream_checkbox)
         return state
 
     def apply_state(self, state):
@@ -954,7 +963,27 @@ class Push(RemoteActionDialog):
         # Restore the "tags" checkbox
         tags = bool(state.get('tags', False))
         self.tags_checkbox.setChecked(tags)
+        if prefs.remember_push_tracking_checkbox(self.context):
+            settings = getattr(self.context, 'settings', None)
+            upstream = None
+            if settings is not None:
+                upstream = settings.get_value(self.name(), self.UPSTREAM_STATE_KEY)
+            if upstream is None and self.UPSTREAM_STATE_KEY in state:
+                upstream = state.get(self.UPSTREAM_STATE_KEY, False)
+            if upstream is not None:
+                self.upstream_checkbox.setChecked(bool(upstream))
         return result
+
+    def remember_action_state(self):
+        """Persist push-specific settings after user confirmation and before push"""
+        if prefs.remember_push_tracking_checkbox(self.context):
+            settings = getattr(self.context, 'settings', None)
+            if settings is not None:
+                settings.set_value(
+                    self.name(),
+                    self.UPSTREAM_STATE_KEY,
+                    get(self.upstream_checkbox),
+                )
 
 
 class Pull(RemoteActionDialog):

--- a/test/prefs_test.py
+++ b/test/prefs_test.py
@@ -1,0 +1,18 @@
+from cola.models import prefs
+
+from . import helper
+from .helper import app_context
+
+
+# prevent unused imports lint errors.
+assert app_context is not None
+
+
+def test_remember_push_tracking_checkbox_default(app_context):
+    assert prefs.remember_push_tracking_checkbox(app_context) is False
+
+
+def test_remember_push_tracking_checkbox_enabled(app_context):
+    helper.run_git('config', 'cola.rememberpushtrackingcheckbox', 'true')
+    app_context.cfg.reset()
+    assert prefs.remember_push_tracking_checkbox(app_context) is True

--- a/test/remote_test.py
+++ b/test/remote_test.py
@@ -1,0 +1,122 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from cola.widgets import remote
+
+
+class FakeCheckbox:
+    def __init__(self, checked):
+        self.checked = checked
+
+    def isChecked(self):
+        return self.checked
+
+    def setChecked(self, value):
+        self.checked = value
+
+
+class DummyPushDialog:
+    def __init__(self):
+        self.UPSTREAM_STATE_KEY = 'upstream'
+        self.context = Mock()
+        self.context.settings = Mock()
+        self.context.settings.get_value.return_value = None
+        self.force_checkbox = FakeCheckbox(False)
+        self.prompt_checkbox = FakeCheckbox(True)
+        self.tags_checkbox = FakeCheckbox(False)
+        self.upstream_checkbox = FakeCheckbox(False)
+        self.name = Mock(return_value='push')
+
+
+def test_push_export_state_remembers_upstream_when_enabled():
+    dialog = DummyPushDialog()
+    dialog.upstream_checkbox.setChecked(True)
+    with (
+        patch.object(remote.RemoteActionDialog, 'export_state', return_value={}),
+        patch(
+            'cola.widgets.remote.prefs.remember_push_tracking_checkbox',
+            return_value=True,
+        ),
+    ):
+        state = remote.Push.export_state(dialog)
+    assert state['upstream'] is True
+
+
+def test_push_export_state_does_not_remember_upstream_when_disabled():
+    dialog = DummyPushDialog()
+    dialog.upstream_checkbox.setChecked(True)
+    with (
+        patch.object(remote.RemoteActionDialog, 'export_state', return_value={}),
+        patch(
+            'cola.widgets.remote.prefs.remember_push_tracking_checkbox',
+            return_value=False,
+        ),
+    ):
+        state = remote.Push.export_state(dialog)
+    assert 'upstream' not in state
+
+
+def test_push_apply_state_restores_upstream_when_enabled():
+    dialog = DummyPushDialog()
+    dialog.context.settings.get_value.return_value = None
+    with (
+        patch.object(remote.RemoteActionDialog, 'apply_state', return_value=True),
+        patch(
+            'cola.widgets.remote.prefs.remember_push_tracking_checkbox',
+            return_value=True,
+        ),
+    ):
+        result = remote.Push.apply_state(dialog, {'upstream': True})
+    assert result is True
+    assert dialog.upstream_checkbox.isChecked() is True
+
+
+def test_push_apply_state_prefers_settings_value_when_enabled():
+    dialog = DummyPushDialog()
+    dialog.context.settings.get_value.return_value = True
+    with (
+        patch.object(remote.RemoteActionDialog, 'apply_state', return_value=True),
+        patch(
+            'cola.widgets.remote.prefs.remember_push_tracking_checkbox',
+            return_value=True,
+        ),
+    ):
+        result = remote.Push.apply_state(dialog, {'upstream': False})
+    assert result is True
+    assert dialog.upstream_checkbox.isChecked() is True
+
+
+def test_push_apply_state_ignores_upstream_when_disabled():
+    dialog = DummyPushDialog()
+    dialog.upstream_checkbox.setChecked(False)
+    with (
+        patch.object(remote.RemoteActionDialog, 'apply_state', return_value=True),
+        patch(
+            'cola.widgets.remote.prefs.remember_push_tracking_checkbox',
+            return_value=False,
+        ),
+    ):
+        result = remote.Push.apply_state(dialog, {'upstream': True})
+    assert result is True
+    assert dialog.upstream_checkbox.isChecked() is False
+
+
+def test_push_remember_action_state_saves_when_enabled():
+    dialog = DummyPushDialog()
+    dialog.upstream_checkbox.setChecked(True)
+    with patch(
+        'cola.widgets.remote.prefs.remember_push_tracking_checkbox',
+        return_value=True,
+    ):
+        remote.Push.remember_action_state(dialog)
+    dialog.context.settings.set_value.assert_called_once_with('push', 'upstream', True)
+
+
+def test_push_remember_action_state_does_nothing_when_disabled():
+    dialog = DummyPushDialog()
+    with patch(
+        'cola.widgets.remote.prefs.remember_push_tracking_checkbox',
+        return_value=False,
+    ):
+        remote.Push.remember_action_state(dialog)
+    dialog.context.settings.set_value.assert_not_called()


### PR DESCRIPTION
Fixes issue #1561

This PR adds an optional preference that allows Git Cola to remember the
"Set upstream tracking" checkbox state in the Push dialog.

Behavior:
- Default behavior remains unchanged.
- When the preference is enabled, Git Cola remembers the last used
  upstream checkbox state and restores it when reopening the Push dialog.

Changes:
- Added new preference key in prefs model
- Added UI toggle in Preferences
- Implemented push dialog logic to persist and restore checkbox state
- Added tests for prefs and remote push behavior

Tests:
11 tests passing locally.

p.s. 

These are some of my first issues. If it needs anything else, please let me know. Thanks! 