### PR TITLE
models: reload GIT_COLA_MSG on each refresh cycle

### DIFF
--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -114,6 +114,8 @@ class MainModel(QtCore.QObject):
         self.commitmsg = ''  # current commit message
         self._auto_commitmsg = ''  # e.g. .git/MERGE_MSG
         self._prev_commitmsg = ''  # saved here when clobbered by .git/MERGE_MSG
+        self._cola_commitmsg = ''  # last content loaded from .git/GIT_COLA_MSG
+        self._cola_commitmsg_mtime: float | None = None  # .git/GIT_COLA_MSG mtime on last read
         self.object_format = 'sha1'  # repository object format variables.
         self.oid_len = git.OID_LENGTH_SHA1
         self.empty_tree_oid = git.EMPTY_TREE_SHA1
@@ -447,6 +449,36 @@ class MainModel(QtCore.QObject):
         elif self._auto_commitmsg and self._auto_commitmsg == self.commitmsg:
             self._auto_commitmsg = ''
             self.set_commitmsg(self._prev_commitmsg)
+
+        elif not self._auto_commitmsg:
+            self._update_cola_commitmsg()
+
+    def _update_cola_commitmsg(self) -> None:
+        """Reload the commit message when .git/GIT_COLA_MSG changes on disk
+
+        Updates the commit message only when the user has not modified the
+        previously loaded content, so manual edits are never clobbered.
+        """
+        path = gitcmds.commit_message_path(self.context)
+        if not path:
+            self._cola_commitmsg_mtime = None
+            return
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            return
+        if mtime == self._cola_commitmsg_mtime:
+            return
+        msg = core.read(path)
+        self._cola_commitmsg_mtime = mtime
+        if msg != self._cola_commitmsg:
+            # needs stripping, as the empty commitmsg is saved as \n during close but initialized as ''
+            if (
+                not self.commitmsg.strip()
+                or self.commitmsg.strip() == self._cola_commitmsg.strip()
+            ):
+                self.set_commitmsg(msg)
+            self._cola_commitmsg = msg
 
     def update_submodules_list(self) -> None:
         self.submodules_list = gitcmds.list_submodule(self.context)

--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -222,7 +222,6 @@ class MainModel(QtCore.QObject):
 
     def set_commitmsg(self, msg: str, notify: bool = True) -> None:
         self.commitmsg = msg
-        self._auto_commitmsg = ''
         if notify:
             self.commit_message_changed.emit(msg)
 

--- a/docs/git-cola.rst
+++ b/docs/git-cola.rst
@@ -445,6 +445,13 @@ The `Ctrl+i` keyboard shortcut adds a standard "Signed-off-by: " line,
 and `Ctrl+Enter` creates a new commit using the commit message and
 staged content.
 
+The commit message is saved to `.git/GIT_COLA_MSG` when `git cola` closes and
+restored from it on the next startup. In addition this file is checked on updates (Ctrl+R)
+and if modified by any tool and not conflicting with manual changes the commit
+message will be updated on the next refresh.
+This feature is useful as it allows scripts or agents to prepare a message for manual
+review.
+
 Sign Off
 --------
 

--- a/test/main_model_test.py
+++ b/test/main_model_test.py
@@ -295,6 +295,30 @@ def test_cola_msg_suppressed_during_merge(app_context):
     os.unlink(merge_path)
 
 
+def test_cola_msg_loaded_after_merge_clears(app_context):
+    """GIT_COLA_MSG is loaded once the merge auto-message cycle completes
+
+    Sequence:
+      - merge sets auto-msg
+      - merge file removed
+      - _prev_commitmsg (empty) restored
+      - next refresh loads GIT_COLA_MSG replacing empty commitmsg."""
+    msg_path = app_context.git.git_path('GIT_COLA_MSG')
+    merge_path = app_context.git.git_path('MERGE_MSG')
+    helper.write_file(msg_path, 'agent message\n')
+    helper.write_file(merge_path, 'merge commit message\n')
+    # First refresh: merge msg is picked up, GIT_COLA_MSG ignored
+    app_context.model._update_commitmsg()
+    assert app_context.model.commitmsg == 'merge commit message'
+    # Merge completes: MERGE_MSG file disappears
+    os.unlink(merge_path)
+    # Second refresh: clears _auto_commitmsg and restore _prev_commitmsg ('')
+    app_context.model._update_commitmsg()
+    # Third refresh: GIT_COLA_MSG is now loaded because commitmsg is empty
+    app_context.model._update_commitmsg()
+    assert app_context.model.commitmsg == 'agent message\n'
+
+
 def test_run_remote_action(mock_context):
     """Test running a remote action"""
     mock_context.cfg.get = Mock(return_value=True)

--- a/test/main_model_test.py
+++ b/test/main_model_test.py
@@ -258,6 +258,43 @@ def test_remote_args_rebase_only(mock_context):
     assert 'ff_only' not in kwargs
 
 
+def test_cola_msg_updated_when_not_manually_edited(app_context):
+    """GIT_COLA_MSG is loaded into the commit message on refresh
+
+    GIT_COLA_MSG update is applied when the user has not edited the message"""
+    msg_path = app_context.git.git_path('GIT_COLA_MSG')
+    helper.write_file(msg_path, 'first message\n')
+    app_context.model._update_commitmsg()
+    assert app_context.model.commitmsg == 'first message\n'
+    helper.write_file(msg_path, 'updated message\n')
+    os.utime(msg_path, (os.path.getmtime(msg_path) + 1,) * 2)  # ensure mtime differs on coarse-grained filesystems
+    app_context.model._update_commitmsg()
+    assert app_context.model.commitmsg == 'updated message\n'
+
+
+def test_cola_msg_not_overwritten_when_user_edited(app_context):
+    """User's manual edits are preserved when GIT_COLA_MSG is updated externally"""
+    msg_path = app_context.git.git_path('GIT_COLA_MSG')
+    helper.write_file(msg_path, 'first message\n')
+    app_context.model._update_commitmsg()
+    app_context.model.commitmsg = 'user message'
+    helper.write_file(msg_path, 'second message\n')
+    os.utime(msg_path, (os.path.getmtime(msg_path) + 1,) * 2)  # ensure mtime differs on coarse-grained filesystems
+    app_context.model._update_commitmsg()
+    assert app_context.model.commitmsg == 'user message'
+
+
+def test_cola_msg_suppressed_during_merge(app_context):
+    """GIT_COLA_MSG is not loaded while a merge message is active"""
+    msg_path = app_context.git.git_path('GIT_COLA_MSG')
+    merge_path = app_context.git.git_path('MERGE_MSG')
+    helper.write_file(msg_path, 'agent message\n')
+    helper.write_file(merge_path, 'merge commit message\n')
+    app_context.model._update_commitmsg()
+    assert app_context.model.commitmsg == 'merge commit message'
+    os.unlink(merge_path)
+
+
 def test_run_remote_action(mock_context):
     """Test running a remote action"""
     mock_context.cfg.get = Mock(return_value=True)


### PR DESCRIPTION
As you think, this is a good idea, I went ahead and tried to add it. I used
the help of such an agent, but reviewed and adapted it carefully. I tried to
keep it as non-invasive as possible. If I am going into the wrong direction,
please tell me.

## Summary

- Add mtime-based detection in `_update_commitmsg`: on each refresh,
  `_update_cola_msg` reads the file when its mtime has changed and updates
  the commit message editor – unless the user has manually edited the field
  since the last auto-load

## Use case

External tools (coding agents) or scripts can write a suggested commit
message to `.git/GIT_COLA_MSG` at any time and have it appear in the open
editor on the next refresh (`Ctrl+R`)
