### PR TITLE
gravatar: Scale local fallback pixmap to expected size

### DIFF
--- a/cola/gravatar.py
+++ b/cola/gravatar.py
@@ -102,6 +102,7 @@ class GravatarLabel(QtWidgets.QLabel):
         if self._default_pixmap_bytes is None:
             xres = self.imgsize
             pixmap = icons.cola().pixmap(xres)
+            pixmap = pixmap.scaled(xres, xres)
             byte_array = QtCore.QByteArray()
             buf = QtCore.QBuffer(byte_array)
             buf.open(QtCore.QIODevice.WriteOnly)


### PR DESCRIPTION
icons.cola().pixmap(xres) uses device pixel ratio to size th epixmap. On high resolution screens this will cause pixmap to be oversized, as it's stored to a png buffer and thus loses device pixel ration attached to it.