### PR TITLE
prefs: per-repository GUI and icon themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ Git Cola is a powerful Git GUI with a slick and intuitive user interface.
 
 * [Contributing guidelines](CONTRIBUTING.md)
 
+## Themes and appearance
+
+The GUI theme is read from the git config entry `cola.theme`. Set a default under
+**Preferences → Appearance** (stored in your user config), or override it for one
+repository only via **Preferences → Current Repository** or with
+`git config cola.theme <theme-name>` inside that repository (local `.git/config`).
+Git applies the usual config precedence, so a repository value overrides your global
+default when both are set.
+
+Passing **`git cola --theme <theme-name>`** (or **`git cola gui --theme ...`**) forces
+that theme for the entire process; preference changes cannot override it until you
+exit and restart without `--theme`.
+
+Icon themes are assembled from the `GIT_COLA_ICON_THEME` environment variable
+(`:`-separated list, if set) and from one or more `cola.icontheme` config entries;
+see `get_icon_themes()` in `cola/app.py` for details. In the main Git Cola window,
+GUI theme, icon theme, and bold-fonts preference changes apply immediately; font
+family, font size, and high DPI still require a restart.
+
 
 # Requirements
 

--- a/cola/app.py
+++ b/cola/app.py
@@ -32,6 +32,7 @@ On a Debian/Ubuntu system you can install these modules using apt:
     )
     sys.exit(1)  # core.EXIT_FAILURE
 
+from qtpy import QtGui
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt
 from qtpy.QtCore import Signal
@@ -66,6 +67,7 @@ from .cmd import CommandBus
 from .i18n import N_
 from .interaction import Interaction
 from .models import main
+from .models import prefs
 from .models import selection
 from .settings import Session
 from .settings import Settings
@@ -182,11 +184,17 @@ def get_icon_themes(context: ApplicationContext) -> list[str]:
 
     icon_themes_env = core.getenv('GIT_COLA_ICON_THEME')
     if icon_themes_env:
-        result.extend([x for x in icon_themes_env.split(':') if x])
+        for x in icon_themes_env.split(':'):
+            x = x.strip()
+            if x:
+                result.append(x)
 
     icon_themes_cfg = list(reversed(context.cfg.get_all('cola.icontheme')))
-    if icon_themes_cfg:
-        result.extend(icon_themes_cfg)
+    for entry in icon_themes_cfg:
+        if isinstance(entry, str):
+            s = entry.strip()
+            if s:
+                result.append(s)
 
     if not result:
         result.append('light')
@@ -199,6 +207,12 @@ class ColaApplication:
     """The main cola application
 
     ColaApplication handles i18n of user-visible data
+
+    Process model: one OS process owns a single :class:`QtWidgets.QApplication`.
+    Each shell invocation of ``git cola`` (or ``git cola --repo …``) is therefore
+    isolated from other processes. Per-repository ``cola.theme`` only affects
+    that process while its Git worktree points at that repository; switching
+    repos in the same window reapplies the merged config for the new worktree.
     """
 
     def __init__(
@@ -207,7 +221,6 @@ class ColaApplication:
         argv: list[str],
         locale: None = None,
         icon_themes: list[Any] | None = None,
-        gui_theme: None = None,
     ) -> None:
         cfgactions.install()
         i18n.install(locale)
@@ -220,26 +233,46 @@ class ColaApplication:
         self.theme: themes.Theme | None = None
         self._install_hidpi_config()
         self._app = ColaQApplication(context, list(argv))
+        # Captured before any custom palette so hot-reload can return to the system theme.
+        self._baseline_palette = QtGui.QPalette(self._app.palette())
         self._app.setWindowIcon(icons.cola())
         self._app.setDesktopFileName('git-cola')
-        self._install_style(gui_theme)
+        self._install_style()
 
-    def _install_style(self, theme_str: None) -> None:
+    def refresh_appearance(self) -> None:
+        """Re-read icon theme list and QSS/palette from config (e.g. after prefs change)."""
+        # In normal operation this is the only QApplication; tests may replace it.
+        inst = QtWidgets.QApplication.instance()
+        if inst is not None and inst is not self._app:
+            return
+        icons.clear_icon_cache()
+        icons.install(get_icon_themes(self.context))
+        self._install_style()
+
+    def _install_style(self, theme_str: str | None = None) -> None:
         """Generate and apply a stylesheet to the app"""
         if theme_str is None:
-            theme_str = self.context.cfg.get('cola.theme', default='default')
+            argv_theme = self.context.args.theme
+            if argv_theme is not None:
+                theme_str = themes.coerce_gui_theme_name(argv_theme)
+            else:
+                theme_str = prefs.gui_theme(self.context)
+        else:
+            theme_str = themes.coerce_gui_theme_name(theme_str)
         theme = themes.find_theme(theme_str)
         self.theme = theme
-
-        bold_fonts = self.context.cfg.get('cola.boldfonts', default=False)
-        theme_stylesheet = theme.build_style_sheet(self._app.palette(), bold_fonts)
-        self._app.setStyleSheet(theme_stylesheet)
 
         is_macos_theme = theme_str.startswith('macos-')
         if is_macos_theme:
             themes.apply_platform_theme(theme_str)
         elif theme_str != 'default':
             self._app.setPalette(theme.build_palette(self._app.palette()))
+        else:
+            self._app.setPalette(QtGui.QPalette(self._baseline_palette))
+
+        bold_fonts = self.context.cfg.get('cola.boldfonts', default=False)
+        theme_stylesheet = theme.build_style_sheet(self._app.palette(), bold_fonts)
+        self._app.setStyleSheet(theme_stylesheet)
 
     def _install_hidpi_config(self) -> None:
         """Sets QT HiDPI scaling (requires Qt 5.6)"""
@@ -394,6 +427,10 @@ def application_init(
         new_worktree(context, args.repo, args.prompt)
         if update:
             context.model.update_status()
+        # Worktree (and thus local git config) was finalized after ColaApplication
+        # construction; re-apply theme so repo-specific cola.theme is not missed.
+        if context.app:
+            context.app.refresh_appearance()
 
     timer.stop('init')
     if args.perf:
@@ -581,9 +618,7 @@ def new_application(
     context: ApplicationContext, args: argparse.Namespace
 ) -> ColaApplication:
     """Create a new ColaApplication"""
-    return ColaApplication(
-        context, sys.argv, icon_themes=args.icon_themes, gui_theme=args.theme
-    )
+    return ColaApplication(context, sys.argv, icon_themes=args.icon_themes)
 
 
 def new_worktree(context: ApplicationContext, repo: str, prompt: bool) -> None:

--- a/cola/icons.py
+++ b/cola/icons.py
@@ -53,6 +53,11 @@ def install(themes: list[str]) -> None:
         qtcompat.add_search_path('icons', icon_dir)
 
 
+def clear_icon_cache() -> None:
+    """Drop memoized QIcons after :func:`install` changes search paths."""
+    from_name.cache.clear()
+
+
 def icon_themes() -> tuple[tuple[str, str], tuple[str, str], tuple[str, str]]:
     return (
         (N_('Default'), 'default'),

--- a/cola/models/prefs.py
+++ b/cola/models/prefs.py
@@ -247,6 +247,24 @@ def bold_headers(context) -> bool:
     return context.cfg.get(BOLD_HEADERS, default=Defaults.bold_headers)
 
 
+def gui_theme(context) -> str:
+    """Effective GUI theme after merging system, global, and local git config.
+
+    Use :func:`GitConfig.get_repo` with ``THEME`` when you need the value stored
+    only in the current repository (missing key means no repo override).
+    Use :meth:`GitConfig.get_user_or_system` for the user/system default without
+    a repo-specific entry.
+
+    Unknown or mistyped values are coerced to a registered name so removing a
+    repo-specific ``cola.theme`` or deleting a custom theme file cannot leave the
+    UI without a valid stylesheet.
+    """
+    from .. import themes
+
+    raw = context.cfg.get(THEME, default=Defaults.theme)
+    return themes.coerce_gui_theme_name(raw)
+
+
 def check_conflicts(context) -> bool:
     """Should we check for merge conflict markers in unmerged files?"""
     return context.cfg.get(CHECK_CONFLICTS, default=Defaults.check_conflicts)
@@ -470,7 +488,7 @@ class PreferencesModel(QtCore.QObject):
         if source == 'local':
             value = self.config.get_repo(config)
         else:
-            value = self.config.get(config)
+            value = self.config.get_user_or_system(config)
         return value
 
 

--- a/cola/themes.py
+++ b/cola/themes.py
@@ -811,9 +811,37 @@ def options(themes: list[Theme] | None = None):
     return [(theme.title, theme.name) for theme in themes]
 
 
+def registered_theme_names() -> frozenset[str]:
+    """Set of theme ``name`` values from built-ins and user ``*.qss`` files."""
+    return frozenset(t.name for t in get_all_themes())
+
+
+def coerce_gui_theme_name(raw: Any) -> str:
+    """Map config or CLI input to a registered theme name.
+
+    Git config parsing can yield non-strings; users may typo theme names or
+    delete custom ``*.qss`` files. Always fall back to ``default`` so the app
+    keeps a valid palette/stylesheet after repo overrides are removed.
+    """
+    if raw is None:
+        return 'default'
+    if isinstance(raw, bool):
+        return 'default'
+    name = str(raw).strip()
+    if not name:
+        return 'default'
+    if name in registered_theme_names():
+        return name
+    return 'default'
+
+
 def find_theme(name: str) -> Theme:
-    themes = get_all_themes()
-    for item in themes:
-        if item.name == name:
+    key = coerce_gui_theme_name(name)
+    themes_list = get_all_themes()
+    for item in themes_list:
+        if item.name == key:
             return item
-    return themes[0]
+    for item in themes_list:
+        if item.name == 'default':
+            return item
+    return themes_list[0]

--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -905,6 +905,9 @@ class MainView(standard.MainWindow):
         )
 
         prefs_model.config_updated.connect(self._config_updated)
+        self.model.worktree_changed.connect(
+            self._worktree_changed_refresh_appearance, type=Qt.QueuedConnection
+        )
         self.commit_menu.aboutToShow.connect(self.update_menu_actions)
         self.open_recent_menu.aboutToShow.connect(self.build_recent_menu)
 
@@ -1062,6 +1065,12 @@ class MainView(standard.MainWindow):
     # Accessors
     mode = property(lambda self: self.model.mode)
 
+    def _worktree_changed_refresh_appearance(self):
+        """Apply merged theme for the new repository (local override may be gone)."""
+        app = self.context.app
+        if app is not None:
+            app.refresh_appearance()
+
     def _config_updated(self, _source, config, value):
         if config == prefs.FONTDIFF:
             # The diff font
@@ -1104,6 +1113,11 @@ class MainView(standard.MainWindow):
         elif config == prefs.SHOW_PATH:
             # the path in the window title was toggled
             self.refresh_window_title()
+
+        elif config in (prefs.THEME, prefs.ICON_THEME, prefs.BOLD_FONTS):
+            app = self.context.app
+            if app is not None:
+                app.refresh_appearance()
 
     def start(self, context):
         """Do the expensive "get_config_actions()" call in the background"""

--- a/cola/widgets/prefs.py
+++ b/cola/widgets/prefs.py
@@ -16,6 +16,24 @@ from . import defs
 from . import standard
 
 
+def sync_icon_theme_to_gui_theme(themes_list, theme_idx, icon_theme_widget):
+    """Align icon theme with light/dark when the GUI theme changes (shared by prefs forms)."""
+    try:
+        theme = themes_list[theme_idx]
+    except IndexError:
+        return
+    icon_theme = icon_theme_widget.value()
+    if theme.name == 'default':
+        if icon_theme in ('light', 'dark'):
+            icon_theme_widget.set_value('default')
+    elif theme.is_dark:
+        if icon_theme in ('default', 'light'):
+            icon_theme_widget.set_value('dark')
+    elif not theme.is_dark:
+        if icon_theme in ('default', 'dark'):
+            icon_theme_widget.set_value('light')
+
+
 def preferences(context, model=None, parent=None):
     if model is None:
         model = prefs.PreferencesModel(context)
@@ -201,6 +219,19 @@ scissors
         tooltip = N_('Enable detection and configuration of HTTP proxy settings')
         self.autodetect_proxy = qtutils.checkbox(checked=True, tooltip=tooltip)
 
+        if source == 'local':
+            self.themes = themes.get_all_themes()
+            self.theme = qtutils.combo_mapped(themes.options(themes=self.themes))
+            self.icon_theme = qtutils.combo_mapped(icons.icon_themes())
+            repo_theme_tip = N_(
+                'Override appearance for this repository only. '
+                'Matches the effective theme until you change it here. '
+                'GUI and icon themes apply immediately in the main window. '
+                'The command-line --theme option overrides all config when set.'
+            )
+            self.theme.setToolTip(repo_theme_tip)
+            self.icon_theme.setToolTip(repo_theme_tip)
+
         self.add_row(N_('Name'), self.name)
         self.add_row(N_('Email'), self.email)
 
@@ -243,7 +274,21 @@ scissors
         )
         self.add_row(N_('HTTP Proxy URL'), self.http_proxy)
 
+        if source == 'local':
+            self.add_row('', QtWidgets.QLabel())
+            self.add_row(N_('GUI theme (this repository)'), self.theme)
+            self.add_row(N_('Icon theme (this repository)'), self.icon_theme)
+            self.theme.currentIndexChanged.connect(self._repo_theme_changed)
+
+        repo_config = {}
+        if source == 'local':
+            repo_config = {
+                prefs.THEME: (self.theme, Defaults.theme),
+                prefs.ICON_THEME: (self.icon_theme, Defaults.icon_theme),
+            }
+
         self.set_config({
+            **repo_config,
             prefs.AUTOTEMPLATE: (self.autotemplate, Defaults.autotemplate),
             prefs.AUTOCOMPLETE_PATHS: (
                 self.autocomplete_paths,
@@ -281,6 +326,11 @@ scissors
             prefs.USER_EMAIL: (self.email, ''),
             prefs.UPDATE_INDEX: (self.update_index, Defaults.update_index),
         })
+
+    def _repo_theme_changed(self, theme_idx):
+        if not hasattr(self, 'themes'):
+            return
+        sync_icon_theme_to_gui_theme(self.themes, theme_idx, self.icon_theme)
 
 
 class SettingsFormWidget(FormWidget):
@@ -497,21 +547,7 @@ class AppearanceFormWidget(FormWidget):
 
     def _theme_changed(self, theme_idx):
         """Set the icon theme to dark/light when the main theme changes"""
-        # Set the icon theme to a theme that corresponds to the main settings.
-        try:
-            theme = self.themes[theme_idx]
-        except IndexError:
-            return
-        icon_theme = self.icon_theme.value()
-        if theme.name == 'default':
-            if icon_theme in ('light', 'dark'):
-                self.icon_theme.set_value('default')
-        elif theme.is_dark:
-            if icon_theme in ('default', 'light'):
-                self.icon_theme.set_value('dark')
-        elif not theme.is_dark:
-            if icon_theme in ('default', 'dark'):
-                self.icon_theme.set_value('light')
+        sync_icon_theme_to_gui_theme(self.themes, theme_idx, self.icon_theme)
 
     def update_from_config(self):
         """Update widgets to the current config values"""
@@ -546,7 +582,13 @@ class AppearanceWidget(QtWidgets.QWidget):
         self.form = form
         self.label = QtWidgets.QLabel(
             '<center><b>'
-            + N_('Restart the application after changing appearance settings.')
+            + N_(
+                'GUI theme, icon theme, and bold-fonts apply immediately. '
+                'Restart after changing fonts, font size, or high DPI. '
+                'Per-repository GUI and icon themes are under '
+                'Preferences → Current Repository. '
+                'The --theme command-line flag overrides all theme config when used.'
+            )
             + '</b></center>'
         )
         layout = qtutils.vbox(

--- a/test/per_repo_theme_test.py
+++ b/test/per_repo_theme_test.py
@@ -55,9 +55,7 @@ def test_gui_theme_reads_cfg_and_coerces():
     context.cfg = Mock()
     context.cfg.get = Mock(return_value='not-a-real-theme')
     assert prefs.gui_theme(context) == 'default'
-    context.cfg.get.assert_called_once_with(
-        prefs.THEME, default=prefs.Defaults.theme
-    )
+    context.cfg.get.assert_called_once_with(prefs.THEME, default=prefs.Defaults.theme)
 
 
 def test_gui_theme_preserves_valid_name():

--- a/test/per_repo_theme_test.py
+++ b/test/per_repo_theme_test.py
@@ -1,0 +1,144 @@
+"""Per-repository theme: coercion, prefs helpers, and config model (mocked git).
+
+Requires the same Qt stack as the rest of git-cola (qtpy + PyQt/PySide).
+Without it, the whole module is skipped at import time.
+"""
+from unittest.mock import Mock
+from unittest.mock import call
+from unittest.mock import patch
+
+import pytest
+
+try:
+    from qtpy import QtCore  # noqa: F401
+except Exception as exc:
+    pytest.skip(f'Qt bindings required: {exc}', allow_module_level=True)
+
+from cola import app as cola_app
+from cola import themes
+from cola.models import prefs
+from cola.models.prefs import PreferencesModel
+from cola.models.prefs import SetConfig
+
+
+@pytest.mark.parametrize(
+    'raw,expected',
+    [
+        (None, 'default'),
+        ('', 'default'),
+        ('   ', 'default'),
+        (True, 'default'),
+        (False, 'default'),
+        (42, 'default'),
+        ('no-such-theme-ever-xyz-999', 'default'),
+        ('default', 'default'),
+        ('flat-dark-blue', 'flat-dark-blue'),
+    ],
+)
+def test_coerce_gui_theme_name(raw, expected):
+    assert themes.coerce_gui_theme_name(raw) == expected
+
+
+def test_registered_theme_names_contains_default():
+    names = themes.registered_theme_names()
+    assert 'default' in names
+    assert 'flat-dark-blue' in names
+
+
+def test_find_theme_unknown_returns_default_named_theme():
+    theme = themes.find_theme('__invalid__')
+    assert theme.name == 'default'
+
+
+def test_gui_theme_reads_cfg_and_coerces():
+    context = Mock()
+    context.cfg = Mock()
+    context.cfg.get = Mock(return_value='not-a-real-theme')
+    assert prefs.gui_theme(context) == 'default'
+    context.cfg.get.assert_called_once_with(
+        prefs.THEME, default=prefs.Defaults.theme
+    )
+
+
+def test_gui_theme_preserves_valid_name():
+    context = Mock()
+    context.cfg = Mock()
+    context.cfg.get = Mock(return_value='flat-dark-green')
+    assert prefs.gui_theme(context) == 'flat-dark-green'
+
+
+def test_preferences_model_set_config_local_theme():
+    context = Mock()
+    context.cfg = Mock()
+    model = PreferencesModel(context)
+    model.set_config('local', prefs.THEME, 'flat-dark-blue')
+    context.cfg.set_repo.assert_called_once_with(prefs.THEME, 'flat-dark-blue')
+
+
+def test_preferences_model_set_config_global_theme():
+    context = Mock()
+    context.cfg = Mock()
+    model = PreferencesModel(context)
+    model.set_config('global', prefs.THEME, 'default')
+    context.cfg.set_user.assert_called_once_with(prefs.THEME, 'default')
+
+
+def test_preferences_model_get_config_routes_by_source():
+    context = Mock()
+    context.cfg = Mock()
+    context.cfg.get_repo = Mock(return_value='flat-light-blue')
+    context.cfg.get_user_or_system = Mock(return_value='flat-dark-grey')
+    model = PreferencesModel(context)
+    assert model.get_config('local', prefs.THEME) == 'flat-light-blue'
+    assert model.get_config('global', prefs.THEME) == 'flat-dark-grey'
+
+
+def test_set_config_command_local_roundtrip_mock():
+    context = Mock()
+    cfg = Mock()
+    cfg.get_repo = Mock(return_value='default')
+    context.cfg = cfg
+    model = PreferencesModel(context)
+    cmd = SetConfig(model, 'local', prefs.THEME, 'flat-dark-red')
+    cmd.do()
+    cfg.get_repo.assert_called_with(prefs.THEME)
+    cfg.set_repo.assert_called_once_with(prefs.THEME, 'flat-dark-red')
+    cmd.undo()
+    assert cfg.set_repo.call_args_list[-1] == call(prefs.THEME, 'default')
+
+
+def test_get_icon_themes_strips_and_skips_empty():
+    context = Mock()
+    context.cfg = Mock()
+    context.cfg.get_all = Mock(return_value=['', '  dark  ', 'light'])
+    with patch.object(cola_app.core, 'getenv', return_value=None):
+        names = cola_app.get_icon_themes(context)
+    assert 'dark' in names
+    assert 'light' in names
+
+
+def test_get_icon_themes_env_split_strips():
+    context = Mock()
+    context.cfg = Mock()
+    context.cfg.get_all = Mock(return_value=[])
+    with patch.object(cola_app.core, 'getenv', return_value=' dark : light '):
+        names = cola_app.get_icon_themes(context)
+    assert names[:2] == ['dark', 'light']
+
+
+def test_get_icon_themes_non_strings_skipped():
+    context = Mock()
+    context.cfg = Mock()
+    context.cfg.get_all = Mock(return_value=[99, None, 'dark'])
+    with patch.object(cola_app.core, 'getenv', return_value=None):
+        names = cola_app.get_icon_themes(context)
+    assert names == ['dark']
+
+
+def test_get_icon_themes_defaults_to_light_when_empty():
+    context = Mock()
+    context.cfg = Mock()
+    context.cfg.get_all = Mock(return_value=[])
+    with patch.object(cola_app.core, 'getenv', return_value=None):
+        names = cola_app.get_icon_themes(context)
+    assert names == ['light']


### PR DESCRIPTION
Read cola.theme and cola.icontheme from the repository git config, add controls on Preferences > Current Repository, refresh appearance when preferences or worktree change, and coerce unknown theme names to default.

Document theme precedence and add unit tests for coercion and config hooks.

Closes https://github.com/git-cola/git-cola/issues/1578