### PR TITLE
dag: Fix line overlap at the middle of row

### DIFF
--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -745,7 +745,8 @@ class GraphDelegate(QtWidgets.QStyledItemDelegate):
         rect = option.rect
         mid_y = rect.center().y()
         top_y = rect.top()
-        bottom_y = rect.bottom()
+        # +1 to connect to the next row (FlatCap ends lines exactly at the endpoint)
+        bottom_y = rect.bottom() + 1
         lane_w = self.LANE_WIDTH
 
         if option.state & QtWidgets.QStyle.State_Selected:
@@ -755,6 +756,7 @@ class GraphDelegate(QtWidgets.QStyledItemDelegate):
         if row is not None or prev_row is not None:
             pen = QtGui.QPen()
             pen.setWidth(self.EDGE_WIDTH)
+            pen.setCapStyle(Qt.FlatCap)
 
             # Top half: edges from the previous row arrive vertically.
             if prev_row is not None:


### PR DESCRIPTION
By default Qt uses SquareCap which extends lines slightly.

Before:
<img width="1843" height="1501" alt="before" src="https://github.com/user-attachments/assets/173ac160-4fa2-49b6-a0e7-01f8d71f6d30" />

After:
<img width="1849" height="1503" alt="after" src="https://github.com/user-attachments/assets/6cdd22d5-5c54-4d29-ab14-851b2ce51d6d" />

