### PR TITLE
dag: Reduce spacing to increase information density

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,8 @@ Usability, bells and whistles
   these potentially dangerous actions from getting triggered accidentally.
   (`#1582 <https://github.com/git-cola/git-cola/issues/1582>`_)
 
+* Reduced extra spacing in commit list to improve information density.
+
 Fixes
 -----
 * The DAG's gravatar icon size was improved when using hi-DPI displays.

--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -928,7 +928,7 @@ class GraphDelegate(QtWidgets.QStyledItemDelegate):
         total_width = graph_width + 8 + labels_width + 8 + text_width
         if total_width < self.LANE_WIDTH * 4:
             total_width = self.LANE_WIDTH * 4
-        height = option.fontMetrics.height() + 4
+        height = option.fontMetrics.height()
         return QtCore.QSize(total_width, height)
 
 

--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -872,7 +872,8 @@ class GraphDelegate(QtWidgets.QStyledItemDelegate):
 
             # Calculate text width using font metrics for consistency
             text_width = font_metrics.horizontalAdvance(display_tag)
-            text_height = font_metrics.height()
+            # Use 80% of font height for tighter vertical fit
+            text_height = font_metrics.height() * 0.8
 
             text_rect = QtCore.QRectF(
                 current_x, y - text_height / 2, text_width, text_height

--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -732,7 +732,7 @@ class GraphDelegate(QtWidgets.QStyledItemDelegate):
 
     LABEL_BORDER = 3
     LABEL_SPACING = 4
-    LABEL_TEXT_OFFSET = 3
+    LABEL_TEXT_OFFSET = 2
 
     def paint(self, painter, option, index):
         row = index.data(GRAPH_ROW_ROLE)


### PR DESCRIPTION
Before:
<img width="2615" height="2109" alt="before" src="https://github.com/user-attachments/assets/d501c21f-c449-4689-b745-a0a55c4a00e6" />

After:
<img width="2615" height="2109" alt="after" src="https://github.com/user-attachments/assets/b97059f6-9deb-42b5-bb3a-73ad37852464" />
