### PR TITLE
Fix the macOS menu bar to show "Git Cola" instead of "python3"

### DIFF
--- a/cola/app.py
+++ b/cola/app.py
@@ -194,6 +194,60 @@ def get_icon_themes(context: ApplicationContext) -> list[str]:
     return result
 
 
+def _set_application_name() -> None:
+    """Tell Qt and Cocoa the user-visible application name is "Git Cola".
+
+    Without this, a non-bundled launch on macOS (running ``git-cola`` via the
+    system ``python3``) shows ``python3`` in the menu bar, the Apple menu
+    "Hide" / "Quit" items, and in the dock, because Cocoa derives all of
+    those from the executable name.
+
+    Cocoa reads three different sources for the user-visible app name and
+    they have to be patched in lock-step:
+
+    * Qt menus: ``QCoreApplication.applicationName``
+    * macOS menu bar (title slot, Hide/Quit items): the ``CFBundleName`` key
+      of ``[[NSBundle mainBundle] infoDictionary]``, which Qt's Cocoa plugin
+      reads when it builds the menu.
+    * Dock tile / ``NSRunningApplication.localizedName``: the Cocoa process
+      name, set via ``-[NSProcessInfo setProcessName:]``.
+
+    Must run before ``QApplication`` is constructed as Qt snapshots the bundle dictionary the first time it builds the
+    Cocoa menu.
+
+    References:
+
+    - https://doc.qt.io/qt-6/qcoreapplication.html
+    - https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundlename
+    - https://developer.apple.com/documentation/foundation/processinfo/processname
+    """
+    QtCore.QCoreApplication.setApplicationName('Git Cola')
+    if sys.platform != 'darwin':
+        return
+    try:
+        # PyObjC is a declared darwin dep but stays optional at import-time.
+        from AppKit import NSBundle
+        from AppKit import NSProcessInfo
+    except ImportError:
+        return
+    try:
+        # Inject CFBundleName / CFBundleDisplayName into the main bundle's
+        # info dictionary. For a non-bundled launch the dictionary may be
+        # nil; replace it via the private _infoDictionary ivar fallback only
+        # if the public mutator is unavailable.
+        bundle = NSBundle.mainBundle()
+        info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
+        if info is not None:
+            # NSBundle's info dict is an NSMutableDictionary in practice;
+            # setObject_forKey_ works even when the public API claims it is
+            # read-only.
+            info.setObject_forKey_('Git Cola', 'CFBundleName')
+            info.setObject_forKey_('Git Cola', 'CFBundleDisplayName')
+        NSProcessInfo.processInfo().setProcessName_('Git Cola')
+    except Exception:  # noqa: BLE001 -- never let cosmetic naming crash startup
+        pass
+
+
 # style note: we use camelCase here since we're masquerading a Qt class
 class ColaApplication:
     """The main cola application
@@ -209,6 +263,7 @@ class ColaApplication:
         icon_themes: list[Any] | None = None,
         gui_theme: None = None,
     ) -> None:
+        _set_application_name()
         cfgactions.install()
         i18n.install(locale)
         qtcompat.install()

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -1,6 +1,10 @@
 import argparse
+import sys
+import types
+from unittest.mock import MagicMock
 
 from cola import app
+from qtpy import QtCore
 
 
 def test_setup_environment():
@@ -14,3 +18,104 @@ def test_add_common_arguments():
     parser = argparse.ArgumentParser()
     assert hasattr(app, 'add_common_arguments')
     app.add_common_arguments(parser)
+
+
+def test_set_application_name_sets_qt_application_name():
+    """The Qt application name is set unconditionally on every platform."""
+    app._set_application_name()
+    assert QtCore.QCoreApplication.applicationName() == 'Git Cola'
+
+
+class _ExplodingAppKit(types.ModuleType):
+    """Stand-in module whose attribute access always fails.
+
+    Used to assert that the code under test does NOT reach the AppKit
+    branch -- if it does, the test fails with a clear AssertionError.
+    """
+
+    def __init__(self):
+        super().__init__('AppKit')
+
+    def __getattr__(self, name):
+        raise AssertionError(f'AppKit.{name} accessed unexpectedly')
+
+
+def test_set_application_name_is_a_noop_on_non_darwin(monkeypatch):
+    """On non-darwin platforms the Cocoa surfaces are never touched."""
+    monkeypatch.setattr(sys, 'platform', 'linux')
+    monkeypatch.setitem(sys.modules, 'AppKit', _ExplodingAppKit())
+
+    # Must not raise, must not touch AppKit.
+    app._set_application_name()
+    assert QtCore.QCoreApplication.applicationName() == 'Git Cola'
+
+
+def test_set_application_name_survives_missing_appkit(monkeypatch):
+    """If PyObjC isn't installed, the function returns without crashing."""
+    monkeypatch.setattr(sys, 'platform', 'darwin')
+    # Force `from AppKit import ...` inside the function to raise ImportError
+    # by stashing a non-module object under that key.
+    monkeypatch.setitem(sys.modules, 'AppKit', None)
+
+    # Must not raise.
+    app._set_application_name()
+    assert QtCore.QCoreApplication.applicationName() == 'Git Cola'
+
+
+def _make_fake_appkit():
+    """Build a fake AppKit module that captures every Cocoa write we make."""
+    fake_info = {}
+    info_dict = MagicMock()
+    info_dict.setObject_forKey_.side_effect = lambda value, key: fake_info.__setitem__(
+        key, value
+    )
+
+    bundle = MagicMock()
+    bundle.localizedInfoDictionary.return_value = None
+    bundle.infoDictionary.return_value = info_dict
+
+    ns_bundle = MagicMock()
+    ns_bundle.mainBundle.return_value = bundle
+
+    process_info_instance = MagicMock()
+    ns_process_info = MagicMock()
+    ns_process_info.processInfo.return_value = process_info_instance
+
+    module = types.ModuleType('AppKit')
+    module.NSBundle = ns_bundle
+    module.NSProcessInfo = ns_process_info
+    return module, fake_info, process_info_instance
+
+
+def test_set_application_name_patches_cocoa_surfaces_on_darwin(monkeypatch):
+    """On darwin we set CFBundleName, CFBundleDisplayName, and processName."""
+    monkeypatch.setattr(sys, 'platform', 'darwin')
+    fake_appkit, captured_info, process_info_instance = _make_fake_appkit()
+    monkeypatch.setitem(sys.modules, 'AppKit', fake_appkit)
+
+    app._set_application_name()
+
+    assert captured_info == {
+        'CFBundleName': 'Git Cola',
+        'CFBundleDisplayName': 'Git Cola',
+    }
+    process_info_instance.setProcessName_.assert_called_once_with('Git Cola')
+
+
+def test_set_application_name_swallows_cocoa_exceptions(monkeypatch):
+    """A failure inside the Cocoa block must not crash app startup.
+
+    The function is best-effort -- it intentionally swallows any AppKit
+    exception because a cosmetic naming failure must not prevent git-cola
+    from launching.
+    """
+    monkeypatch.setattr(sys, 'platform', 'darwin')
+    fake_appkit, _captured_info, _process_info = _make_fake_appkit()
+    # Make every NSBundle call blow up.
+    fake_appkit.NSBundle.mainBundle.side_effect = RuntimeError('boom')
+    monkeypatch.setitem(sys.modules, 'AppKit', fake_appkit)
+
+    # Must not raise.
+    app._set_application_name()
+    # Qt-side name still got set despite the AppKit explosion.
+    assert QtCore.QCoreApplication.applicationName() == 'Git Cola'


### PR DESCRIPTION
When git-cola is launched from a non-bundled Python (running the `git-cola` script via a system `python3`, or via Homebrew's keg-only `python`, rather than from a `.app` bundle), the macOS menu bar shows the interpreter's executable name — `python3`, `python`, or `python3.14` — in the Apple menu, in the Hide / Quit items, and in the dock tile. Cocoa derives all of those from the running process when no bundle is present.

It's amazing how weird Apple is for running apps, I thought this would be a simple fix.. GitHub code search got a workout with this one to see how others fix things...

Anyway, three things need to be done BEFORE `QApplication` is constructed so Qt's Cocoa plugin uses the right name when it builds the menu:

- [`QCoreApplication.applicationName`](https://doc.qt.io/qt-6/qcoreapplication.html) — used for Qt menus.
- [`CFBundleName`](https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundlename) / `CFBundleDisplayName` in `[[NSBundle mainBundle] infoDictionary]` — read by Qt to populate the macOS menu bar (title slot, Hide / Quit items).
- [`NSProcessInfo.processName`](https://developer.apple.com/documentation/foundation/processinfo/processname) — used for the dock tile and Apple-menu app title.

Verified locally on macOS 15.7.2 / arm64 / Qt 6.11.0 / PyQt6 6.11.0: after this change the menu bar reads "Git Cola", the Apple menu reads "About git-cola" / "Hide Git Cola" / "Quit Git Cola", and the dock tile reads "Git Cola" on hover.

For homebrew git-cola, before:

<img width="265" height="258" alt="image" src="https://github.com/user-attachments/assets/432aeae6-b5f2-4de4-ac9c-cb404fcc9916" />

After:

<img width="495" height="490" alt="image" src="https://github.com/user-attachments/assets/1b4502f3-49e9-4b6f-bec1-0e6498e28ee0" />

(I'll fix the Quit Menu item, which is already not working, later).