### PR TITLE
Fix maximized window state on restore on macOS

### DIFF
--- a/cola/widgets/standard.py
+++ b/cola/widgets/standard.py
@@ -22,6 +22,40 @@ from ..settings import Settings
 from ..settings import mklist
 from . import defs
 
+# Magic header emitted by QWidget::saveGeometry() (Qt 5/6).
+_QWIDGET_GEOMETRY_MAGIC = b'\x01\xd9\xd0\xcb'
+# Offset of the "maximized" flag byte inside a saveGeometry() blob:
+#   4 magic + 2 major + 2 minor + 16 frame QRect + 16 normal QRect + 4 screen
+_QWIDGET_GEOMETRY_MAXIMIZED_OFFSET = 44
+
+
+def _strip_maximized_geometry_flag(blob):
+    """Return (blob_without_maximized_flag, was_maximized).
+
+    QWidget::saveGeometry() encodes the maximized state as a single byte at a
+    well-known offset. Strip it so restoreGeometry() does not re-apply the
+    maximized state during widget construction; the caller is responsible for
+    re-applying it after show() has been called.
+
+    Cf. https://doc.qt.io/qt-6/qwidget.html#saveGeometry
+    """
+    # The QByteArray returned by fromBase64 supports the bytes-like protocol,
+    # so bytes(blob) gives us a plain Python bytes object we can index into.
+    raw = bytes(blob)
+    if len(raw) <= _QWIDGET_GEOMETRY_MAXIMIZED_OFFSET or not raw.startswith(
+        _QWIDGET_GEOMETRY_MAGIC
+    ):
+        return blob, False
+    was_maximized = bool(raw[_QWIDGET_GEOMETRY_MAXIMIZED_OFFSET])
+    if not was_maximized:
+        return blob, False
+    patched = (
+        raw[:_QWIDGET_GEOMETRY_MAXIMIZED_OFFSET]
+        + b'\x00'
+        + raw[_QWIDGET_GEOMETRY_MAXIMIZED_OFFSET + 1 :]
+    )
+    return QtCore.QByteArray(patched), True
+
 
 class WidgetMixin:
     """Mix-in for common utilities and serialization of widget state"""
@@ -97,7 +131,29 @@ class WidgetMixin:
         geometry = state.get('geometry', '')
         if geometry:
             from_base64 = QtCore.QByteArray.fromBase64
-            result = self.restoreGeometry(from_base64(core.encode(geometry)))
+            geometry_bytes = from_base64(core.encode(geometry))
+            # On macOS 15, calling restoreGeometry() with a blob whose
+            # "maximized" flag is set sends Qt into a layout-feedback loop on
+            # relaunch -- the window grinds creating and destroying tab bars
+            # and dock-widget children until it eventually settles or hangs.
+            # This is the latest in a series of recurring upstream reports;
+            # the chain is QTBUG-4397 -> QTBUG-21371 -> QTBUG-106678 ->
+            # QTBUG-123335 (still open as of Qt 6.11).
+            #
+            # Strip the maximized flag from the blob and re-apply it via
+            # setWindowState() after the event loop is running, which gives
+            # Cocoa a chance to place the window before we ask for the
+            # maximized state.
+            #
+            # Cf. https://bugreports.qt.io/browse/QTBUG-123335
+            geometry_bytes, was_maximized = _strip_maximized_geometry_flag(
+                geometry_bytes
+            )
+            result = self.restoreGeometry(geometry_bytes)
+            if was_maximized:
+                QtCore.QTimer.singleShot(
+                    0, lambda: self.setWindowState(Qt.WindowMaximized)
+                )
         elif width and height:
             # Users migrating from older versions won't have 'geometry'.
             # They'll be upgraded to the new format on shutdown.

--- a/test/widgets_standard_test.py
+++ b/test/widgets_standard_test.py
@@ -1,0 +1,79 @@
+"""Tests for cola.widgets.standard helpers."""
+from cola.widgets.standard import _strip_maximized_geometry_flag
+from qtpy import QtCore
+
+# Real saveGeometry() blob captured from a maximised git-cola main window on
+# macOS 15 (recorded from ~/.config/git-cola/settings). The byte at offset 44
+# is 0x02 ("maximized" flag). Qt does not always write 0x01 here.
+_MAXIMIZED_BLOB_B64 = b'AdnQywADAAAAAAAAAAAAJgAABecAAAPVAAAAAAAAAEIAAAXl' b'AAAD0wAAAAACAAAABegAAAAAAAAAQgAABecAAAPV'
+
+# Real saveGeometry() blob captured from a non-maximised window (byte 44 is 0).
+_NORMAL_BLOB_B64 = b'AdnQywADAAAAAAHgAAAAGQAAB38AAAQ1AAAB4AAAADUAAAd/' b'AAAENQAAAAAAAAAAB4AAAAHgAAAANQAAB38AAAQ1'
+
+
+def _maximized_byte(blob):
+    """Return the byte at the well-known maximized-flag offset."""
+    return bytes(blob)[44]
+
+
+def test_strip_clears_the_maximized_flag():
+    """A blob with the maximized flag set comes back with byte 44 zeroed."""
+    blob_in = QtCore.QByteArray.fromBase64(_MAXIMIZED_BLOB_B64)
+    assert _maximized_byte(blob_in) != 0
+
+    blob_out, was_maximized = _strip_maximized_geometry_flag(blob_in)
+
+    assert was_maximized is True
+    assert _maximized_byte(blob_out) == 0
+
+
+def test_strip_preserves_every_other_byte():
+    """Only the maximized-flag byte changes; the rest is byte-identical."""
+    blob_in = QtCore.QByteArray.fromBase64(_MAXIMIZED_BLOB_B64)
+    blob_out, _ = _strip_maximized_geometry_flag(blob_in)
+
+    raw_in = bytes(blob_in)
+    raw_out = bytes(blob_out)
+    assert len(raw_in) == len(raw_out)
+    assert raw_in[:44] == raw_out[:44]
+    assert raw_in[45:] == raw_out[45:]
+
+
+def test_strip_passes_through_normal_geometry_unchanged():
+    """A blob that is not maximized comes back as the same object."""
+    blob_in = QtCore.QByteArray.fromBase64(_NORMAL_BLOB_B64)
+    assert _maximized_byte(blob_in) == 0
+
+    blob_out, was_maximized = _strip_maximized_geometry_flag(blob_in)
+
+    assert was_maximized is False
+    assert blob_out is blob_in
+
+
+def test_strip_ignores_blobs_without_the_qwidget_geometry_magic():
+    """Junk bytes that don't start with the QWidget magic are not modified."""
+    junk = QtCore.QByteArray(b'\x00\x00\x00\x00not-a-geometry-blob' + b'\xff' * 60)
+    out, was_maximized = _strip_maximized_geometry_flag(junk)
+    assert was_maximized is False
+    assert out is junk
+
+
+def test_strip_ignores_truncated_blobs():
+    """A blob shorter than the maximized-flag offset is left alone."""
+    short = QtCore.QByteArray(b'\x01\xd9\xd0\xcb\x00\x00')
+    out, was_maximized = _strip_maximized_geometry_flag(short)
+    assert was_maximized is False
+    assert out is short
+
+
+def test_strip_treats_any_non_zero_byte_as_maximized():
+    """Qt's saveGeometry() has been observed to write 0x02 at this offset,
+    so the helper must accept any non-zero value as 'maximized'."""
+    raw = bytearray(bytes(QtCore.QByteArray.fromBase64(_NORMAL_BLOB_B64)))
+    raw[44] = 0x02
+    blob_in = QtCore.QByteArray(bytes(raw))
+
+    blob_out, was_maximized = _strip_maximized_geometry_flag(blob_in)
+
+    assert was_maximized is True
+    assert _maximized_byte(blob_out) == 0


### PR DESCRIPTION
On macOS 15, calling `QMainWindow.restoreGeometry()` with a blob whose "maximized" flag is set sends Qt into a layout-feedback loop on relaunch: the window grinds creating and destroying tab bars and dock-widget children until it eventually settles or hangs.

How to reproduce on MacOS:

1. Launch git-cola in a fresh profile (e.g move $HOME/.config/git-cola somewhere else, so it doesn't break your current settings)
2. Make the window maximised (NOT FULL SCREEN!)
3. Close git-cola
4. Reopen git-cola, and it should now "freeze"

With a clean `~/.config/git-cola` the relaunch seems to be stuck in widget construction, using `py-spy dump` shows the GUI thread in `QApplication.exec_()`, with `qt.widgets.showhide` events showing.

This is the latest in a long-running upstream chain: [QTBUG-4397](https://bugreports.qt.io/browse/QTBUG-4397), [QTBUG-21371](https://bugreports.qt.io/browse/QTBUG-21371), [QTBUG-106678](https://bugreports.qt.io/browse/QTBUG-106678), [QTBUG-123335](https://bugreports.qt.io/browse/QTBUG-123335) (`save/restoreGeometry behaves incorrectly when application is maximized`, still open and affecting macOS + Windows).

So, this fixes it for me, but I would love to get some more testing, especially around the ridiculous flag bytes.

In `cola/widgets/standard.py`, we parse the `saveGeometry()` header, stripping the maximized flag byte (offset 44 in the [documented binary format](https://doc.qt.io/qt-6/qwidget.html#saveGeometry)), and re-apply `Qt.WindowMaximized` via `QTimer.singleShot(0, ...)` so it lands AFTER Cocoa has placed the window and the event loop is running. This breaks the feedback loop while preserving the user's maximized state across launches.

New unit tests in `test/widgets_standard_test.py` cover the strip helper across real captured `saveGeometry()` blobs (maximized and non-maximized), plus edge cases (junk bytes, truncated blob, the observed-in-practice `0x02` flag value that isn't documented as the canonical "true"). I have very little experience with Qt, so please feel free to change anything.
