### PR TITLE
fix: refresh UI when macOS appearance changes at runtime

### DIFF
--- a/cola/app.py
+++ b/cola/app.py
@@ -296,6 +296,14 @@ class ColaApplication:
         elif theme_str != 'default':
             self._app.setPalette(theme.build_palette(self._app.palette()))
 
+    def _refresh_system_appearance(self) -> None:
+        """Rebuild styles that follow the system palette."""
+        theme_str = self.context.cfg.get('cola.theme', default='default')
+        if theme_str != 'default':
+            return
+
+        self._install_style(None)
+
     def _install_hidpi_config(self) -> None:
         """Sets QT HiDPI scaling (requires Qt 5.6)"""
         value = self.context.cfg.get('cola.hidpi', default=hidpi.Option.AUTO)
@@ -353,6 +361,11 @@ class ColaQApplication(QtWidgets.QApplication):
 
     def event(self, e: QEvent) -> bool:
         """Respond to focus events for the cola.refreshonfocus feature"""
+        if hasattr(QtCore.QEvent, 'ApplicationPaletteChange'):
+            if e.type() == QtCore.QEvent.ApplicationPaletteChange:
+                cola_app = getattr(self.context, 'app', None)
+                if cola_app:
+                    QtCore.QTimer.singleShot(0, cola_app._refresh_system_appearance)
         if e.type() == QtCore.QEvent.ApplicationActivate:
             context = self.context
             if context:

--- a/cola/widgets/dag.py
+++ b/cola/widgets/dag.py
@@ -2473,6 +2473,19 @@ class GraphView(QtWidgets.QGraphicsView, ViewerMixin):
             self, N_('Select Newest Child'), self._select_newest_child, hotkeys.MOVE_UP
         )
 
+    def refresh_appearance(self) -> None:
+        """Update palette-derived colors after a system appearance change."""
+        background_color = qtutils.css_color(
+            self.context.app.theme.background_color_rgb()
+        )
+        self.setBackgroundBrush(background_color)
+        self.viewport().update()
+
+    def changeEvent(self, event):
+        if event.type() == QtCore.QEvent.PaletteChange:
+            self.refresh_appearance()
+        super().changeEvent(event)
+
     def clear(self):
         EdgeColor.reset()
         self.scene().clear()

--- a/cola/widgets/diff.py
+++ b/cola/widgets/diff.py
@@ -66,9 +66,12 @@ class DiffSyntaxHighlighter(QtGui.QSyntaxHighlighter):
         # block_number -> per-line intra-line spans
         self._intraline_spans: intraline_diff.SpansByLineIndex = {}
 
+        self._configure_colors(context, qtutils.current_palette())
+        self.setCurrentBlockState(self.INITIAL_STATE)
+
+    def _configure_colors(self, context, palette) -> None:
         QPalette = QtGui.QPalette
         cfg = context.cfg
-        palette = QPalette()
         disabled = palette.color(QPalette.Disabled, QPalette.Text)
         header = qtutils.rgb_hex(disabled)
 
@@ -105,7 +108,10 @@ class DiffSyntaxHighlighter(QtGui.QSyntaxHighlighter):
             )
         )
 
-        self.setCurrentBlockState(self.INITIAL_STATE)
+    def refresh_palette(self, context) -> None:
+        """Update syntax colors to match the current application palette."""
+        self._configure_colors(context, qtutils.current_palette())
+        self.rehighlight()
 
     def set_intraline_spans(self, spans):
         """Set the per-line spans used for intra-line diff highlighting."""
@@ -274,6 +280,17 @@ class DiffTextEdit(VimHintedPlainTextEdit):
         self.cursorPositionChanged.connect(self._cursor_changed)
         self.selectionChanged.connect(self._selection_changed)
         self.mouse_zoomed.connect(self.update_block_cursor)
+
+    def refresh_appearance(self) -> None:
+        """Update palette-derived colors after a system appearance change."""
+        self.highlighter.refresh_palette(self.context)
+        if self.numbers:
+            self.numbers.refresh_palette()
+
+    def changeEvent(self, event):
+        if event.type() == QtCore.QEvent.PaletteChange:
+            self.refresh_appearance()
+        super().changeEvent(event)
 
     def setFont(self, font):
         """Override setFont() so that we can use a custom "block" cursor"""
@@ -553,14 +570,19 @@ class DiffLineNumbers(TextDecorator):
         self.setFont(font)
         self._char_width = qtutils.text_width(font, 'M')
 
+        self.refresh_palette()
+
+    def refresh_palette(self) -> None:
+        """Update line number colors to match the current palette."""
         QPalette = QtGui.QPalette
-        self._palette = palette = self.palette()
+        palette = self.palette()
         self._base = palette.color(QtGui.QPalette.Base)
         self._highlight = palette.color(QPalette.Highlight)
         self._highlight.setAlphaF(0.3)
         self._highlight_text = palette.color(QPalette.HighlightedText)
         self._window = palette.color(QPalette.Window)
         self._disabled = palette.color(QPalette.Disabled, QPalette.Text)
+        self.update()
 
     def set_diff(self, diff, lines=None):
         """Update to a new diff display"""

--- a/test/appearance_test.py
+++ b/test/appearance_test.py
@@ -1,0 +1,107 @@
+"""Tests for runtime appearance refresh behavior."""
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+from qtpy import QtGui
+from qtpy import QtWidgets
+
+from cola import app as cola_app
+from cola.widgets.diff import DiffSyntaxHighlighter
+
+
+@pytest.fixture(scope='module')
+def qapp():
+    """Provide a QApplication for widget tests."""
+    instance = QtWidgets.QApplication.instance()
+    if instance is None:
+        instance = QtWidgets.QApplication(
+            sys.argv[:1] if sys.argv else ['git-cola-test']
+        )
+    yield instance
+
+
+def _make_palette(*, dark: bool) -> QtGui.QPalette:
+    palette = QtGui.QPalette()
+    base = QtGui.QColor('#202025' if dark else '#ffffff')
+    palette.setColor(QtGui.QPalette.Base, base)
+    return palette
+
+
+def _hex_to_rgb(value: str) -> tuple[int, int, int]:
+    return (
+        int(value[0:2], 16),
+        int(value[2:4], 16),
+        int(value[4:6], 16),
+    )
+
+
+def _make_context():
+    context = MagicMock()
+    context.cfg.color.side_effect = lambda _key, default: _hex_to_rgb(default)
+    return context
+
+
+def test_refresh_system_appearance_rebuilds_default_theme():
+    """The default theme follows the system palette and must be rebuilt."""
+    cola = cola_app.ColaApplication.__new__(cola_app.ColaApplication)
+    cola.context = MagicMock()
+    cola.context.cfg.get.return_value = 'default'
+    cola._install_style = MagicMock()
+
+    cola._refresh_system_appearance()
+
+    cola._install_style.assert_called_once_with(None)
+
+
+def test_refresh_system_appearance_skips_non_default_theme():
+    """User-selected themes replace the palette and must not be overridden."""
+    cola = cola_app.ColaApplication.__new__(cola_app.ColaApplication)
+    cola.context = MagicMock()
+    cola.context.cfg.get.return_value = 'flat-dark-blue'
+    cola._install_style = MagicMock()
+
+    cola._refresh_system_appearance()
+
+    cola._install_style.assert_not_called()
+
+
+def test_diff_syntax_highlighter_uses_light_palette_defaults(qapp):
+    context = _make_context()
+    doc = QtGui.QTextDocument()
+    highlighter = DiffSyntaxHighlighter(context, doc)
+
+    highlighter._configure_colors(context, _make_palette(dark=False))
+
+    assert highlighter.color_add.red() == 0xD2
+    assert highlighter.color_add.green() == 0xFF
+    assert highlighter.color_add.blue() == 0xE4
+    assert highlighter.color_remove.red() == 0xFE
+    assert highlighter.color_remove.green() == 0xE0
+    assert highlighter.color_remove.blue() == 0xE4
+
+
+def test_diff_syntax_highlighter_uses_dark_palette_defaults(qapp):
+    context = _make_context()
+    doc = QtGui.QTextDocument()
+    highlighter = DiffSyntaxHighlighter(context, doc)
+
+    highlighter._configure_colors(context, _make_palette(dark=True))
+
+    assert highlighter.color_add.red() == 0x77
+    assert highlighter.color_add.green() == 0xAA
+    assert highlighter.color_add.blue() == 0x77
+    assert highlighter.color_remove.red() == 0xAA
+    assert highlighter.color_remove.green() == 0x77
+    assert highlighter.color_remove.blue() == 0x77
+
+
+def test_diff_syntax_highlighter_refresh_palette_rehighlights(qapp):
+    context = _make_context()
+    doc = QtGui.QTextDocument()
+    highlighter = DiffSyntaxHighlighter(context, doc)
+    highlighter.rehighlight = MagicMock()
+
+    highlighter.refresh_palette(context)
+
+    highlighter.rehighlight.assert_called_once()


### PR DESCRIPTION
My system switches theme automatically every morning/evening. And each time I have to restart the app to make it usable again.

This PR fixes this issu

Fixes: #1403

- **fix: refresh UI when macOS appearance changes at runtime**
- **test: add appearance refresh unit tests**

### Before
<img width="1398" height="1086" alt="2026-06-06 01 44 54" src="https://github.com/user-attachments/assets/e4965b87-e847-4d80-813a-275f87cc5bf6" />

### Now

<img width="1398" height="1086" alt="2026-06-06 01 44 28" src="https://github.com/user-attachments/assets/836ab1da-4812-48ee-ad08-ea3d13c4aaf3" />

