### PR TITLE
Display remote URL alongside remote name in push/fetch/pull dialog

### DIFF
--- a/cola/widgets/remote.py
+++ b/cola/widgets/remote.py
@@ -181,7 +181,11 @@ class RemoteActionDialog(standard.Dialog):
         if action == PUSH:
             mode = QtWidgets.QAbstractItemView.ExtendedSelection
             self.remotes.setSelectionMode(mode)
-        self.remotes.addItems(model.remotes)
+        displayed_remotes = []
+        for remote_name in model.remotes:
+            url = model.remote_url(remote_name, action)
+            displayed_remotes.append(f'{remote_name} ({url})')
+        self.remotes.addItems(displayed_remotes)
 
         self.remote_branch_label = QtWidgets.QLabel()
         self.remote_branch_label.setText(N_('Remote Branch'))


### PR DESCRIPTION
Fixes #1602

When using the Push, Fetch, or Pull dialog, the remote list only 
showed the remote name (e.g. "origin"). This made it hard to 
identify which remote corresponds to which repository, especially 
when multiple remotes are configured.

This change updates the remote list to show the remote name along 
with its URL in parentheses.

Before: origin
After: origin (https://github.com/user/repo.git)

The URL is fetched using the existing `model.remote_url()` method, 
so no new logic was needed.
<img width="1456" height="1017" alt="Screenshot 2026-06-07 210503" src="https://github.com/user-attachments/assets/a682ba9b-6549-4ae3-8f4d-a28b9637d40a" />
