### PR TITLE
Support copying multiple files at once

### DIFF
--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -731,6 +731,7 @@ class MainView(standard.MainWindow):
             self.diffeditor,
             self.bookmarkswidget.tree,
             self.recentwidget.tree,
+            self.statuswidget.tree,
         )
         select_widgets = copy_widgets + (self.statuswidget.tree,)
         edit_proxy.override('copy', copy_widgets)

--- a/cola/widgets/status.py
+++ b/cola/widgets/status.py
@@ -1283,9 +1283,13 @@ def view_history(context):
 
 
 def copy_path(context, absolute=True):
-    """Copy a selected path to the clipboard"""
-    filename = context.selection.filename()
-    qtutils.copy_path(filename, absolute=absolute)
+    """Copy selected path(s) to the clipboard"""
+    filenames = context.selection.group()
+    if not filenames:
+        return
+    if absolute:
+        filenames = [core.abspath(f) for f in filenames]
+    qtutils.set_clipboard('\n'.join(filenames))
 
 
 def copy_relpath(context):
@@ -1294,30 +1298,49 @@ def copy_relpath(context):
 
 
 def copy_basename(context):
-    filename = os.path.basename(context.selection.filename())
-    basename, _ = os.path.splitext(filename)
-    qtutils.copy_path(basename, absolute=False)
+    filenames = context.selection.group()
+    if not filenames:
+        return
+    basenames = []
+    for f in filenames:
+        basename, _ = os.path.splitext(os.path.basename(f))
+        basenames.append(basename)
+    qtutils.set_clipboard('\n'.join(basenames))
 
 
 def copy_leading_path(context, strip_components):
-    """Peal off trailing path components and copy the current path to the clipboard"""
-    filename = context.selection.filename()
-    value = filename
-    for _ in range(strip_components):
-        value = os.path.dirname(value)
-    qtutils.copy_path(value, absolute=False)
+    """Peel off trailing path components and copy the current path(s) to the clipboard"""
+    filenames = context.selection.group()
+    if not filenames:
+        return
+    seen = set()
+    values = []
+    for filename in filenames:
+        value = filename
+        for _ in range(strip_components):
+            value = os.path.dirname(value)
+        if value not in seen:
+            seen.add(value)
+            values.append(value)
+    qtutils.set_clipboard('\n'.join(values))
 
 
 def copy_format(context, fmt):
     """Add variables usable in the custom Copy format strings"""
-    values = {}
-    values['path'] = path = context.selection.filename()
-    values['abspath'] = abspath = os.path.abspath(path)
-    values['absdirname'] = os.path.dirname(abspath)
-    values['dirname'] = os.path.dirname(path)
-    values['filename'] = os.path.basename(path)
-    values['basename'], values['ext'] = os.path.splitext(os.path.basename(path))
-    qtutils.set_clipboard(fmt % values)
+    filenames = context.selection.group()
+    if not filenames:
+        return
+    lines = []
+    for path in filenames:
+        values = {}
+        values['path'] = path
+        values['abspath'] = abspath = os.path.abspath(path)
+        values['absdirname'] = os.path.dirname(abspath)
+        values['dirname'] = os.path.dirname(path)
+        values['filename'] = os.path.basename(path)
+        values['basename'], values['ext'] = os.path.splitext(os.path.basename(path))
+        lines.append(fmt % values)
+    qtutils.set_clipboard('\n'.join(lines))
 
 
 def show_help(context):

--- a/cola/widgets/status.py
+++ b/cola/widgets/status.py
@@ -1102,6 +1102,10 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
     def untracked_items(self):
         return qtutils.get_selected_items(self, UNTRACKED_IDX)
 
+    def copy(self):
+        """Called by FocusProxy when Cmd+C / Ctrl+C is pressed."""
+        copy_path(self.context)
+
     def show_selection(self):
         """Show the selected item."""
         context = self.context

--- a/test/widgets_status_copy_test.py
+++ b/test/widgets_status_copy_test.py
@@ -1,0 +1,108 @@
+"""Tests for the Copy actions in cola.widgets.status.
+
+These verify the multi-selection behaviour: selecting N files in the status
+tree and triggering "Copy Path" / "Copy Relative Path" / "Copy Basename" /
+"Copy Leading Path" / a custom "Copy Format" should put N newline-separated
+strings on the clipboard, not just the first file.
+"""
+from unittest.mock import patch
+
+from cola.widgets import status
+
+
+class _FakeSelection:
+    """Minimal stand-in for cola.models.selection.SelectionModel.
+
+    Real selection.group() returns the first non-empty list among
+    (staged, unmerged, modified, untracked); this fake honours the same
+    precedence so we can also assert the "staged wins over modified"
+    behaviour the copy helpers inherit.
+    """
+
+    def __init__(self, staged=None, unmerged=None, modified=None, untracked=None):
+        self._staged = staged or []
+        self._unmerged = unmerged or []
+        self._modified = modified or []
+        self._untracked = untracked or []
+
+    def group(self):
+        for bucket in (self._staged, self._unmerged, self._modified, self._untracked):
+            if bucket:
+                return bucket
+        return []
+
+
+class _FakeContext:
+    def __init__(self, selection):
+        self.selection = selection
+
+
+def _ctx(**kwargs):
+    return _FakeContext(_FakeSelection(**kwargs))
+
+
+def test_copy_path_relative_joins_selected_paths_with_newlines():
+    ctx = _ctx(modified=['a.py', 'sub/b.py', 'sub/c.py'])
+    with patch.object(status.qtutils, 'set_clipboard') as set_clipboard:
+        status.copy_path(ctx, absolute=False)
+    set_clipboard.assert_called_once_with('a.py\nsub/b.py\nsub/c.py')
+
+
+def test_copy_relpath_is_a_relative_copy():
+    """copy_relpath is documented to be copy_path(absolute=False)."""
+    ctx = _ctx(modified=['x.py', 'y.py'])
+    with patch.object(status.qtutils, 'set_clipboard') as set_clipboard:
+        status.copy_relpath(ctx)
+    set_clipboard.assert_called_once_with('x.py\ny.py')
+
+
+def test_copy_basename_strips_extensions_per_path():
+    ctx = _ctx(modified=['src/foo.py', 'src/bar.txt', 'baz'])
+    with patch.object(status.qtutils, 'set_clipboard') as set_clipboard:
+        status.copy_basename(ctx)
+    set_clipboard.assert_called_once_with('foo\nbar\nbaz')
+
+
+def test_copy_leading_path_deduplicates_repeated_prefixes():
+    """A multi-file selection inside one directory should not paste the same
+    leading path N times -- the helper deduplicates while preserving order."""
+    ctx = _ctx(modified=['src/foo.py', 'src/bar.py', 'tests/spam.py'])
+    with patch.object(status.qtutils, 'set_clipboard') as set_clipboard:
+        status.copy_leading_path(ctx, strip_components=1)
+    set_clipboard.assert_called_once_with('src\ntests')
+
+
+def test_copy_format_runs_the_template_per_selected_path():
+    ctx = _ctx(modified=['src/foo.py', 'src/bar.txt'])
+    with patch.object(status.qtutils, 'set_clipboard') as set_clipboard:
+        status.copy_format(ctx, '%(path)s::%(basename)s')
+    set_clipboard.assert_called_once_with('src/foo.py::foo\nsrc/bar.txt::bar')
+
+
+def test_copy_actions_are_a_no_op_when_nothing_is_selected():
+    """No selection -> clipboard is not touched at all."""
+    ctx = _ctx()  # all buckets empty
+    with patch.object(status.qtutils, 'set_clipboard') as set_clipboard:
+        status.copy_path(ctx)
+        status.copy_relpath(ctx)
+        status.copy_basename(ctx)
+        status.copy_leading_path(ctx, strip_components=1)
+        status.copy_format(ctx, '%(path)s')
+    set_clipboard.assert_not_called()
+
+
+def test_single_file_selection_does_not_produce_a_trailing_newline():
+    ctx = _ctx(staged=['only.py'])
+    with patch.object(status.qtutils, 'set_clipboard') as set_clipboard:
+        status.copy_path(ctx, absolute=False)
+    set_clipboard.assert_called_once_with('only.py')
+
+
+def test_staged_bucket_wins_over_modified_for_mixed_selections():
+    """selection.group() picks the first non-empty bucket. The Copy actions
+    inherit this -- selecting one staged file and one modified file copies
+    only the staged file, matching the long-standing single-file behaviour."""
+    ctx = _ctx(staged=['s.py'], modified=['m.py'])
+    with patch.object(status.qtutils, 'set_clipboard') as set_clipboard:
+        status.copy_path(ctx, absolute=False)
+    set_clipboard.assert_called_once_with('s.py')


### PR DESCRIPTION
Copying multiple files at once in the status window only copies the first file name, and I've been annoyed long enough by this quirk that I decided to fix it. :-)

Happy for this to be changed however you want. Not fussed, just would like a solution :P.

Users can select multiple files at once, but trying to copy multiple files via either a shortcut (CTRL+C/CMD+C) or via Right Click -> `Copy` -> `Copy Path to Clipboard`/`Copy Relative Path to Clipboard`/`Copy Leading Path to Clipboard`/`Copy Basename to Clipboard` only copies the first file.

<img width="1473" height="1045" alt="image" src="https://github.com/user-attachments/assets/d4b95366-145f-470d-b27c-720688a362cd" />

Instead, we can use `context.selection.group()` to get all the files in copy_path/copy_basename/copy_leading_path/copy_format, and split by new line (`\n`).

> Single-file selections still produce a single line with no trailing newline.