### PR TITLE
Improve Gravatar (use sha256, fix resizing of avatars)

### DIFF
--- a/cola/gravatar.py
+++ b/cola/gravatar.py
@@ -8,6 +8,7 @@ from qtpy import QtCore
 from qtpy import QtGui
 from qtpy import QtNetwork
 from qtpy import QtWidgets
+from qtpy.QtCore import Qt
 
 from . import core
 from . import icons
@@ -78,6 +79,9 @@ class GravatarLabel(QtWidgets.QLabel):
         # which may have moved on to a newer selection.
         self.requested: dict[str, str] = {}
         self._default_pixmap_bytes = None
+        # The default icon, decoded once and reused, so cache-misses don't
+        # re-decode PNG bytes on every commit.
+        self._default_pixmap: QPixmap | None = None
 
         self.network = QtNetwork.QNetworkAccessManager()
         self.network.finished.connect(self.network_finished)
@@ -100,6 +104,11 @@ class GravatarLabel(QtWidgets.QLabel):
                 return
             # The retry window has elapsed; allow another attempt.
             del self.failed[email]
+        # Show the default icon while the avatar is fetched. This must repaint
+        # even when an avatar is already displayed: the email has changed to an
+        # author we have not resolved yet, so continuing to show the previous
+        # author's avatar would attribute the wrong face to this commit.
+        # network_finished() swaps in the real avatar once the reply arrives.
         self.set_pixmap_from_default()
         self.request(email)
 
@@ -152,7 +161,9 @@ class GravatarLabel(QtWidgets.QLabel):
         if reply_error == no_error and not relocated:
             # A real avatar was returned. Cache it permanently for this email.
             response = reply.readAll()
-            pixmap = self.pixmap_from_bytes(response)
+            # Scale to the label's size so swapping avatars never resizes the
+            # label and nudges the layout, which reads as flicker.
+            pixmap = self._scale_to_imgsize(self.pixmap_from_bytes(response))
             if email is not None:
                 self.pixmaps[email] = pixmap
                 self.failed.pop(email, None)
@@ -184,9 +195,34 @@ class GravatarLabel(QtWidgets.QLabel):
         pixmap.loadFromData(data)
         return pixmap
 
+    def _scale_to_imgsize(self, pixmap: QPixmap) -> QPixmap:
+        """Scale a pixmap to the label's icon size with a smooth transform.
+
+        Keeping every displayed pixmap the same size means swapping the default
+        icon for a downloaded avatar (or one avatar for another) never resizes
+        the label, avoiding the layout jump that reads as flicker. The avatar is
+        already roughly imgsize (requested via s=imgsize), so this is usually a
+        no-op or a minor adjustment.
+        """
+        if pixmap.isNull():
+            return pixmap
+        size = self.imgsize
+        if pixmap.width() == size and pixmap.height() == size:
+            return pixmap
+        return pixmap.scaled(
+            size,
+            size,
+            Qt.KeepAspectRatio,
+            Qt.SmoothTransformation,
+        )
+
     def default_pixmap(self) -> QPixmap:
-        """Return the fallback git-cola icon as a QPixmap"""
-        return self.pixmap_from_bytes(self.default_pixmap_as_bytes())
+        """Return the fallback git-cola icon, decoded once and reused"""
+        if self._default_pixmap is None:
+            self._default_pixmap = self.pixmap_from_bytes(
+                self.default_pixmap_as_bytes()
+            )
+        return self._default_pixmap
 
     def set_pixmap_from_default(self) -> QPixmap:
         """Display the fallback icon and return it"""

--- a/cola/gravatar.py
+++ b/cola/gravatar.py
@@ -53,15 +53,30 @@ def sha256_hexdigest(value: str) -> core.UStr:
 
 
 class GravatarLabel(QtWidgets.QLabel):
+    # Re-request an email whose lookup failed only after this many seconds.
+    RETRY_INTERVAL_SECONDS = 5 * 60
+
     def __init__(self, context: ApplicationContext, parent: Any = None) -> None:
         QtWidgets.QLabel.__init__(self, parent)
 
         self.context = context
+        # The email whose avatar is currently meant to be displayed. Replies
+        # for any other email update the cache but must not repaint the label.
         self.email: str | None = None
-        self.response: bytes | None = None
-        self.timeout = 0
         self.imgsize = defs.medium_icon
-        self.pixmaps = {}
+        # Per-email pixmap cache. The single source of truth for what to show;
+        # populated for successful, default and missing-avatar lookups alike so
+        # an email is never requested twice once resolved.
+        self.pixmaps: dict[str, QPixmap] = {}
+        # Emails whose lookup failed, mapped to the time of failure. These are
+        # not cached as pixmaps so that the default icon is reused, but they
+        # are remembered to avoid hammering the network; retried after
+        # RETRY_INTERVAL_SECONDS.
+        self.failed: dict[str, int] = {}
+        # In-flight request URLs mapped back to the email that issued them, so
+        # a reply can identify its own email instead of relying on self.email,
+        # which may have moved on to a newer selection.
+        self.requested: dict[str, str] = {}
         self._default_pixmap_bytes = None
 
         self.network = QtNetwork.QNetworkAccessManager()
@@ -69,25 +84,38 @@ class GravatarLabel(QtWidgets.QLabel):
 
     def set_email(self, email: str) -> None:
         """Update the author icon based on the specified email"""
+        # Normalize as Gravatar does so case/whitespace variants of the same
+        # address share a single cache entry, request and reply attribution.
+        email = email.strip().lower()
+        self.email = email
         pixmap = self.pixmaps.get(email, None)
         if pixmap is not None:
             self.setPixmap(pixmap)
             return
-        if self.timeout > 0 and (int(time.time()) - self.timeout) < (5 * 60):
-            self.set_pixmap_from_response()
-            return
-        if email == self.email and self.response is not None:
-            self.set_pixmap_from_response()
-            return
-        self.email = email
+        # A recent failed lookup shows the default icon without re-requesting.
+        failed_at = self.failed.get(email)
+        if failed_at is not None:
+            if (int(time.time()) - failed_at) < self.RETRY_INTERVAL_SECONDS:
+                self.set_pixmap_from_default()
+                return
+            # The retry window has elapsed; allow another attempt.
+            del self.failed[email]
+        self.set_pixmap_from_default()
         self.request(email)
 
     def request(self, email) -> None:
         if prefs.enable_gravatar(self.context):
             url = Gravatar.url_for_email(email, self.imgsize)
+            # A request for this email is already in flight; don't issue a
+            # duplicate. The pending reply will repaint if still current.
+            if url in self.requested:
+                return
+            # Remember which email this URL belongs to so the reply can be
+            # attributed correctly even if the selection has since changed.
+            self.requested[url] = email
             self.network.get(QtNetwork.QNetworkRequest(QtCore.QUrl(url)))
         else:
-            self.pixmaps[email] = self.set_pixmap_from_response()
+            self.pixmaps[email] = self.set_pixmap_from_default()
 
     def default_pixmap_as_bytes(self) -> QByteArray:
         if self._default_pixmap_bytes is None:
@@ -105,37 +133,42 @@ class GravatarLabel(QtWidgets.QLabel):
         return byte_array
 
     def network_finished(self, reply: Any) -> None:
-        email = self.email
+        # Identify the email from the reply's own request URL rather than
+        # self.email, which may have advanced to a newer selection while this
+        # request was in flight. Without this, a slow reply could be attributed
+        # to (and cached under) the wrong author.
+        url = reply.url().toString()
+        email = self.requested.pop(url, None)
+
         location = qtutils.network_reply_header(reply, 'Location')
-        if location:
-            request_location = Gravatar.url_for_email(self.email, self.imgsize)
+        if location and email is not None:
+            request_location = Gravatar.url_for_email(email, self.imgsize)
             relocated = location != request_location
         else:
             relocated = False
         no_error = qtutils.enum_value(QtNetwork.QNetworkReply.NetworkError.NoError)
         reply_error = qtutils.enum_value(reply.error())
-        if reply_error == no_error:
-            if relocated:
-                # We could do get_url(parse.unquote(location)) to
-                # download the default image.
-                # Save bandwidth by using a pixmap.
-                self.response = self.default_pixmap_as_bytes()
-            else:
-                self.response = reply.readAll()
-            self.timeout = 0
+
+        if reply_error == no_error and not relocated:
+            # A real avatar was returned. Cache it permanently for this email.
+            response = reply.readAll()
+            pixmap = self.pixmap_from_bytes(response)
+            if email is not None:
+                self.pixmaps[email] = pixmap
+                self.failed.pop(email, None)
         else:
-            self.response = self.default_pixmap_as_bytes()
-            self.timeout = int(time.time())
+            # No avatar exists for this email (relocated to the default, or the
+            # request errored). Record the miss so the default icon is reused
+            # and the email is not re-requested until the retry window lapses.
+            pixmap = self.default_pixmap()
+            if email is not None:
+                self.failed[email] = int(time.time())
 
-        pixmap = self.set_pixmap_from_response()
-
-        # If the email has not changed (e.g. no other requests)
-        # then we know that this pixmap corresponds to this specific
-        # email address.  We can't blindly trust self.email else
-        # we may add cache entries for the wrong email address.
-        url = Gravatar.url_for_email(email, self.imgsize)
-        if url == reply.url().toString():
-            self.pixmaps[email] = pixmap
+        # Only repaint if this reply is for the email that is currently meant
+        # to be displayed. A late reply for a previous author must not clobber
+        # the avatar shown for the current one.
+        if email is not None and email == self.email:
+            self.setPixmap(pixmap)
 
         # Schedule reply destruction on the next event-loop tick. Without this,
         # Qt eventually tears the SSL socket down while the QNetworkReply is
@@ -145,10 +178,18 @@ class GravatarLabel(QtWidgets.QLabel):
         # https://doc.qt.io/qt-6/qnetworkaccessmanager.html#finished
         reply.deleteLater()
 
-    def set_pixmap_from_response(self) -> QPixmap:
-        if self.response is None:
-            self.response = self.default_pixmap_as_bytes()
+    def pixmap_from_bytes(self, data: QByteArray) -> QPixmap:
+        """Build a QPixmap from raw image bytes"""
         pixmap = QtGui.QPixmap()
-        pixmap.loadFromData(self.response)
+        pixmap.loadFromData(data)
+        return pixmap
+
+    def default_pixmap(self) -> QPixmap:
+        """Return the fallback git-cola icon as a QPixmap"""
+        return self.pixmap_from_bytes(self.default_pixmap_as_bytes())
+
+    def set_pixmap_from_default(self) -> QPixmap:
+        """Display the fallback icon and return it"""
+        pixmap = self.default_pixmap()
         self.setPixmap(pixmap)
         return pixmap

--- a/cola/gravatar.py
+++ b/cola/gravatar.py
@@ -26,9 +26,7 @@ if TYPE_CHECKING:
 class Gravatar:
     @staticmethod
     def url_for_email(email, imgsize) -> str:
-        email_hash = md5_hexdigest(email)
-        # Python2.6 requires byte strings for urllib2.quote() so we have
-        # to force
+        email_hash = sha256_hexdigest(email)
         default_url = 'https://git-cola.github.io/images/git-64x64.jpg'
         encoded_url = parse.quote(core.encode(default_url), core.encode(''))
         query = '?s=%d&d=%s' % (imgsize, core.decode(encoded_url))
@@ -36,28 +34,22 @@ class Gravatar:
         return url
 
 
-def md5_hexdigest(value: str) -> core.UStr | None:
-    """Return the md5 hexdigest for a value.
+def sha256_hexdigest(value: str) -> core.UStr:
+    """Return the SHA256 hexdigest of an email for the Gravatar API.
 
-    Used for implementing the gravatar API. Not used for security purposes.
+    Gravatar prefers SHA256 over MD5 and requires the email to be trimmed and
+    lower-cased before hashing. https://docs.gravatar.com/rest/hash/
+
+    SHA256 also resolves the FIPS crash that MD5 caused: on FIPS-enabled
+    systems hashlib.md5() raises ValueError and aborted git-dag (exit 134) the
+    moment a commit was viewed (https://github.com/git-cola/git-cola/issues/1157).
+    The old fix passed usedforsecurity=False to MD5, but that only exists on
+    Python 3.9+ and still asks OpenSSL to permit a FIPS-disallowed algorithm.
+    SHA256 is FIPS-approved, so the workaround is no longer needed. Do not
+    revert to MD5.
     """
-    # https://github.com/git-cola/git-cola/issues/1157
-    #  ValueError: error:060800A3:
-    #   digital envelope routines: EVP_DigestInit_ex: disabled for fips
-    #
-    # Newer versions of Python, including Centos8's patched Python3.6 and
-    # mainline Python 3.9+ have a "usedoforsecurity" parameter which allows us
-    # to continue using hashlib.md5().
-    encoded_value = core.encode(value)
-    result = ''
-    try:
-        # This could raise ValueError in theory but we always use encoded bytes
-        # so that does not happen in practice.
-        result = hashlib.md5(encoded_value, usedforsecurity=False).hexdigest()
-    except TypeError:
-        # Fallback to trying hashlib.md5 directly.
-        result = hashlib.md5(encoded_value).hexdigest()
-    return core.decode(result)
+    normalized = core.encode(value.strip().lower())
+    return core.decode(hashlib.sha256(normalized).hexdigest())
 
 
 class GravatarLabel(QtWidgets.QLabel):

--- a/test/gravatar_test.py
+++ b/test/gravatar_test.py
@@ -4,10 +4,18 @@ from cola.compat import ustr
 
 def test_url_for_email_():
     email = 'email@example.com'
+    # Gravatar prefers the SHA256 digest of the trimmed, lower-cased email.
     expect = (
-        'https://gravatar.com/avatar/5658ffccee7f0ebfda2b226238b1eb6e?s=64'
+        'https://gravatar.com/avatar/'
+        '2a539d6520266b56c3b0c525b9e6128858baeccb5ee9b694a2906e123c8d6dd3?s=64'
         + r'&d=https%3A%2F%2Fgit-cola.github.io%2Fimages%2Fgit-64x64.jpg'
     )
     actual = gravatar.Gravatar.url_for_email(email, 64)
     assert expect == actual
     assert isinstance(actual, ustr)
+
+
+def test_url_for_email_normalizes_case_and_whitespace():
+    """Trimming and lower-casing yield the same URL as the canonical form."""
+    canonical = gravatar.Gravatar.url_for_email('email@example.com', 64)
+    assert gravatar.Gravatar.url_for_email('  Email@Example.COM  ', 64) == canonical

--- a/test/gravatar_test.py
+++ b/test/gravatar_test.py
@@ -190,3 +190,64 @@ def test_disabled_gravatar_uses_default_without_network(qapp):
     label.network.get.assert_not_called()
     assert email in label.pixmaps
     assert isinstance(label.pixmaps[email], QtGui.QPixmap)
+
+
+def test_switching_to_uncached_email_shows_default_not_stale_avatar(qapp):
+    """Switching authors shows the default while loading, never the old face.
+
+    Regression: holding the previous author's avatar during the fetch made a
+    commit whose author has no gravatar display the wrong person's picture.
+    """
+    label = _make_label()
+    alice = 'alice@example.com'
+    bob = 'bob@example.com'
+
+    # Resolve alice so the label is showing alice's real avatar.
+    label.set_email(alice)
+    label.network_finished(_real_avatar_reply(label, alice))
+    alice_pixmap = label.pixmaps[alice]
+
+    painted = []
+    label.setPixmap = lambda pixmap: painted.append(pixmap)
+
+    # Switching to an uncached author must repaint the default immediately, so
+    # alice's face is not shown for bob's commit while bob's avatar loads.
+    label.set_email(bob)
+    assert len(painted) == 1
+    assert painted[0] is not alice_pixmap
+    assert painted[0] is label.default_pixmap()
+    assert label.network.get.call_count == 2  # bob is requested
+
+    # bob turns out to have no avatar -> the default stays (no stale alice).
+    label.network_finished(_missing_avatar_reply(label, bob))
+    assert painted[-1] is label.default_pixmap()
+
+
+def test_revisiting_cached_miss_shows_default_not_stale_avatar(qapp):
+    """An author with a known-missing avatar shows the default, not the prior face."""
+    label = _make_label()
+    alice = 'alice@example.com'
+    bob = 'bob@example.com'
+
+    # alice has an avatar; bob is a known miss.
+    label.set_email(alice)
+    label.network_finished(_real_avatar_reply(label, alice))
+    label.set_email(bob)
+    label.network_finished(_missing_avatar_reply(label, bob))
+
+    # Show alice again (cached avatar), then bob again (cached miss).
+    label.set_email(alice)
+    painted = []
+    label.setPixmap = lambda pixmap: painted.append(pixmap)
+    label.set_email(bob)
+    # bob's miss is cached, so no new request and the default is shown.
+    assert label.network.get.call_count == 2
+    assert painted[-1] is label.default_pixmap()
+
+
+def test_default_pixmap_decoded_once(qapp):
+    """The fallback icon is decoded a single time and reused."""
+    label = _make_label()
+    first = label.default_pixmap()
+    second = label.default_pixmap()
+    assert first is second

--- a/test/gravatar_test.py
+++ b/test/gravatar_test.py
@@ -1,5 +1,14 @@
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
 from cola import gravatar
 from cola.compat import ustr
+from cola.gravatar import Gravatar
+from cola.gravatar import GravatarLabel
+from qtpy import QtGui
+from qtpy import QtWidgets
 
 
 def test_url_for_email_():
@@ -19,3 +28,165 @@ def test_url_for_email_normalizes_case_and_whitespace():
     """Trimming and lower-casing yield the same URL as the canonical form."""
     canonical = gravatar.Gravatar.url_for_email('email@example.com', 64)
     assert gravatar.Gravatar.url_for_email('  Email@Example.COM  ', 64) == canonical
+
+
+@pytest.fixture(scope='module')
+def qapp():
+    """Provide a QApplication for widget tests."""
+    instance = QtWidgets.QApplication.instance()
+    if instance is None:
+        instance = QtWidgets.QApplication(
+            sys.argv[:1] if sys.argv else ['git-cola-test']
+        )
+    yield instance
+
+
+class FakeReply:
+    """Minimal stand-in for QNetworkReply used to drive network_finished."""
+
+    def __init__(self, url, *, error=0, location='', data=b'avatar-bytes'):
+        self._url = url
+        self._error = error
+        self._location = location
+        self._data = data
+        self.deleted = False
+
+    def url(self):
+        mock = MagicMock()
+        mock.toString.return_value = self._url
+        return mock
+
+    def error(self):
+        return self._error
+
+    def rawHeader(self, _name):
+        return self._location.encode('utf-8')
+
+    def readAll(self):
+        return self._data
+
+    def deleteLater(self):
+        self.deleted = True
+
+
+def _make_label(enable_gravatar=True):
+    context = MagicMock()
+    context.cfg.get.return_value = enable_gravatar
+    label = GravatarLabel(context)
+    # Avoid real network traffic; capture requested URLs instead.
+    label.network = MagicMock()
+    return label
+
+
+def _real_avatar_reply(label, email):
+    """A reply that returns an actual avatar (no Location redirect)."""
+    url = Gravatar.url_for_email(email, label.imgsize)
+    return FakeReply(url, error=0, location='', data=b'\x89PNG real-avatar')
+
+
+def _missing_avatar_reply(label, email):
+    """A reply redirected to the default image (no avatar for this email)."""
+    url = Gravatar.url_for_email(email, label.imgsize)
+    return FakeReply(url, error=0, location='https://example.com/default.png')
+
+
+def test_successful_avatar_is_cached(qapp):
+    """A fetched avatar is cached and reused without re-requesting."""
+    label = _make_label()
+    email = 'alice@example.com'
+
+    label.set_email(email)
+    assert label.network.get.call_count == 1  # initial request
+
+    label.network_finished(_real_avatar_reply(label, email))
+    assert email in label.pixmaps
+
+    # Revisiting the same author hits the cache; no new request.
+    label.set_email(email)
+    assert label.network.get.call_count == 1
+
+
+def test_missing_avatar_is_not_re_requested(qapp):
+    """An email with no avatar is remembered and not requested again."""
+    label = _make_label()
+    email = 'noavatar@example.com'
+
+    label.set_email(email)
+    assert label.network.get.call_count == 1
+
+    # Reply redirects to the default image -> recorded as a miss.
+    label.network_finished(_missing_avatar_reply(label, email))
+    assert email in label.failed
+    assert email not in label.pixmaps
+
+    # Revisiting must not fire another request within the retry window.
+    label.set_email(email)
+    assert label.network.get.call_count == 1
+
+
+def test_missing_avatar_retried_after_window(qapp):
+    """A failed lookup is retried once the retry window elapses."""
+    label = _make_label()
+    email = 'noavatar@example.com'
+
+    label.set_email(email)
+    label.network_finished(_missing_avatar_reply(label, email))
+    assert label.network.get.call_count == 1
+
+    # Age the failure beyond the retry window.
+    label.failed[email] -= label.RETRY_INTERVAL_SECONDS + 1
+    label.set_email(email)
+    assert label.network.get.call_count == 2
+
+
+def test_late_reply_for_previous_email_does_not_repaint(qapp):
+    """A reply for an old author must not overwrite the current avatar."""
+    label = _make_label()
+    alice = 'alice@example.com'
+    bob = 'bob@example.com'
+
+    # Request alice, then immediately switch to bob before alice resolves.
+    label.set_email(alice)
+    label.set_email(bob)
+    assert label.email == bob
+
+    captured = []
+    label.setPixmap = lambda pixmap: captured.append(pixmap)
+
+    # Alice's (stale) reply arrives now.
+    label.network_finished(_real_avatar_reply(label, alice))
+    # Alice is still cached for later, but the visible label is not repainted.
+    assert alice in label.pixmaps
+    assert captured == []
+
+    # Bob's reply arrives and does repaint, since bob is current.
+    label.network_finished(_real_avatar_reply(label, bob))
+    assert bob in label.pixmaps
+    assert len(captured) == 1
+
+
+def test_inflight_request_is_not_duplicated(qapp):
+    """Revisiting an email whose request is still pending issues no duplicate."""
+    label = _make_label()
+    email = 'alice@example.com'
+
+    label.set_email(email)
+    assert label.network.get.call_count == 1
+
+    # Switch away and back while the first request is still in flight.
+    label.set_email('bob@example.com')
+    label.set_email(email)
+    # alice's request is still pending, so no second alice request is sent;
+    # bob's is the only additional request.
+    assert label.network.get.call_count == 2
+
+
+def test_disabled_gravatar_uses_default_without_network(qapp):
+    """With gravatar disabled, the default icon is cached and no request fires."""
+    label = _make_label(enable_gravatar=False)
+    email = 'alice@example.com'
+
+    label.set_email(email)
+    label.network.get.assert_not_called()
+    assert email in label.pixmaps
+    assert isinstance(label.pixmaps[email], QtGui.QPixmap)


### PR DESCRIPTION
Scrolling through commits in `DAG` would show a delay and "flicker" when Gravatar is enabled.

I have been doing a fair bit of git history spelunking in the last week or so, and this was annoying me :-).

Before:

https://github.com/user-attachments/assets/7f81c899-46a5-48bc-831c-5203de8de7f3

After:

https://github.com/user-attachments/assets/59e52c73-d4a5-4992-992f-db61bd8feee5

--

After going down this new rabbithole, I also found that Gravatar changed their avatar lookup to SHA256, which means we can now simplify the lookup, see: https://docs.gravatar.com/rest/hash .

I then started testing across various repos, finding weird bugs, mostly due to pixmap misunderstandings, so I tried to create a test for every example I found.

---

I then was getting annoyed by the rendering of the avatars, and the "flickering"/loading, so I learnt more about pixmaps, and use that as the default.

As a result, scrolling through the DAG view is now much nicer, IMHO, as it doesn't nudge about the layout.

---

I've split the work into three commits, happy for this to be split into smaller work, as always - take whatever you think is useful for the commits (none, some, all, I don't mind), rework how you see fit.

I'm going to continue testing this to ensure I haven't created any weird bugs, hence the draft.