### PR TITLE
diff: debounce DAG diff loading and drop superseded results

### DIFF
--- a/cola/widgets/diff.py
+++ b/cola/widgets/diff.py
@@ -1947,6 +1947,11 @@ class AuthorLabel(PlainTextLabel):
 class CommitDiffWidget(QtWidgets.QWidget):
     """Display commit metadata and text diffs"""
 
+    # Delay before a selected commit's diff is loaded. Holding an arrow key
+    # in the DAG steps through commits faster than this, so intermediate
+    # commits never trigger a "git diff"; only the commit we land on does.
+    DIFF_DEBOUNCE_MSEC = 100
+
     def __init__(self, context, parent, is_commit=False, options=None):
         QtWidgets.QWidget.__init__(self, parent)
 
@@ -1955,6 +1960,22 @@ class CommitDiffWidget(QtWidgets.QWidget):
         self.oid_start = None
         self.oid_end = None
         self.options = options
+
+        # Debounce diff loading so that rapidly moving the selection (e.g.
+        # holding an arrow key in the DAG) only loads the diff for the commit
+        # we settle on rather than spawning a "git diff" for every commit we
+        # pass over.
+        self._pending_diff = None
+        self._diff_timer = QtCore.QTimer(self)
+        self._diff_timer.setSingleShot(True)
+        self._diff_timer.setInterval(self.DIFF_DEBOUNCE_MSEC)
+        self._diff_timer.timeout.connect(self._load_pending_diff)
+        # Monotonic token used to discard results from superseded diff tasks.
+        # Each started task captures the current value; set_diff only applies a
+        # result when its token still matches, so a slow diff that finishes
+        # after the selection has moved on is dropped instead of stomping the
+        # view.
+        self._diff_token = 0
 
         author_font = QtGui.QFont(self.font())
         author_font.setPointSize(int(author_font.pointSize() * 1.1))
@@ -2021,7 +2042,11 @@ class CommitDiffWidget(QtWidgets.QWidget):
         """Clear the display and start a diff-gathering task"""
         self.diff.save_scrollbar()
         cmds.do(cmds.DiffLoading, self.context)
-        self.context.runtask.start(task, result=self.set_diff)
+        # Stamp the task so that a result arriving after the selection has
+        # already moved on can be discarded in set_diff().
+        self._diff_token += 1
+        token = self._diff_token
+        self.context.runtask.start(task, result=lambda diff: self.set_diff(diff, token))
 
     def set_diff_oid(self, oid, filename=None):
         """Set the diff from a single commit object ID"""
@@ -2035,6 +2060,8 @@ class CommitDiffWidget(QtWidgets.QWidget):
     def commits_selected(self, commits):
         """Display an appropriate diff when commits are selected"""
         if not commits:
+            self._diff_timer.stop()
+            self._pending_diff = None
             self.clear()
             return
         commit = commits[-1]
@@ -2043,21 +2070,41 @@ class CommitDiffWidget(QtWidgets.QWidget):
         email = commit.email or ''
         date = commit.authdate or ''
         summary = commit.summary or ''
+        # Metadata is already in hand, so update it immediately to keep the
+        # selection feeling responsive. Only the expensive diff is debounced.
         self.set_details(oid, author, email, date, summary)
         self.oid = oid
 
         if len(commits) > 1:
             start, end = commits[0], commits[-1]
-            self.set_diff_range(start.oid, end.oid)
+            self._pending_diff = ('range', start.oid, end.oid)
             self.oid_start = start
             self.oid_end = end
         else:
-            self.set_diff_oid(oid)
+            self._pending_diff = ('oid', oid)
             self.oid_start = None
             self.oid_end = None
+        # (Re)start the debounce; the diff loads once the selection settles.
+        self._diff_timer.start()
 
-    def set_diff(self, diff):
+    def _load_pending_diff(self):
+        """Load the diff for the most recently selected commit(s)"""
+        pending = self._pending_diff
+        if pending is None:
+            return
+        self._pending_diff = None
+        if pending[0] == 'range':
+            _, start, end = pending
+            self.set_diff_range(start, end)
+        else:
+            _, oid = pending
+            self.set_diff_oid(oid)
+
+    def set_diff(self, diff, token=None):
         """Set the diff text"""
+        # Drop results from superseded tasks; only the latest token applies.
+        if token is not None and token != self._diff_token:
+            return
         self.diff.set_diff(diff)
 
     def set_details(self, oid, author, email, date, summary):

--- a/test/diff_debounce_test.py
+++ b/test/diff_debounce_test.py
@@ -1,0 +1,107 @@
+"""Tests for the debounced, supersede-guarded diff loading in CommitDiffWidget.
+
+Stepping commit-to-commit in the DAG must not spawn a "git diff" for every
+commit passed over, and a slow diff that finishes after the selection has
+moved on must not overwrite the diff for the current commit.
+"""
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from cola.widgets.diff import CommitDiffWidget
+from qtpy import QtWidgets
+
+from .helper import app_context
+
+# Prevent unused imports lint errors.
+assert app_context is not None
+
+
+@pytest.fixture(scope='module')
+def qapp():
+    """Provide a QApplication for widget tests."""
+    instance = QtWidgets.QApplication.instance()
+    if instance is None:
+        instance = QtWidgets.QApplication(
+            sys.argv[:1] if sys.argv else ['git-cola-test']
+        )
+    yield instance
+
+
+def _make_commit(oid):
+    commit = MagicMock()
+    commit.oid = oid
+    commit.author = 'A U Thor'
+    commit.email = 'author@example.com'
+    commit.authdate = '2026-01-01'
+    commit.summary = 'summary'
+    return commit
+
+
+def _make_widget(app_context):
+    widget = CommitDiffWidget(app_context, None, is_commit=True)
+    # Observe diff task scheduling without running real git.
+    app_context.runtask = MagicMock()
+    return widget
+
+
+def test_commits_selected_debounces_diff_load(qapp, app_context):
+    """Rapid selection changes only load the diff for the settled-on commit."""
+    widget = _make_widget(app_context)
+
+    # Step through three commits faster than the debounce interval.
+    for oid in ('a' * 40, 'b' * 40, 'c' * 40):
+        widget.commits_selected([_make_commit(oid)])
+
+    # No diff task has been started yet -- only the timer is pending.
+    app_context.runtask.start.assert_not_called()
+    assert widget._pending_diff == ('oid', 'c' * 40)
+    # Metadata still tracks the latest selection for immediate responsiveness.
+    assert widget.oid == 'c' * 40
+
+    # Fire the debounce as the event loop eventually would.
+    widget._load_pending_diff()
+    assert app_context.runtask.start.call_count == 1
+    assert widget._pending_diff is None
+
+
+def test_empty_selection_cancels_pending_diff(qapp, app_context):
+    """Clearing the selection drops any pending diff load."""
+    widget = _make_widget(app_context)
+
+    widget.commits_selected([_make_commit('a' * 40)])
+    assert widget._pending_diff is not None
+
+    widget.commits_selected([])
+    assert widget._pending_diff is None
+    assert not widget._diff_timer.isActive()
+    app_context.runtask.start.assert_not_called()
+
+
+def test_set_diff_drops_superseded_result(qapp, app_context):
+    """A result from a superseded task is discarded; the latest one applies."""
+    widget = _make_widget(app_context)
+    widget.diff = MagicMock()
+
+    # Two diffs started in sequence: a stale token (1) then the current one (2).
+    stale_token = 1
+    current_token = 2
+    widget._diff_token = current_token
+
+    # The stale result arrives late and must be ignored.
+    widget.set_diff('stale diff', stale_token)
+    widget.diff.set_diff.assert_not_called()
+
+    # The current result is applied.
+    widget.set_diff('current diff', current_token)
+    widget.diff.set_diff.assert_called_once_with('current diff')
+
+
+def test_set_diff_without_token_applies_immediately(qapp, app_context):
+    """Direct callers (e.g. graph diff) pass no token and are never dropped."""
+    widget = _make_widget(app_context)
+    widget.diff = MagicMock()
+
+    widget.set_diff('direct diff')
+    widget.diff.set_diff.assert_called_once_with('direct diff')


### PR DESCRIPTION
"Scrolling" (e.g using up/down arrow keys) commit-to-commit in the DAG felt sluggish because every selection change synchronously kicked off "git log %b" + "git diff" for the commit passed over, even while holding an arrow key through dozens of commits.

CommitDiffWidget now updates the metadata labels immediately (so the selection stays responsive) but defers the diff load behind a 100ms single-shot timer, so only the commit the selection settles on triggers git.

Each started diff task is stamped with a monotonic token; set_diff drops a result whose token is no longer current, so a slow diff finishing after the selection has moved on cannot overwrite the diff for the current commit. (Empty selection cancels any pending load.)

---

Before:

https://github.com/user-attachments/assets/94b67679-c806-46bb-bcd7-abd11b7ba49b

After:

https://github.com/user-attachments/assets/61ebdeac-4bf1-4387-862e-3e4ab3a388f5

IMHO, the debounce could be a setting, as it's really noticeable for larger repositories.