### PR TITLE
cola: implement basic server/client mode

### DIFF
--- a/cola/app.py
+++ b/cola/app.py
@@ -159,8 +159,8 @@ def _get_askpass(ops: operations.IOperations) -> TextType:
     if sys.platform == 'darwin':
         return resources.package_command('ssh-askpass-darwin')
 
-    kde_askpass = core.find_executable('ksshaskpass')
-    gnome_askpass = core.find_executable('gnome-ssh-askpass')
+    kde_askpass = ops.find_executable('ksshaskpass')
+    gnome_askpass = ops.find_executable('gnome-ssh-askpass')
     if gnome_askpass is None:
         gnome_askpass = '/usr/lib/openssh/gnome-ssh-askpass'
 

--- a/cola/app.py
+++ b/cola/app.py
@@ -90,10 +90,12 @@ def setup_environment() -> None:
     # Spoof an X11 display for SSH
     os.environ.setdefault('DISPLAY', ':0')
 
+    ops = operations.LocalOperations()
+
     if not core.getenv('SHELL', ''):
         for shell in ('/bin/zsh', '/bin/bash', '/bin/sh'):
             if os.path.exists(shell):
-                compat.setenv('SHELL', shell)
+                compat.setenv(ops, 'SHELL', shell)
                 break
 
     # Setup the path so that git finds us when we run 'git cola'
@@ -101,19 +103,19 @@ def setup_environment() -> None:
     bindir = core.decode(os.path.dirname(sys_argv0))
     path_entries.append(bindir)
     path = os.pathsep.join(path_entries)
-    compat.setenv('PATH', path)
+    compat.setenv(ops, 'PATH', path)
 
     # We don't ever want a pager
-    compat.setenv('GIT_PAGER', '')
+    compat.setenv(ops, 'GIT_PAGER', '')
 
     # Setup the openssh askpass credentials helper.
-    askpass = _get_askpass(operations.LocalOperations())
-    compat.setenv('GIT_ASKPASS', askpass)
-    compat.setenv('SSH_ASKPASS', askpass)
+    askpass = _get_askpass(ops)
+    compat.setenv(ops, 'GIT_ASKPASS', askpass)
+    compat.setenv(ops, 'SSH_ASKPASS', askpass)
 
     # Avoid taking optional locks for read-only operations.
     # We assume that proper state-modifying operations continue to take locks.
-    compat.setenv('GIT_OPTIONAL_LOCKS', '0')
+    compat.setenv(ops, 'GIT_OPTIONAL_LOCKS', '0')
 
     # --- >8 --- >8 ---
     # Git v1.7.10 Release Notes
@@ -145,7 +147,7 @@ def setup_environment() -> None:
     # --- >8 --- >8 ---
     # Longer-term: Use `git merge --no-commit` so that we always
     # have a chance to explain our merges.
-    compat.setenv('GIT_MERGE_AUTOEDIT', 'no')
+    compat.setenv(ops, 'GIT_MERGE_AUTOEDIT', 'no')
 
 
 def _get_askpass(ops: operations.IOperations) -> TextType:
@@ -159,8 +161,8 @@ def _get_askpass(ops: operations.IOperations) -> TextType:
     if sys.platform == 'darwin':
         return resources.package_command('ssh-askpass-darwin')
 
-    kde_askpass = ops.find_executable('ksshaskpass')
-    gnome_askpass = ops.find_executable('gnome-ssh-askpass')
+    kde_askpass = core.find_executable('ksshaskpass')
+    gnome_askpass = core.find_executable('gnome-ssh-askpass')
     if gnome_askpass is None:
         gnome_askpass = '/usr/lib/openssh/gnome-ssh-askpass'
 
@@ -401,7 +403,7 @@ def process_args(args: argparse.Namespace, ops, setup_repo: bool = False) -> Non
         sys.exit(core.EXIT_SUCCESS)
 
     # Handle session management
-    restore_session(ops, args)
+    restore_session(args)
 
     # Initialize args.repo. If a repository was specified as a
     # positional argument then we will use that value.
@@ -428,7 +430,7 @@ def process_args(args: argparse.Namespace, ops, setup_repo: bool = False) -> Non
         sys.exit(core.EXIT_USAGE)
 
 
-def restore_session(ops, args: argparse.Namespace) -> None:
+def restore_session(args: argparse.Namespace) -> None:
     """Load a session based on the window-manager provided arguments"""
     # args.settings is provided when restoring from a session.
     args.settings = None
@@ -747,7 +749,7 @@ def initialize() -> str:
     ops: operations.IOperations = operations.LocalOperations()
     git_path = find_git(ops)
     if git_path:
-        prepend_path(git_path)
+        prepend_path(ops, git_path)
 
     # The current directory may have been deleted while we are still
     # in that directory.  We rectify this situation by walking up the
@@ -926,13 +928,13 @@ def find_git(ops) -> str | None:
     return None
 
 
-def prepend_path(path) -> None:
+def prepend_path(path, ops) -> None:
     """Adds git to the PATH.  This is needed on Windows."""
     path = core.decode(path)
     path_entries = core.getenv('PATH', '').split(os.pathsep)
     if path not in path_entries:
         path_entries.insert(0, path)
-        compat.setenv('PATH', os.pathsep.join(path_entries))
+        compat.setenv(ops, 'PATH', os.pathsep.join(path_entries))
 
 
 def detect_system_theme() -> str:

--- a/cola/app.py
+++ b/cola/app.py
@@ -390,12 +390,16 @@ class ColaQApplication(QtWidgets.QApplication):
         sid = session_mgr.sessionId()
         skey = session_mgr.sessionKey()
         session_id = f'{sid}_{skey}'
-        session = Session(session_id, repo=core.getcwd())
+        session = Session(session_id, repo=self.context.ops.getcwd())
         session.update()
         view.save_state(settings=session)
 
 
-def process_args(args: argparse.Namespace, ops, setup_repo: bool = False) -> None:
+def process_args(
+    ops: operations.IOperations,
+    args: argparse.Namespace,
+    setup_repo: bool = False,
+) -> None:
     """Process and verify command-line arguments"""
     if args.version:
         # Accept 'git cola --version' or 'git cola version'
@@ -403,7 +407,7 @@ def process_args(args: argparse.Namespace, ops, setup_repo: bool = False) -> Non
         sys.exit(core.EXIT_SUCCESS)
 
     # Handle session management
-    restore_session(args)
+    restore_session(ops, args)
 
     # Initialize args.repo. If a repository was specified as a
     # positional argument then we will use that value.
@@ -426,17 +430,17 @@ def process_args(args: argparse.Namespace, ops, setup_repo: bool = False) -> Non
             )
             % repo
         )
-        core.print_stderr(errmsg)
+        ops.print_stderr(errmsg)
         sys.exit(core.EXIT_USAGE)
 
 
-def restore_session(args: argparse.Namespace) -> None:
+def restore_session(ops: operations.IOperations, args: argparse.Namespace) -> None:
     """Load a session based on the window-manager provided arguments"""
     # args.settings is provided when restoring from a session.
     args.settings = None
     if args.session is None:
         return
-    session = Session(args.session)
+    session = Session(args.session, ops)
     if session.load():
         args.settings = session
         args.repo = session.repo
@@ -902,7 +906,7 @@ class Notifier(QtCore.QObject):
         self.emit_log(f'[git] {message}')
 
 
-def find_git(ops) -> str | None:
+def find_git(ops: operations.IOperations) -> str | None:
     """Return the path of git.exe, or None if we can't find it."""
     if not utils.is_win32():
         return None  # UNIX systems have git in their $PATH

--- a/cola/app.py
+++ b/cola/app.py
@@ -55,6 +55,7 @@ from . import guicmds
 from . import hidpi
 from . import i18n
 from . import icons
+from . import operations
 from . import qtcompat
 from . import qtutils
 from . import resources
@@ -106,7 +107,7 @@ def setup_environment() -> None:
     compat.setenv('GIT_PAGER', '')
 
     # Setup the openssh askpass credentials helper.
-    askpass = _get_askpass()
+    askpass = _get_askpass(operations.LocalOperations())
     compat.setenv('GIT_ASKPASS', askpass)
     compat.setenv('SSH_ASKPASS', askpass)
 
@@ -147,7 +148,7 @@ def setup_environment() -> None:
     compat.setenv('GIT_MERGE_AUTOEDIT', 'no')
 
 
-def _get_askpass() -> TextType:
+def _get_askpass(ops: operations.IOperations) -> TextType:
     """Get a default askpass program appropriate for the current environment"""
     git_askpass = core.getenv('GIT_ASKPASS')
     ssh_askpass = core.getenv('SSH_ASKPASS')
@@ -170,7 +171,7 @@ def _get_askpass() -> TextType:
         order = (kde_askpass, gnome_askpass)
 
     for askpass in order:
-        if askpass and os.path.exists(askpass):
+        if askpass and ops.exists(askpass):
             return askpass
 
     return resources.package_command('ssh-askpass')
@@ -392,7 +393,7 @@ class ColaQApplication(QtWidgets.QApplication):
         view.save_state(settings=session)
 
 
-def process_args(args: argparse.Namespace, setup_repo: bool = False) -> None:
+def process_args(args: argparse.Namespace, ops, setup_repo: bool = False) -> None:
     """Process and verify command-line arguments"""
     if args.version:
         # Accept 'git cola --version' or 'git cola version'
@@ -400,22 +401,22 @@ def process_args(args: argparse.Namespace, setup_repo: bool = False) -> None:
         sys.exit(core.EXIT_SUCCESS)
 
     # Handle session management
-    restore_session(args)
+    restore_session(ops, args)
 
     # Initialize args.repo. If a repository was specified as a
     # positional argument then we will use that value.
     # If unspecified, the current directory is used.
     if setup_repo and not args.repo:
-        if args.args and git.is_git_repository(args.args[0]):
+        if args.args and git.is_git_repository(ops, args.args[0]):
             args.repo = args.args.pop(0)
     if not args.repo:
-        args.repo = core.getcwd()
+        args.repo = ops.getcwd()
 
     # Bail out if --repo is not a directory
     repo: TextType = core.decode(args.repo)
     repo = repo.removeprefix('file:')
-    repo = core.realpath(repo)
-    if not core.isdir(repo):
+    repo = ops.realpath(repo)
+    if not ops.isdir(repo):
         errmsg = (
             N_(
                 'fatal: "%s" is not a directory.  '
@@ -427,7 +428,7 @@ def process_args(args: argparse.Namespace, setup_repo: bool = False) -> None:
         sys.exit(core.EXIT_USAGE)
 
 
-def restore_session(args: argparse.Namespace) -> None:
+def restore_session(ops, args: argparse.Namespace) -> None:
     """Load a session based on the window-manager provided arguments"""
     # args.settings is provided when restoring from a session.
     args.settings = None
@@ -449,10 +450,12 @@ def application_init(
     """Parses the command-line arguments and starts git-cola"""
     # Ensure that we're working in a valid git repository.
     # If not, try to find one.  When found, chdir there.
-    setup_environment()
-    process_args(args, setup_repo=setup_repo)
+    ops = operations.LocalOperations()
 
-    context = new_context(args, app_name=app_name)
+    setup_environment()
+    process_args(ops, args, setup_repo=setup_repo)
+
+    context = new_context(ops, args, app_name=app_name)
     enforce_single_instance(context)
 
     timer = context.timer
@@ -470,13 +473,16 @@ def application_init(
 
 
 def new_context(
-    args: argparse.Namespace, app_name: str = 'Git Cola'
+    ops: operations.IOperations,
+    args: argparse.Namespace,
+    app_name: str = 'Git Cola',
 ) -> ApplicationContext:
     """Create top-level ApplicationContext objects"""
     context = ApplicationContext(args)
     context.timestamp = time.time()
     context.settings = args.settings or Settings.read()
-    context.git = git.create()
+    context.ops = ops
+    context.git = git.create(context.ops)
     context.cfg = gitcfg.create(context)
     context.fsmonitor = fsmonitor.create(context)
     context.selection = selection.create()
@@ -490,8 +496,9 @@ def new_context(
 
 def create_context() -> ApplicationContext:
     """Create a one-off context from the current directory"""
-    args = null_args()
-    return new_context(args)  # type: ignore[arg-type]
+    ops = operations._create_ops()
+    args = null_args(ops)
+    return new_context(ops, args)  # type: ignore[arg-type]
 
 
 def enforce_single_instance(context: ApplicationContext) -> None:
@@ -508,7 +515,7 @@ def enforce_single_instance(context: ApplicationContext) -> None:
     # the app from within their repository and we will prevent multiple instances
     # from being launched from within that same repository.
     shared_mem_id = window_id + '-'
-    current_dir_hash = utils.sha256hex(os.getcwd())
+    current_dir_hash = utils.sha256hex(context.ops.getcwd())
     # Shared memory IDs can be max 30 characters on macOS.
     remaining_bytes = 30 - len(shared_mem_id)
     shared_mem_id += current_dir_hash[:-remaining_bytes]
@@ -534,7 +541,7 @@ def enforce_single_instance(context: ApplicationContext) -> None:
     if is_running:
         format_vars = {
             'app_name': context.app_name,
-            'dirname': os.getcwd(),
+            'dirname': context.ops.getcwd(),
         }
         QtWidgets.QMessageBox.warning(
             None,
@@ -680,7 +687,7 @@ def new_worktree(context: ApplicationContext, repo: str, prompt: bool) -> None:
         if not gitdir:
             sys.exit(core.EXIT_NOINPUT)
 
-        if not core.exists(os.path.join(gitdir, '.git')):
+        if not context.ops.exists(os.path.join(gitdir, '.git')):
             offer_to_create_repo(context, gitdir)
             valid = model.set_worktree(gitdir)
             continue
@@ -737,7 +744,8 @@ def initialize() -> str:
     """System-level initialization"""
     # We support ~/.config/git-cola/git-bindir on Windows for configuring
     # a custom location for finding the "git" executable.
-    git_path = find_git()
+    ops: operations.IOperations = operations.LocalOperations()
+    git_path = find_git(ops)
     if git_path:
         prepend_path(git_path)
 
@@ -746,14 +754,14 @@ def initialize() -> str:
     # directory tree and retrying.
     #
     # This is needed because  because Python throws exceptions in lots of
-    # stdlib functions when in this situation, e.g. os.path.abspath() and
+    # stdlib functions when in this situation, e.g. ops.abspath() and
     # os.path.realpath(), so it's simpler to mitigate the damage by changing
     # the current directory to one that actually exists.
     while True:
         try:
-            return core.getcwd()
+            return ops.getcwd()
         except OSError:
-            os.chdir('..')
+            ops.chdir('..')
 
 
 class Timer:
@@ -787,26 +795,27 @@ class Timer:
 class NullArgs:
     """Stub arguments for interactive API use"""
 
-    def __init__(self) -> None:
+    def __init__(self, ops: operations.IOperations) -> None:
         self.icon_themes = []
         self.perf = False
         self.prompt = False
-        self.repo = core.getcwd()
+        self.repo = ops.getcwd()
         self.session = None
         self.settings = None
         self.theme = None
         self.version = False
 
 
-def null_args() -> NullArgs:
+def null_args(ops: operations.IOperations) -> NullArgs:
     """Create a new instance of application arguments"""
-    return NullArgs()
+    return NullArgs(ops)
 
 
 class ApplicationContext:
     """Context for performing operations on Git and related data models"""
 
     def __init__(self, args: argparse.Namespace) -> None:
+        self.ops: operations.IOperations = None
         self.args = args
         self.app: ColaApplication | None = None  # ColaApplication
         self.shared_memory = None  # QSharedMemory
@@ -891,7 +900,7 @@ class Notifier(QtCore.QObject):
         self.emit_log(f'[git] {message}')
 
 
-def find_git() -> str | None:
+def find_git(ops) -> str | None:
     """Return the path of git.exe, or None if we can't find it."""
     if not utils.is_win32():
         return None  # UNIX systems have git in their $PATH
@@ -899,10 +908,10 @@ def find_git() -> str | None:
     # If the user wants to use a Git/bin/ directory from a non-standard
     # directory then they can write its location into
     # ~/.config/git-cola/git-bindir
-    git_bindir = resources.config_home('git-bindir')
-    if core.exists(git_bindir):
+    git_bindir = resources.config_home(ops, 'git-bindir')
+    if ops.exists(git_bindir):
         custom_path = core.read(git_bindir).strip()
-        if custom_path and core.exists(custom_path):
+        if custom_path and ops.exists(custom_path):
             return custom_path
 
     # Try to find Git's bin/ directory in one of the typical locations

--- a/cola/app.py
+++ b/cola/app.py
@@ -74,6 +74,7 @@ from .widgets import standard
 from .widgets import startup
 
 if TYPE_CHECKING:
+    from . import server
     from .types import TextType
     from .types import ViewType
 
@@ -448,6 +449,7 @@ def restore_session(ops: operations.IOperations, args: argparse.Namespace) -> No
 
 def application_init(
     args: argparse.Namespace,
+    socket: server.SocketClient | None = None,
     update: bool = False,
     app_name: str = 'Git Cola',
     setup_worktree: bool = True,
@@ -456,7 +458,10 @@ def application_init(
     """Parses the command-line arguments and starts git-cola"""
     # Ensure that we're working in a valid git repository.
     # If not, try to find one.  When found, chdir there.
-    ops = operations.LocalOperations()
+    if socket:
+        ops: operations.IOperations = operations.RemoteOperations(socket)
+    else:
+        ops: operations.IOperations = operations.LocalOperations()
 
     setup_environment()
     process_args(ops, args, setup_repo=setup_repo)
@@ -502,7 +507,7 @@ def new_context(
 
 def create_context() -> ApplicationContext:
     """Create a one-off context from the current directory"""
-    ops = operations._create_ops()
+    ops = operations.LocalOperations()
     args = null_args(ops)
     return new_context(ops, args)  # type: ignore[arg-type]
 
@@ -746,11 +751,15 @@ def startup_message() -> None:
         Interaction.log(msg2)
 
 
-def initialize() -> str:
+def initialize(socket: server.SocketClient | None = None) -> str:
     """System-level initialization"""
     # We support ~/.config/git-cola/git-bindir on Windows for configuring
     # a custom location for finding the "git" executable.
-    ops: operations.IOperations = operations.LocalOperations()
+    if socket:
+        ops: operations.IOperations = operations.RemoteOperations(socket)
+    else:
+        ops: operations.IOperations = operations.LocalOperations()
+
     git_path = find_git(ops)
     if git_path:
         prepend_path(ops, git_path)
@@ -932,7 +941,7 @@ def find_git(ops: operations.IOperations) -> str | None:
     return None
 
 
-def prepend_path(path, ops) -> None:
+def prepend_path(ops: operations.IOperations, path) -> None:
     """Adds git to the PATH.  This is needed on Windows."""
     path = core.decode(path)
     path_entries = core.getenv('PATH', '').split(os.pathsep)

--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -368,15 +368,17 @@ class ApplyPatch(ContextCommand):
     def do(self) -> None:
         context = self.context
 
-        tmp_file = utils.tmp_filename('apply', suffix='.patch')
+        tmp_file = context.ops.tmp_filename('apply', suffix='.patch')
         try:
-            core.write(tmp_file, self.patch.as_text(), encoding=self.encoding)
+            context.ops.write_file(
+                tmp_file, self.patch.as_text(), encoding=self.encoding
+            )
             if self.apply_to_worktree:
                 status, out, err = gitcmds.apply_diff_to_worktree(context, tmp_file)
             else:
                 status, out, err = gitcmds.apply_diff(context, tmp_file)
         finally:
-            core.unlink(tmp_file)
+            context.ops.unlink(tmp_file)
 
         Interaction.log_status(status, out, err)
         self.model.update_file_status(update_index=True)
@@ -460,7 +462,7 @@ class Archive(ContextCommand):
         if self.prefix:
             cmd.append('--prefix=' + self.prefix)
         cmd.append(self.ref)
-        proc = core.start_command(cmd, stdout=fp)
+        proc = self.context.ops.run_command(cmd, stdout=fp)
         out, err = proc.communicate()
         fp.close()
         status = proc.returncode
@@ -867,7 +869,7 @@ class Commit(ResetMode):
         # Create the commit message file
         context = self.context
         msg = self.msg
-        tmp_file = utils.tmp_filename('commit-message')
+        tmp_file = context.ops.tmp_filename('commit-message')
         add_env = {
             'NO_COLOR': '1',
             'TERM': 'dumb',
@@ -896,7 +898,7 @@ class Commit(ResetMode):
             self.context.notifier.git_cmd(core.list2cmdline(cmd_args))
 
         try:
-            core.write(tmp_file, msg)
+            self.context.ops.write_file(tmp_file, msg)
             # Run 'git commit'
             status, out, err = self.git.commit(
                 _add_env=add_env,
@@ -908,7 +910,7 @@ class Commit(ResetMode):
                 **kwargs,
             )
         finally:
-            core.unlink(tmp_file)
+            self.context.ops.unlink(tmp_file)
         if status == 0:
             super().do()
             if context.cfg.get(prefs.AUTOTEMPLATE):
@@ -958,10 +960,10 @@ class Ignore(ContextCommand):
             filename = self.git.git_path('info', 'exclude')
         else:
             filename = '.gitignore'
-        if core.exists(filename):
+        if self.context.ops.exists(filename):
             current_list = core.read(filename)
             new_additions = current_list.rstrip() + '\n' + new_additions
-        core.write(filename, new_additions)
+        self.context.ops.write_file(filename, new_additions)
         Interaction.log_status(0, f'Added to {filename}:\n{for_status}', '')
         self.model.update_file_status()
 
@@ -1208,7 +1210,7 @@ class RemoveFiles(ContextCommand):
     def __init__(self, context: ApplicationContext, remover, filenames) -> None:
         super().__init__(context)
         if remover is None:
-            remover = os.remove
+            remover = self.context.ops.remove
         self.remover = remover
         self.filenames = filenames
         # We could git-hash-object stuff and provide undo-ability
@@ -1232,7 +1234,8 @@ class RemoveFiles(ContextCommand):
 
         if bad_filenames:
             Interaction.information(
-                N_('Error'), N_('Deleting "%s" failed') % file_summary(bad_filenames)
+                N_('Error'),
+                N_('Deleting "%s" failed') % file_summary(bad_filenames),
             )
 
         if rescan:
@@ -1547,7 +1550,7 @@ class DiffImage(EditModel):
 
             if new_oid != missing_blob_oid:
                 found_in_annex = False
-                if annex and core.islink(filename):
+                if annex and self.context.ops.islink(filename):
                     status, out, _ = self.git.annex('status', '--', filename)
                     if status == 0:
                         details = out.split(' ')
@@ -1573,7 +1576,7 @@ class DiffImage(EditModel):
         merge_heads = [
             merge_head
             for merge_head in candidate_merge_heads
-            if core.exists(self.git.git_path(merge_head))
+            if context.ops.exists(self.git.git_path(merge_head))
         ]
 
         if annex:  # Attempt to find files in git-annex
@@ -1900,7 +1903,7 @@ class LoadCommitMessageFromFile(ContextCommand):
 
     def do(self) -> None:
         path = os.path.expanduser(self.path)
-        if not path or not core.isfile(path):
+        if not path or not self.context.ops.isfile(path):
             Interaction.log(N_('Error: Cannot find commit template'))
             Interaction.log(N_('%s: No such file or directory.') % path)
             return
@@ -1965,7 +1968,7 @@ class PrepareCommitMessageHook(ContextCommand):
         title = N_('Error running prepare-commitmsg hook')
         hook = gitcmds.prepare_commit_message_hook(self.context)
 
-        if os.path.exists(hook):
+        if self.context.ops.exists(hook):
             Interaction.log(f'hook cola-prepare-commit-msg exists: "{hook}"')
             filename = self.model.save_commitmsg()
 
@@ -2091,7 +2094,7 @@ class OpenDefaultApp(ContextCommand):
     def do(self) -> None:
         if not self.filenames:
             return
-        utils.launch_default_app(self.filenames)
+        utils.launch_default_app(self.context, self.filenames)
 
 
 class OpenDir(OpenDefaultApp):
@@ -2110,8 +2113,8 @@ class OpenDir(OpenDefaultApp):
         if not dirnames:
             return
         # An empty dirname defaults to to the current directory.
-        dirs = [(dirname or core.getcwd()) for dirname in dirnames]
-        utils.launch_default_app(dirs)
+        dirs = [(dirname or self.context.ops.getcwd()) for dirname in dirnames]
+        utils.launch_default_app(self.context, dirs)
 
 
 class OpenParentDir(OpenDir):
@@ -2180,7 +2183,7 @@ class OpenRepo(EditModel):
                 # Load the message prepared for the newly opened repository.
                 msg_path = gitcmds.commit_message_path(self.context)
                 if msg_path:
-                    self.new_commitmsg = core.read(msg_path)
+                    self.new_commitmsg = self.context.ops.file_read(msg_path)
                 self.model.set_commitmsg(self.new_commitmsg)
             settings = self.context.settings
             settings.load()
@@ -2199,7 +2202,7 @@ class OpenParentRepo(OpenRepo):
             if status == 0:
                 path = out
         if not path:
-            path = os.path.dirname(core.getcwd())
+            path = os.path.dirname(context.ops.getcwd())
         super().__init__(context, path)
 
 
@@ -2891,15 +2894,15 @@ def check_conflicts(context: ApplicationContext, unmerged: list[Any]) -> list[An
 
     """
     if prefs.check_conflicts(context):
-        unmerged = [path for path in unmerged if is_conflict_free(path)]
+        unmerged = [path for path in unmerged if is_conflict_free(context, path)]
     return unmerged
 
 
-def is_conflict_free(path) -> bool:
+def is_conflict_free(context: ApplicationContext, path) -> bool:
     """Return True if `path` contains no conflict markers"""
     rgx = re.compile(r'^(<<<<<<<|\|\|\|\|\|\|\||>>>>>>>) ')
     try:
-        with core.xopen(path, 'rb') as f:
+        with context.ops.xopen(path, 'rb') as f:
             for line in f:
                 line = core.decode(line, errors='ignore')
                 if rgx.match(line):
@@ -2966,11 +2969,11 @@ class Stage(ContextCommand):
         self.git.reset('--', *self.paths)
         if self._old_diff:
             tmp_file = utils.tmp_filename('undo-stage')
-            core.write(tmp_file, self._old_diff)
+            self.context.ops.write_file(tmp_file, self._old_diff)
             try:
                 status, out, err = gitcmds.apply_diff(self.context, tmp_file)
             finally:
-                core.unlink(tmp_file)
+                self.context.ops.unlink(tmp_file)
             if status != 0:
                 Interaction.log_status(status, out, err)
         self.model.update_files(emit=True)
@@ -2991,7 +2994,7 @@ class Stage(ContextCommand):
         err = ''
 
         for path in set(paths):
-            if core.exists(path) or core.islink(path):
+            if self.context.ops.exists(path) or self.context.ops.islink(path):
                 if path.endswith('/'):
                     path = path.rstrip('/')
                 add.append(path)
@@ -3200,9 +3203,9 @@ class Tag(ContextCommand):
         tmp_file = None
         try:
             if tag_message:
-                tmp_file = utils.tmp_filename('tag-message')
+                tmp_file = self.context.ops.tmp_filename('tag-message')
                 opts['file'] = tmp_file
-                core.write(tmp_file, tag_message)
+                self.context.ops.write_file(tmp_file, tag_message)
 
             if sign:
                 opts['sign'] = True
@@ -3212,11 +3215,11 @@ class Tag(ContextCommand):
                 cmd_args = ['git', 'tag']
                 cmd_args.extend(transform_kwargs(**opts))
                 cmd_args.extend((tag_name, revision))
-                self.context.notifier.git_cmd(core.list2cmdline(cmd_args))
+                self.context.notifier.git_cmd(self.context.ops.list2cmdline(cmd_args))
             status, out, err = self.git.tag(tag_name, revision, **opts)
         finally:
             if tmp_file:
-                core.unlink(tmp_file)
+                self.context.ops.unlink(tmp_file)
 
         title = N_('Error: could not create tag "%s"') % tag_name
         Interaction.command(title, 'git tag', status, out, err)
@@ -3274,11 +3277,11 @@ class Unstage(ContextCommand):
         if not self.paths or not self._old_diff:
             return
         tmp_file = utils.tmp_filename('undo-unstage')
-        core.write(tmp_file, self._old_diff)
+        self.context.ops.write_file(tmp_file, self._old_diff)
         try:
             status, out, err = gitcmds.apply_diff(self.context, tmp_file)
         finally:
-            core.unlink(tmp_file)
+            self.context.ops.unlink(tmp_file)
         if status != 0:
             Interaction.log_status(status, out, err)
         self.model.update_file_status()

--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -1860,7 +1860,7 @@ class LaunchTerminal(ContextCommand):
                 if executable:
                     command = executable
                     break
-            argv.append(os.getenv('SHELL', command))
+            argv.append(self.context.ops.getenv('SHELL', command))
             shell = False
 
         core.fork(argv, cwd=self.path, shell=shell)
@@ -2327,7 +2327,7 @@ class SequenceEditorEnvironment:
 
     def __enter__(self) -> Self:
         for var, value in self.env.items():
-            compat.setenv(var, value)
+            compat.setenv(self.context.ops, var, value)
         return self
 
     def __exit__(
@@ -2337,7 +2337,7 @@ class SequenceEditorEnvironment:
         exc_tb: None,
     ) -> None:
         for var in self.env:
-            compat.unsetenv(var)
+            compat.unsetenv(self.context.ops, var)
 
 
 class Rebase(ContextCommand):
@@ -2678,7 +2678,7 @@ class RunConfigAction(ContextCommand):
         """Run the user-configured action"""
         for env in ('ARGS', 'DIRNAME', 'FILENAME', 'REVISION'):
             try:
-                compat.unsetenv(env)
+                compat.unsetenv(self.context.ops, env)
             except KeyError:
                 pass
         rev = None
@@ -2703,8 +2703,8 @@ class RunConfigAction(ContextCommand):
                 )
                 return False
             dirname = utils.dirname(filename, current_dir='.')
-            compat.setenv('FILENAME', filename)
-            compat.setenv('DIRNAME', dirname)
+            compat.setenv(self.context.ops, 'FILENAME', filename)
+            compat.setenv(self.context.ops, 'DIRNAME', dirname)
 
         if opts.get('revprompt') or opts.get('argprompt'):
             while True:
@@ -2726,9 +2726,9 @@ class RunConfigAction(ContextCommand):
             if not Interaction.question(title, prompt):
                 return False
         if rev:
-            compat.setenv('REVISION', rev)
+            compat.setenv(self.context.ops, 'REVISION', rev)
         if args:
-            compat.setenv('ARGS', args)
+            compat.setenv(self.context.ops, 'ARGS', args)
         title = os.path.expandvars(cmd)
         Interaction.log(N_('Running command: %s') % title)
         cmd = ['sh', '-c', cmd]

--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -874,7 +874,7 @@ class Commit(ResetMode):
             'NO_COLOR': '1',
             'TERM': 'dumb',
         }
-        add_env.update(main.autodetect_proxy_environ())
+        add_env.update(main.autodetect_proxy_environ(self.context))
         kwargs = {}
         # Override the commit date.
         if self.date:
@@ -1856,7 +1856,7 @@ class LaunchTerminal(ContextCommand):
             command = '/bin/sh'
             shells = ('zsh', 'fish', 'bash', 'sh')
             for basename in shells:
-                executable = core.find_executable(basename)
+                executable = self.context.ops.find_executable(basename)
                 if executable:
                     command = executable
                     break
@@ -1990,11 +1990,11 @@ class PrepareCommitMessageHook(ContextCommand):
                 cmd = [bash, hook_rep, filename_rep]
 
                 Interaction.log(f"running 'prepare-commit-msg': {cmd!s}")
-                status, out, err = core.run_command(cmd)
+                status, out, err = self.context.ops.run_command(cmd)
             else:
                 # On *nix:
                 # The hook script is executed directly using the given path.
-                status, out, err = core.run_command([hook, filename])
+                status, out, err = self.context.ops.run_command([hook, filename])
 
             if status == 0:
                 result = core.read(filename)
@@ -2323,6 +2323,7 @@ class SequenceEditorEnvironment:
             'GIT_SEQUENCE_EDITOR': sequence_editor(),
         }
         self.env.update(kwargs)
+        self.context = context
 
     def __enter__(self) -> Self:
         for var, value in self.env.items():
@@ -2736,9 +2737,9 @@ class RunConfigAction(ContextCommand):
             core.fork(cmd)
             status, out, err = (0, '', '')
         elif opts.get('noconsole'):
-            status, out, err = core.run_command(cmd)
+            status, out, err = self.context.ops.run_command(cmd)
         else:
-            status, out, err = Interaction.run_command(title, cmd)
+            status, out, err = Interaction.run_command(self.context.ops, title, cmd)
 
         if not opts.get('background') and not opts.get('norescan'):
             self.model.update_status()
@@ -3215,7 +3216,7 @@ class Tag(ContextCommand):
                 cmd_args = ['git', 'tag']
                 cmd_args.extend(transform_kwargs(**opts))
                 cmd_args.extend((tag_name, revision))
-                self.context.notifier.git_cmd(self.context.ops.list2cmdline(cmd_args))
+                self.context.notifier.git_cmd(core.list2cmdline(cmd_args))
             status, out, err = self.git.tag(tag_name, revision, **opts)
         finally:
             if tmp_file:
@@ -3379,7 +3380,7 @@ class VisualizeAll(ContextCommand):
     def do(self) -> None:
         context = self.context
         browser = utils.shell_split(prefs.history_browser(context))
-        launch_history_browser(browser + ['--all'])
+        launch_history_browser(context, browser + ['--all'])
 
 
 class VisualizeCurrent(ContextCommand):
@@ -3388,7 +3389,7 @@ class VisualizeCurrent(ContextCommand):
     def do(self) -> None:
         context = self.context
         browser = utils.shell_split(prefs.history_browser(context))
-        launch_history_browser(browser + [self.model.currentbranch] + ['--'])
+        launch_history_browser(context, browser + [self.model.currentbranch] + ['--'])
 
 
 class VisualizePaths(ContextCommand):
@@ -3404,7 +3405,7 @@ class VisualizePaths(ContextCommand):
             self.argv = browser
 
     def do(self) -> None:
-        launch_history_browser(self.argv)
+        launch_history_browser(self.context, self.argv)
 
 
 class VisualizeRevision(ContextCommand):
@@ -3425,7 +3426,7 @@ class VisualizeRevision(ContextCommand):
         if self.paths:
             argv.append('--')
             argv.extend(self.paths)
-        launch_history_browser(argv)
+        launch_history_browser(context, argv)
 
 
 class SubmoduleAdd(ConfirmAction):
@@ -3558,7 +3559,7 @@ class SubmodulesUpdate(ConfirmAction):
         return cmd
 
 
-def launch_history_browser(argv: list[str]) -> None:
+def launch_history_browser(context: ApplicationContext, argv: list[str]) -> None:
     """Launch the configured history browser"""
     try:
         core.fork(argv)

--- a/cola/compat.py
+++ b/cola/compat.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
 import os
 import sys
+from typing import TYPE_CHECKING
 from typing import Any
 
 try:
@@ -8,6 +10,8 @@ except ImportError:
     # Python 3
     from urllib import parse  # noqa
 
+if TYPE_CHECKING:
+    from .ops import IOperations
 
 PY_VERSION = sys.version_info[:2]  # (2, 7)
 PY_VERSION_MAJOR = PY_VERSION[0]
@@ -48,22 +52,24 @@ else:
 maxint = (2**31) - 1
 
 
-def setenv(key: str, value: str) -> None:
+def setenv(ops: IOperations, key: str, value: str) -> None:
     """Compatibility wrapper for setting environment variables
 
     Windows requires putenv(). Unix only requires os.environ.
     """
+
     if not PY3 and isinstance(value, ustr):
         value = value.encode(ENCODING, 'replace')
-    os.environ[key] = value
-    os.putenv(key, value)
+    ops.environ_setvalue(key, value)
+    ops.putenv(key, value)
 
 
-def unsetenv(key: str) -> None:
+def unsetenv(ops: IOperations, key: str) -> None:
     """Compatibility wrapper for clearing environment variables"""
-    os.environ.pop(key, None)
+
+    ops.environ_pop(key, None)
     if hasattr(os, 'unsetenv'):
-        os.unsetenv(key)
+        ops.unsetenv(key)
 
 
 def no_op(value: Any) -> Any:

--- a/cola/core.py
+++ b/cola/core.py
@@ -365,7 +365,7 @@ def _win32_find_exe(exe: Any, ops: operations.IOperations) -> Any:
     # if argument does not have an extension, also try it with each of the
     # extensions specified in PATHEXT
     if '.' not in exe:
-        extensions = getenv('PATHEXT', '').split(os.pathsep)
+        extensions = ops.getenv('PATHEXT', '').split(os.pathsep)
         candidates.extend([(exe + ext) for ext in extensions if ext.startswith('.')])
     # search the current directory first
     for candidate in candidates:
@@ -374,7 +374,7 @@ def _win32_find_exe(exe: Any, ops: operations.IOperations) -> Any:
     # if the argument does not include a path separator, search each of the
     # directories on the PATH
     if not os.path.dirname(exe):
-        for path in getenv('PATH').split(os.pathsep):
+        for path in ops.getenv('PATH').split(os.pathsep):
             if path:
                 for candidate in candidates:
                     full_path = os.path.join(path, candidate)

--- a/cola/core.py
+++ b/cola/core.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from typing_extensions import Self
 
+from . import operations
 from .compat import PY2
 from .compat import PY3
 from .compat import WIN32
@@ -310,7 +311,12 @@ def run_command(cmd: list[UStr | str], *args, **kwargs) -> tuple[int, UStr, UStr
 
 
 @interruptable
-def _fork_posix(args: list[str], cwd: str | None = None, shell: bool = False) -> int:
+def _fork_posix(
+    args: list[str],
+    cwd: str | None = None,
+    shell: bool = False,
+    ops: operations.IOperations | None = None,
+) -> int:
     """Launch a process in the background."""
     encoded_args = [encode(arg) for arg in args]
     return subprocess.Popen(encoded_args, cwd=cwd, shell=shell).pid
@@ -320,6 +326,7 @@ def _fork_win32(
     args,
     cwd: str | None = None,
     shell: bool = False,
+    ops: operations.IOperations = None,
 ) -> int:
     """Launch a background process using crazy win32 voodoo."""
     # This is probably wrong, but it works.  Windows.. Wow.
@@ -328,7 +335,7 @@ def _fork_win32(
         args = [sys.executable] + args
 
     if not shell:
-        args[0] = _win32_find_exe(args[0])
+        args[0] = _win32_find_exe(args[0], ops)
 
     if PY3:
         # see comment in start_command()
@@ -342,7 +349,7 @@ def _fork_win32(
     ).pid
 
 
-def _win32_find_exe(exe: Any) -> Any:
+def _win32_find_exe(exe: Any, ops: operations.IOperations) -> Any:
     """Find the actual file for a Windows executable.
 
     This function goes through the same process that the Windows shell uses to
@@ -505,10 +512,10 @@ def _find_executable(executable: UStr, path: str | None = None) -> str | None:
     if (sys.platform == 'win32') and (ext != '.exe'):
         executable = executable + '.exe'
 
-    if not os.path.isfile(executable):
+    if not isfile(executable):
         for dirname in paths:
             filename = os.path.join(dirname, executable)
-            if os.path.isfile(filename):
+            if isfile(filename):
                 # the file exists, we have a shot at spawn working
                 return filename
         return None

--- a/cola/difftool.py
+++ b/cola/difftool.py
@@ -100,7 +100,7 @@ class Difftool(standard.Dialog):
         if expr is None or hide_expr:
             self.expr.hide()
 
-        self.tree = filetree.FileTree(parent=self)
+        self.tree = filetree.FileTree(self.context, parent=self)
 
         self.diff_button = qtutils.create_button(
             text=N_('Compare'), icon=icons.diff(), enabled=False, default=True

--- a/cola/editpatch.py
+++ b/cola/editpatch.py
@@ -79,7 +79,7 @@ def edit_patch(
     reverse: bool,
     apply_to_worktree: bool
 ):
-    patch_file_path = utils.tmp_filename('edit', '.patch')
+    patch_file_path = context.ops.tmp_filename('edit', '.patch')
     try:
         content_parts = [
             patch_edit_header(
@@ -88,8 +88,10 @@ def edit_patch(
             patch.as_text(file_headers=False),
             patch_edit_footer(context),
         ]
-        core.write(patch_file_path, ''.join(content_parts), encoding=encoding)
-        status, _, _ = core.run_command(
+        context.ops.write_file(
+            patch_file_path, ''.join(content_parts), encoding=encoding
+        )
+        status, _, _ = context.ops.run_command(
             [*utils.shell_split(prefs.editor(context)), patch_file_path]
         )
         if status == 0:
@@ -103,4 +105,4 @@ def edit_patch(
             patch_text = ''
         return diffparse.Patch.parse(patch.filename, patch_text)
     finally:
-        core.unlink(patch_file_path)
+        context.ops.unlink(patch_file_path)

--- a/cola/fsmonitor.py
+++ b/cola/fsmonitor.py
@@ -185,7 +185,7 @@ if AVAILABLE == 'inotify':
             git = context.git
             worktree = git.worktree()
             if worktree is not None:
-                worktree = core.abspath(worktree)
+                worktree = self.context.ops.abspath(worktree)
             self._worktree = worktree
             self._git_dir = git.git_path()
             self._lock = Lock()
@@ -466,13 +466,14 @@ if AVAILABLE == 'pywin32':
             git = context.git
             worktree = git.worktree()
             if worktree is not None:
-                worktree = self._transform_path(core.abspath(worktree))
+                worktree = self._transform_path(context.ops.abspath(worktree))
             self._worktree = worktree
             self._worktree_watch: _Win32Watch | None = None
-            self._git_dir = self._transform_path(core.abspath(git.git_path()))
+            self._git_dir = self._transform_path(context.ops.abspath(git.git_path()))
             self._git_dir_watch: _Win32Watch | None = None
             self._stop_event_lock = Lock()
             self._stop_event = None
+            self.context = context
 
         @staticmethod
         def _transform_path(path: str) -> str:
@@ -535,7 +536,7 @@ if AVAILABLE == 'pywin32':
                     if (
                         path != self._git_dir
                         and not path.startswith(self._git_dir + '/')
-                        and not os.path.isdir(path)
+                        and not self.context.ops.isdir(path)
                     ):
                         if self._use_check_ignore:
                             self._file_paths.add(path)

--- a/cola/git.py
+++ b/cola/git.py
@@ -128,7 +128,7 @@ class Paths:
         """Search for git worktrees and bare repositories"""
         if not self.git_dir or not self.worktree:
             ceiling_dirs = set()
-            ceiling = core.getenv('GIT_CEILING_DIRECTORIES')
+            ceiling = self.ops.getenv('GIT_CEILING_DIRECTORIES')
             if ceiling:
                 ceiling_dirs.update([x for x in ceiling.split(os.pathsep) if x])
             if path:

--- a/cola/git.py
+++ b/cola/git.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from typing import Any
 
 from . import core
+from . import operations
 from .compat import WIN32
 from .compat import int_types
 from .compat import ustr
@@ -48,52 +49,51 @@ def dashify(value: str) -> str:
     return value.replace('_', '-')
 
 
-def is_git_dir(git_dir: TextType) -> bool:
+def is_git_dir(ops: operations.IOperations, git_dir: TextType) -> bool:
     """From git's setup.c:is_git_directory()."""
     result = False
     if git_dir:
         headref = join(git_dir, 'HEAD')
 
         if (
-            core.isdir(git_dir)
+            ops.isdir(git_dir)
             and (
-                core.isdir(join(git_dir, 'objects'))
-                and core.isdir(join(git_dir, 'refs'))
+                ops.isdir(join(git_dir, 'objects')) and ops.isdir(join(git_dir, 'refs'))
             )
             or (
-                core.isfile(join(git_dir, 'gitdir'))
-                and core.isfile(join(git_dir, 'commondir'))
+                ops.isfile(join(git_dir, 'gitdir'))
+                and ops.isfile(join(git_dir, 'commondir'))
             )
         ):
-            result = core.isfile(headref) or (
-                core.islink(headref) and core.readlink(headref).startswith('refs/')
+            result = ops.isfile(headref) or (
+                ops.islink(headref) and core.readlink(headref).startswith('refs/')
             )
         else:
-            result = is_git_file(git_dir)
+            result = is_git_file(ops, git_dir)
 
     return result
 
 
-def is_git_file(filename: TextType) -> bool:
-    return core.isfile(filename) and os.path.basename(filename) == '.git'
+def is_git_file(ops: operations.IOperations, filename: TextType) -> bool:
+    return ops.isfile(filename) and os.path.basename(filename) == '.git'
 
 
-def is_git_worktree(dirname) -> bool:
-    return is_git_dir(join(dirname, '.git'))
+def is_git_worktree(ops: operations.IOperations, dirname) -> bool:
+    return is_git_dir(ops, join(dirname, '.git'))
 
 
-def is_git_repository(path) -> bool:
-    return is_git_worktree(path) or is_git_dir(path)
+def is_git_repository(ops: operations.IOperations, path) -> bool:
+    return is_git_worktree(ops, path) or is_git_dir(ops, path)
 
 
-def read_git_file(path: str) -> str | None:
+def read_git_file(ops: operations.IOperations, path: str) -> str | None:
     """Read the path from a .git-file
 
     `None` is returned when <path> is not a .git-file.
 
     """
     result = None
-    if path and is_git_file(path):
+    if path and is_git_file(ops, path):
         header = 'gitdir: '
         data = core.read(path).strip()
         if data.startswith(header):
@@ -110,17 +110,19 @@ class Paths:
 
     def __init__(
         self,
+        ops: operations.IOperations,
         git_dir: TextType | None = None,
         git_file: TextType | None = None,
         worktree: TextType | None = None,
         common_dir: TextType | None = None,
     ) -> None:
-        if git_dir and not is_git_dir(git_dir):
+        if git_dir and not is_git_dir(ops, git_dir):
             git_dir = None
         self.git_dir = git_dir
         self.git_file = git_file
         self.worktree = worktree
         self.common_dir = common_dir
+        self.ops = ops
 
     def get(self, path: core.UStr | str) -> Paths:
         """Search for git worktrees and bare repositories"""
@@ -130,17 +132,17 @@ class Paths:
             if ceiling:
                 ceiling_dirs.update([x for x in ceiling.split(os.pathsep) if x])
             if path:
-                path = core.abspath(path)
+                path = self.ops.abspath(path)
             self._search_for_git(path, ceiling_dirs)
 
         if self.git_dir:
-            git_dir_path = read_git_file(self.git_dir)
+            git_dir_path = read_git_file(self.ops, self.git_dir)
             if git_dir_path:
                 self.git_file = self.git_dir
                 self.git_dir = git_dir_path
 
                 commondir_file = join(git_dir_path, 'commondir')
-                if core.exists(commondir_file):
+                if self.ops.exists(commondir_file):
                     common_path = core.read(commondir_file).strip()
                     if common_path:
                         if os.path.isabs(common_path):
@@ -157,7 +159,7 @@ class Paths:
         while path:
             if path in ceiling_dirs:
                 break
-            if is_git_dir(path):
+            if is_git_dir(self.ops, path):
                 if not self.git_dir:
                     self.git_dir = path
                 basename = os.path.basename(path)
@@ -170,11 +172,11 @@ class Paths:
                     basename = os.path.basename(self.git_dir)
                     if basename == '.git':
                         self.worktree = os.path.dirname(self.git_dir)
-                    elif path and not is_git_dir(path):
+                    elif path and not is_git_dir(self.ops, path):
                         self.worktree = path
                 break
             gitpath = join(path, '.git')
-            if is_git_dir(gitpath):
+            if is_git_dir(self.ops, gitpath):
                 if not self.git_dir:
                     self.git_dir = gitpath
                 if not self.worktree:
@@ -185,10 +187,12 @@ class Paths:
                 break
 
 
-def find_git_directory(path: core.UStr) -> Paths:
+def find_git_directory(ops: operations.IOperations, path: core.UStr | str) -> Paths:
     """Perform Git repository discovery"""
     return Paths(
-        git_dir=core.getenv('GIT_DIR'), worktree=core.getenv('GIT_WORK_TREE')
+        ops,
+        git_dir=ops.getenv('GIT_DIR'),
+        worktree=ops.getenv('GIT_WORK_TREE'),
     ).get(path)
 
 
@@ -197,14 +201,15 @@ class Git:
     The Git class manages communication with the Git binary
     """
 
-    def __init__(self, worktree: None = None) -> None:
-        self.paths = Paths()
+    def __init__(self, ops: operations.IOperations, worktree: None = None) -> None:
+        self.ops = ops
+        self.paths = Paths(self.ops)
 
         self._valid = {}  #: Store the result of is_git_dir() for performance
-        self.set_worktree(worktree or core.getcwd())
+        self.set_worktree(worktree or self.ops.getcwd())
 
     def is_git_repository(self, path) -> bool:
-        return is_git_repository(path)
+        return is_git_repository(path, self.ops)
 
     def getcwd(self) -> TextType:
         """Return the working directory used by git()"""
@@ -212,13 +217,13 @@ class Git:
 
     def set_worktree(self, path: str) -> TextType:
         path = core.decode(path)
-        self.paths = find_git_directory(path)
+        self.paths = find_git_directory(self.ops, path)
         return self.paths.worktree
 
     def worktree(self) -> TextType:
         if not self.paths.worktree:
-            path = core.abspath(core.getcwd())
-            self.paths = find_git_directory(path)
+            path = self.ops.abspath(self.ops.getcwd())
+            self.paths = find_git_directory(self.ops, path)
         return self.paths.worktree
 
     def is_valid(self) -> bool:
@@ -231,7 +236,7 @@ class Git:
         try:
             valid = bool(git_dir) and self._valid[git_dir]
         except KeyError:
-            valid = self._valid[git_dir] = is_git_dir(git_dir)
+            valid = self._valid[git_dir] = is_git_dir(self.ops, git_dir)
 
         return valid
 
@@ -246,16 +251,16 @@ class Git:
         result = None
         if self.paths.git_dir:
             result = join(self.paths.git_dir, *paths)
-        if common and result and self.paths.common_dir and not core.exists(result):
+        if common and result and self.paths.common_dir and not self.ops.exists(result):
             common_result = join(self.paths.common_dir, *paths)
-            if core.exists(common_result):
+            if self.ops.exists(common_result):
                 result = common_result
         return result
 
     def git_dir(self) -> TextType:
         if not self.paths.git_dir:
-            path = core.abspath(core.getcwd())
-            self.paths = find_git_directory(path)
+            path = self.ops.abspath(self.ops.getcwd())
+            self.paths = find_git_directory(self.ops, path)
         return self.paths.git_dir
 
     def __getattr__(self, name: str) -> partial:
@@ -266,6 +271,7 @@ class Git:
     @staticmethod
     def execute(
         command: list[TextType],
+        ops: operations.IOperations = operations.LocalOperations(),
         _add_env: dict[str, str] | None = None,
         _cwd: TextType | None = None,
         _decode: bool = True,
@@ -292,7 +298,7 @@ class Git:
         """
         # Allow the user to have the command executed in their working dir.
         if not _cwd:
-            _cwd = core.getcwd()
+            _cwd = ops.getcwd()
 
         extra = {}
 
@@ -397,21 +403,21 @@ class Git:
                 # case of argv overflow. We should be safe from that but use
                 # defensive coding for the worst-case scenario. On UNIX
                 # we have ENAMETOOLONG but that doesn't exist on Windows.
-                if _git_is_installed():
+                if _git_is_installed(self.ops):
                     raise
-                _print_win32_git_hint()
+                _print_win32_git_hint(self.ops)
             result = (1, '', f"error: unable to execute '{GIT}'")
         return result
 
 
-def _git_is_installed():
+def _git_is_installed(ops: operations.IOperations):
     """Return True if git is installed"""
     # On win32 Git commands can fail with ENOENT in case of argv overflow. We
     # should be safe from that but use defensive coding for the worst-case
     # scenario. On UNIX we have ENAMETOOLONG but that doesn't exist on
     # Windows.
     try:
-        status, _, _ = Git.execute([GIT, '--version'])
+        status, _, _ = Git.execute([GIT, '--version'], ops)
         result = status == 0
     except OSError:
         result = False
@@ -468,18 +474,18 @@ def win32_git_error_hint() -> str:
 
 
 @memoize
-def _print_win32_git_hint() -> None:
+def _print_win32_git_hint(ops: operations.IOperations) -> None:
     hint = '\n' + win32_git_error_hint() + '\n'
-    core.print_stderr("error: unable to execute 'git'" + hint)
+    ops.print_stderr("error: unable to execute 'git'" + hint)
 
 
-def create() -> Git:
+def create(ops: operations.IOperations) -> Git:
     """Create Git instances
 
-    >>> git = create()
+    >>> git = create(operations.LocalOperations())
     >>> status, out, err = git.version()
     >>> 'git' == out[:3].lower()
     True
 
     """
-    return Git()
+    return Git(ops)

--- a/cola/git.py
+++ b/cola/git.py
@@ -316,7 +316,7 @@ class Git:
         if not _readonly:
             _index_lock.acquire()
         try:
-            status, out, err = core.run_command(
+            status, out, err = ops.run_command(
                 command,
                 add_env=_add_env,
                 cwd=_cwd,
@@ -395,7 +395,7 @@ class Git:
         call.extend(args)
         try:
             result: tuple[int, TextType, TextType] = self.execute(
-                call, **_kwargs  # type: ignore[arg-type]
+                call, self.ops, **_kwargs  # type: ignore[arg-type]
             )
         except OSError as exc:
             if WIN32 and exc.errno == errno.ENOENT:

--- a/cola/git.py
+++ b/cola/git.py
@@ -344,12 +344,12 @@ class Git:
             Interaction.log_status(status, msg, '')
         elif cola_trace == 'full':
             if out or err:
-                core.print_stderr(
+                ops.print_stderr(
                     "# %.3fs: %s -> %d: '%s' '%s'"
                     % (elapsed_time, ' '.join(command), status, out, err)
                 )
             else:
-                core.print_stderr(
+                ops.print_stderr(
                     '# %.3fs: %s -> %d' % (elapsed_time, ' '.join(command), status)
                 )
         elif cola_trace:

--- a/cola/gitcfg.py
+++ b/cola/gitcfg.py
@@ -444,9 +444,13 @@ class GitConfig(QtCore.QObject):
         if utils.is_win32():
             # Try to find Git's sh.exe directory in
             # one of the typical locations
-            pf = os.environ.get('ProgramFiles', r'C:\Program Files')
-            pf32 = os.environ.get('ProgramFiles(x86)', r'C:\Program Files (x86)')
-            pf64 = os.environ.get('ProgramW6432', r'C:\Program Files')
+            pf = self.context.ops.get_environ().get('ProgramFiles', r'C:\Program Files')
+            pf32 = self.context.ops.get_environ().get(
+                'ProgramFiles(x86)', r'C:\Program Files (x86)'
+            )
+            pf64 = self.context.ops.get_environ().get(
+                'ProgramW6432', r'C:\Program Files'
+            )
 
             for p in [pf64, pf32, pf, 'C:\\']:
                 candidate = os.path.join(p, r'Git\bin\sh.exe')

--- a/cola/gitcfg.py
+++ b/cola/gitcfg.py
@@ -38,14 +38,14 @@ def create(context: ApplicationContext) -> GitConfig:
 
 def _cache_key_from_paths(
     context: ApplicationContext, paths: list[Any | str]
-) -> list[float] | None:
+) -> list[float]:
     """Return a stat cache from the given paths"""
     if not paths:
         return None
-    mtimes = []
+    mtimes: list[float] = []
     for path in sorted(paths):
         try:
-            mtimes.append(context.ops.stat(path).st_mtime)
+            mtimes.append(context.ops.stat(path).get('st_mtime'))
         except OSError:
             continue
     if mtimes:

--- a/cola/gitcfg.py
+++ b/cola/gitcfg.py
@@ -467,7 +467,7 @@ class GitConfig(QtCore.QObject):
             ('xterm', 'xterm -e'),
         )
         for executable, command in terminals:
-            if core.find_executable(executable):
+            if self.context.ops.find_executable(executable):
                 return command
         return None
 

--- a/cola/gitcfg.py
+++ b/cola/gitcfg.py
@@ -45,7 +45,7 @@ def _cache_key_from_paths(
     mtimes = []
     for path in sorted(paths):
         try:
-            mtimes.append(core.stat(path).st_mtime)
+            mtimes.append(context.ops.stat(path).st_mtime)
         except OSError:
             continue
     if mtimes:

--- a/cola/gitcfg.py
+++ b/cola/gitcfg.py
@@ -36,7 +36,9 @@ def create(context: ApplicationContext) -> GitConfig:
     return GitConfig(context)
 
 
-def _cache_key_from_paths(paths: list[Any | str]) -> list[float] | None:
+def _cache_key_from_paths(
+    context: ApplicationContext, paths: list[Any | str]
+) -> list[float] | None:
     """Return a stat cache from the given paths"""
     if not paths:
         return None
@@ -146,7 +148,7 @@ class GitConfig(QtCore.QObject):
         Updates the cache and returns False when the cache does not match.
 
         """
-        cache_key = _cache_key_from_paths(self._cache_paths)
+        cache_key = _cache_key_from_paths(self.context, self._cache_paths)
         return self._cache_key and cache_key == self._cache_key  # type: ignore[return-value]
 
     def update(self) -> None:
@@ -202,7 +204,7 @@ class GitConfig(QtCore.QObject):
 
         # Update the cache
         self._cache_paths = sorted(cache_paths)
-        self._cache_key = _cache_key_from_paths(self._cache_paths)
+        self._cache_key = _cache_key_from_paths(self.context, self._cache_paths)
 
         # Send a notification that the configuration has been updated.
         self.updated.emit()
@@ -348,7 +350,8 @@ class GitConfig(QtCore.QObject):
 
     def is_per_file_attrs_enabled(self) -> bool:
         return self.get(
-            'cola.fileattributes', func=lambda: os.path.exists('.gitattributes')
+            'cola.fileattributes',
+            func=lambda: self.context.ops.exists('.gitattributes'),
         )
 
     def is_binary(self, path) -> bool:
@@ -447,7 +450,7 @@ class GitConfig(QtCore.QObject):
 
             for p in [pf64, pf32, pf, 'C:\\']:
                 candidate = os.path.join(p, r'Git\bin\sh.exe')
-                if os.path.isfile(candidate):
+                if self.context.ops.isfile(candidate):
                     return candidate
             return None
 
@@ -622,7 +625,7 @@ def _read_config_fallback(
     includes = version.check_git(context, 'config-includes')
 
     current_path = '/etc/gitconfig'
-    if os.path.exists(current_path):
+    if context.ops.exists(current_path):
         cache_paths.add(current_path)
         status, config_output, _ = context.git.config(
             z=True,
@@ -638,9 +641,9 @@ def _read_config_fallback(
     gitconfig_home = core.expanduser(os.path.join('~', '.gitconfig'))
     gitconfig_xdg = resources.xdg_config_home('git', 'config')
 
-    if os.path.exists(gitconfig_home):
+    if context.ops.exists(gitconfig_home):
         gitconfig = gitconfig_home
-    elif os.path.exists(gitconfig_xdg):
+    elif context.ops.exists(gitconfig_xdg):
         gitconfig = gitconfig_xdg
     else:
         gitconfig = None
@@ -656,7 +659,7 @@ def _read_config_fallback(
                 yield global_scope, key, value, False
 
     local_config = context.git.git_path('config')
-    if local_config and os.path.exists(local_config):
+    if local_config and context.ops.exists(local_config):
         cache_paths.add(gitconfig)
         status, config_output, _ = context.git.config(
             z=True,

--- a/cola/gitcmds.py
+++ b/cola/gitcmds.py
@@ -213,7 +213,7 @@ def current_branch(context: ApplicationContext) -> core.UStr:
     else:
         stat_file = context.git.git_path('HEAD')
     try:
-        key = context.ops.stat(stat_file).st_mtime
+        key = context.ops.stat(stat_file).get('st_mtime')
         if CurrentBranchCache.key == key:
             return CurrentBranchCache.value
     except OSError:

--- a/cola/gitcmds.py
+++ b/cola/gitcmds.py
@@ -194,7 +194,7 @@ def all_files(context: ApplicationContext, *args) -> list[str]:
 class CurrentBranchCache:
     """Cache for current_branch()"""
 
-    key = None
+    key: float | None = None
     value = None
 
 

--- a/cola/gitcmds.py
+++ b/cola/gitcmds.py
@@ -213,7 +213,7 @@ def current_branch(context: ApplicationContext) -> core.UStr:
     else:
         stat_file = context.git.git_path('HEAD')
     try:
-        key = core.stat(stat_file).st_mtime
+        key = context.ops.stat(stat_file).st_mtime
         if CurrentBranchCache.key == key:
             return CurrentBranchCache.value
     except OSError:

--- a/cola/gitcmds.py
+++ b/cola/gitcmds.py
@@ -245,9 +245,9 @@ def current_branch(context: ApplicationContext) -> core.UStr:
 def _read_git_head(context: ApplicationContext, head, default: str = 'main') -> str:
     """Pure-python .git/HEAD reader"""
     # Common .git/HEAD "ref: refs/heads/main" files
-    islink = core.islink(head)
-    if core.isfile(head) and not islink:
-        data = core.read(head).rstrip()
+    islink = context.ops.islink(head)
+    if context.ops.isfile(head) and not islink:
+        data = context.ops.file_read(head).rstrip()
         ref_prefix = 'ref: '
         if data.startswith(ref_prefix):
             return data[len(ref_prefix) :]
@@ -255,8 +255,8 @@ def _read_git_head(context: ApplicationContext, head, default: str = 'main') -> 
         return data
     # Legacy .git/HEAD symlinks
     if islink:
-        refs_heads = core.realpath(context.git.git_path('refs', 'heads'))
-        path = core.abspath(head).replace('\\', '/')
+        refs_heads = context.ops.realpath(context.git.git_path('refs', 'heads'))
+        path = context.ops.abspath(head).replace('\\', '/')
         if path.startswith(refs_heads + '/'):
             return path[len(refs_heads) + 1 :]
 
@@ -989,7 +989,7 @@ def commit_message_path(context: ApplicationContext) -> str:
 
     """
     path = context.git.git_path('GIT_COLA_MSG', common=False)
-    if core.exists(path):
+    if context.ops.exists(path):
         return path
     return None
 
@@ -998,7 +998,7 @@ def merge_message_path(context: ApplicationContext) -> str | None:
     """Return the path to .git/MERGE_MSG or .git/SQUASH_MSG."""
     for basename in ('MERGE_MSG', 'SQUASH_MSG'):
         path = context.git.git_path(basename)
-        if core.exists(path):
+        if context.ops.exists(path):
             return path
     return None
 
@@ -1161,7 +1161,7 @@ def cat_file(context: ApplicationContext, filename: str, *args, **kwargs) -> str
     # has the correct extension, and so that it resembles the original name.
     basename = os.path.basename(filename)
     suffix = '-' + basename  # ensures the correct filename extension
-    path = utils.tmp_filename('blob', suffix=suffix)
+    path = context.ops.tmp_filename('blob', suffix=suffix)
     with open(path, 'wb') as tmp_file:
         status, out, err = context.git.cat_file(
             _raw=True, _readonly=True, _stdout=tmp_file, *args, **kwargs
@@ -1170,7 +1170,7 @@ def cat_file(context: ApplicationContext, filename: str, *args, **kwargs) -> str
         if status == 0:
             result = path
     if not result:
-        core.unlink(path)
+        context.ops.unlink(path)
     return result
 
 
@@ -1211,7 +1211,7 @@ def annex_path(context: ApplicationContext, head: str, filename: str):
     key = annex_info.get('key', '')
     if key:
         status, out, _ = context.git.annex('contentlocation', key, _readonly=True)
-        if status == 0 and os.path.exists(out):
+        if status == 0 and context.ops.exists(out):
             path = out
 
     return path

--- a/cola/guicmds.py
+++ b/cola/guicmds.py
@@ -12,6 +12,7 @@ from . import difftool
 from . import display
 from . import gitcmds
 from . import icons
+from . import operations
 from . import qtutils
 from . import resources
 from .i18n import N_
@@ -100,7 +101,7 @@ def new_repo(context: ApplicationContext) -> str | None:
 
     """
     git = context.git
-    path = qtutils.opendir_dialog(N_('New Repository...'), core.getcwd())
+    path = qtutils.opendir_dialog(N_('New Repository...'), context.ops.getcwd())
     if not path:
         return None
     # Avoid needlessly calling `git init`.
@@ -130,7 +131,7 @@ def open_new_repo(context: ApplicationContext) -> None:
 def new_bare_repo(context: ApplicationContext) -> str | None:
     """Create a bare repository and configure a remote pointing to it"""
     result = None
-    repo = prompt_for_new_bare_repo()
+    repo = prompt_for_new_bare_repo(context.ops)
     if not repo:
         return result
     # Create bare repo
@@ -148,14 +149,14 @@ def new_bare_repo(context: ApplicationContext) -> str | None:
     return result
 
 
-def prompt_for_new_bare_repo() -> str | None:
+def prompt_for_new_bare_repo(ops: operations.IOperations) -> str | None:
     """Prompt for a directory and name for a new bare repository"""
-    path = qtutils.opendir_dialog(N_('Select Directory...'), core.getcwd())
+    path = qtutils.opendir_dialog(N_('Select Directory...'), ops.getcwd())
     if not path:
         return None
 
     bare_repo = None
-    default = os.path.basename(core.getcwd())
+    default = os.path.basename(ops.getcwd())
     if not default.endswith('.git'):
         default += '.git'
     while not bare_repo:
@@ -169,7 +170,7 @@ def prompt_for_new_bare_repo() -> str | None:
         if not name.endswith('.git'):
             name += '.git'
         repo = os.path.join(path, name)
-        if core.isdir(repo):
+        if ops.isdir(repo):
             Interaction.critical(N_('Error'), N_('"%s" already exists') % repo)
         else:
             bare_repo = repo
@@ -452,8 +453,8 @@ def restore_worktree(context: ApplicationContext) -> None:
 def build_layout_menu(widget: QtWidgets.QWidget, menu: QtWidgets.QMenu) -> None:
     """Add layouts from ~/.config/git-cola/layouts to the specified menu"""
     directory = resources.xdg_config_home('git-cola', 'layouts')
-    if os.path.isdir(directory):
-        layouts = sorted(os.listdir(directory))
+    if core.isdir(directory):
+        layouts = sorted(core.listdir(directory))
     else:
         layouts = []
     suffix = '.layout'
@@ -479,8 +480,8 @@ def save_layout(widget: QtWidgets.QWidget) -> None:
         'git-cola', 'layouts', 'default.layout'
     )
     parent_dir = os.path.dirname(default_filename)
-    if not os.path.isdir(parent_dir):
-        os.makedirs(parent_dir)
+    if not core.isdir(parent_dir):
+        core.makedirs(parent_dir)
     filename = qtutils.save_as(default_filename)
     if not filename:
         return
@@ -492,15 +493,15 @@ def save_layout(widget: QtWidgets.QWidget) -> None:
 def load_layout(widget: QtWidgets.QWidget) -> None:
     """Choose a Qt layout file and apply it to the current widget"""
     directory = resources.xdg_config_home('git-cola', 'layouts')
-    if not os.path.isdir(directory):
-        os.makedirs(directory)
+    if not core.isdir(directory):
+        core.makedirs(directory)
     filename = qtutils.existing_file(directory, title=N_('Load Layout'))
     load_layout_file(widget, filename)
 
 
 def load_layout_file(widget: QtWidgets.QWidget, filename: Any) -> None:
     """Load a Qt layout file into the specified widget"""
-    if not filename or not os.path.isfile(filename):
+    if not filename or not core.isfile(filename):
         return
     with open(filename, 'rb') as handle:
         state = handle.read()

--- a/cola/hidpi.py
+++ b/cola/hidpi.py
@@ -4,6 +4,7 @@ from qtpy import QtCore
 
 from . import compat
 from . import core
+from . import operations
 from . import version
 from .i18n import N_
 
@@ -23,17 +24,18 @@ def is_supported() -> bool:
 
 def apply_choice(value: str) -> None:
     value = compat.ustr(value)
+    ops = operations.LocalOperations()
     if value == Option.AUTO:
         # Do not override the configuration when either of these
         # two environment variables are defined.
         if not core.getenv('QT_AUTO_SCREEN_SCALE_FACTOR') and not core.getenv(
             'QT_SCALE_FACTOR'
         ):
-            compat.setenv('QT_AUTO_SCREEN_SCALE_FACTOR', '1')
-            compat.unsetenv('QT_SCALE_FACTOR')
+            compat.setenv(ops, 'QT_AUTO_SCREEN_SCALE_FACTOR', '1')
+            compat.unsetenv(ops, 'QT_SCALE_FACTOR')
     elif value and value != Option.DISABLE:
-        compat.unsetenv('QT_AUTO_SCREEN_SCALE_FACTOR')
-        compat.setenv('QT_SCALE_FACTOR', value)
+        compat.unsetenv(ops, 'QT_AUTO_SCREEN_SCALE_FACTOR')
+        compat.setenv(ops, 'QT_SCALE_FACTOR', value)
 
 
 def options() -> tuple[tuple[str, str], ...]:

--- a/cola/i18n.py
+++ b/cola/i18n.py
@@ -99,12 +99,12 @@ def get_filename_for_locale(name: str | None) -> str | None:
     name: str = name.split('.', 1)[0]  # foo_BAR.UTF-8 -> foo_BAR
 
     filename = resources.i18n(f'{name}.po')
-    if os.path.exists(filename):
+    if core.exists(filename):
         return filename
 
     short_name = name.split('_', 1)[0]
     filename = resources.i18n(f'{short_name}.po')
-    if os.path.exists(filename):
+    if core.exists(filename):
         return filename
     return None
 

--- a/cola/interaction.py
+++ b/cola/interaction.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 from . import core
+from . import operations
 from .i18n import N_
 
 if TYPE_CHECKING:
@@ -145,11 +146,11 @@ class Interaction:
 
     @classmethod
     def run_command(
-        cls, title: str, cmd: list[str]
+        cls, ops: operations.IOperations, title: str, cmd: list[str]
     ) -> tuple[int, core.UStr, core.UStr]:
         cls.log('# ' + title)
         cls.log('$ ' + core.list2cmdline(cmd))
-        status, out, err = core.run_command(cmd)
+        status, out, err = ops.run_command(cmd)
         cls.log_status(status, out, err)
         return status, out, err
 

--- a/cola/main.py
+++ b/cola/main.py
@@ -517,7 +517,7 @@ def cmd_cola(
 
     status_filter = args.status_filter
     if status_filter:
-        status_filter = core.abspath(status_filter)
+        status_filter = context.ops.abspath(status_filter)
 
     if context is None:
         context = app.application_init(args)
@@ -528,7 +528,7 @@ def cmd_cola(
         cmds.do(cmds.AmendMode, context, amend=True)
 
     if status_filter:
-        view.set_filter(core.relpath(status_filter))
+        view.set_filter(context.ops.relpath(status_filter))
 
     context.timer.stop('view')
     if args.perf:

--- a/cola/main.py
+++ b/cola/main.py
@@ -9,6 +9,7 @@ from . import app
 from . import cmds
 from . import compat
 from . import core
+from . import server
 from . import version
 from .widgets.main import MainView
 

--- a/cola/main.py
+++ b/cola/main.py
@@ -67,6 +67,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     add_remote_command(subparser)
     add_search_command(subparser)
     add_stash_command(subparser)
+    add_connect_command(subparser)
     add_tag_command(subparser)
     add_version_command(subparser)
 
@@ -475,6 +476,13 @@ def add_stash_command(subparser: argparse._SubParsersAction) -> None:
     add_command(subparser, 'stash', 'stash and unstash changes', cmd_stash)
 
 
+def add_connect_command(subparser: argparse._SubParsersAction):
+    parser = add_command(subparser, 'connect', 'connect to the server', cmd_connect)
+    parser.add_argument('address', help='IP:PORT')
+    parser.add_argument('repo', help='/path/to/repo')
+    _add_cola_options(parser)
+
+
 def add_tag_command(subparser: argparse._SubParsersAction) -> None:
     """Add the "git cola tag" command for creating tags"""
     parser = add_command(subparser, 'tag', 'create tags', cmd_tag)
@@ -664,10 +672,12 @@ def cmd_merge(args: argparse.Namespace) -> int:
     return app.application_start(context, view)
 
 
-def cmd_open(args: argparse.Namespace) -> int:
+def cmd_open(
+    args: argparse.Namespace, socket: server.SocketClient | None = None
+) -> int:
     from . import guicmds
 
-    context = app.application_init(args, setup_worktree=False)
+    context = app.application_init(args, socket=socket, setup_worktree=False)
     quick_open = guicmds.open_quick_repo_search(context, open_repo=False, parent=None)
     worktree = quick_open.worktree()
     if worktree:
@@ -787,6 +797,14 @@ def cmd_tag(args: argparse.Namespace) -> int:
     context.model.update_status()
     view = new_create_tag(context, name=args.name, ref=args.ref, sign=args.sign)
     return app.application_start(context, view)
+
+
+def cmd_connect(args: argparse.Namespace):
+    splitdata = args.address.split(':')
+    socket_client = server.SocketClient(ip=splitdata[0], port=int(splitdata[1]))
+
+    context = app.application_init(args, socket=socket_client)
+    return cmd_cola(args=args, context=context)
 
 
 # Windows shortcut launch features:

--- a/cola/models/browse.py
+++ b/cola/models/browse.py
@@ -308,7 +308,7 @@ class GitRepoInfoTask(qtutils.Task):
             st = self.context.ops.stat(self.path)
         except OSError:
             return N_('%d minutes ago') % 0
-        elapsed = time.time() - st.st_mtime
+        elapsed = time.time() - st.get('st_mtime')
         minutes = int(elapsed / 60)
         if minutes < 60:
             return N_('%d minutes ago') % minutes

--- a/cola/models/browse.py
+++ b/cola/models/browse.py
@@ -7,7 +7,6 @@ from qtpy.QtCore import QModelIndex
 from qtpy.QtCore import Qt
 from qtpy.QtCore import Signal
 
-from .. import core
 from .. import gitcmds
 from .. import icons
 from .. import qtutils
@@ -306,7 +305,7 @@ class GitRepoInfoTask(qtutils.Task):
 
         """
         try:
-            st = core.stat(self.path)
+            st = self.context.ops.stat(self.path)
         except OSError:
             return N_('%d minutes ago') % 0
         elapsed = time.time() - st.st_mtime

--- a/cola/models/browse.py
+++ b/cola/models/browse.py
@@ -83,7 +83,7 @@ class GitRepoModel(QtGui.QStandardItemModel):
 
     def mimeData(self, indexes: list[QModelIndex]) -> QMimeData:
         paths = qtutils.paths_from_indexes(
-            self, indexes, item_type=GitRepoNameItem.TYPE
+            self.context, self, indexes, item_type=GitRepoNameItem.TYPE
         )
         return qtutils.mimedata_from_paths(self.context, paths)
 

--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -723,10 +723,10 @@ def autodetect_proxy(context, kwargs: dict[Any, Any]) -> None:
         kwargs['_add_env'] = add_env
 
 
-def autodetect_proxy_environ(ops) -> dict[Any, Any]:
+def autodetect_proxy_environ(context: ApplicationContext) -> dict[Any, Any]:
     """Return the environment variables used for configuring proxies"""
     add_env = {}
-    xdg_current_desktop = core.getenv('XDG_CURRENT_DESKTOP', default='')
+    xdg_current_desktop = context.ops.getenv('XDG_CURRENT_DESKTOP', default='')
     if not xdg_current_desktop:
         return add_env
 
@@ -744,7 +744,7 @@ def autodetect_proxy_environ(ops) -> dict[Any, Any]:
             http_proxy = autodetect_proxy_gnome(context, gsettings, 'http')
             https_proxy = autodetect_proxy_gnome(context, gsettings, 'https')
 
-    if os.environ.get('http_proxy'):
+    if context.ops.get_environ().get('http_proxy'):
         Interaction.log(
             N_('http proxy configured by the "http_proxy" environment variable')
         )
@@ -755,7 +755,7 @@ def autodetect_proxy_environ(ops) -> dict[Any, Any]:
         )
         add_env['http_proxy'] = http_proxy
 
-    if os.environ.get('https_proxy', None):
+    if context.ops.get_environ().get('https_proxy', None):
         Interaction.log(
             N_('https proxy configured by the "https_proxy" environment variable')
         )

--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -179,7 +179,7 @@ class MainModel(QtCore.QObject):
             cwd = self.git.getcwd()
             self.project = os.path.basename(cwd)
             self.set_directory(cwd)
-            core.chdir(cwd)
+            self.context.ops.chdir(cwd)
             self.update_config(reset=reset)
 
             # Detect the "git init" scenario by checking for branches.
@@ -188,7 +188,9 @@ class MainModel(QtCore.QObject):
                 has_branches = bool(gitcmds.branch_list(self.context))
             else:
                 refs = self.git.git_path('refs', 'heads')
-                has_branches = core.exists(refs) and bool(core.listdir(refs))
+                has_branches = self.context.ops.exists(refs) and bool(
+                    self.context.ops.listdir(refs)
+                )
             # "git rev-parse" exits with a non-zero exit status when the
             # safe.directory protection is active.
             if has_branches:
@@ -218,9 +220,9 @@ class MainModel(QtCore.QObject):
         return (
             lfs_filter
             and lfs_dir
-            and core.exists(lfs_dir)
+            and self.context.ops.exists(lfs_dir)
             and lfs_hook
-            and core.exists(lfs_hook)
+            and self.context.ops.exists(lfs_hook)
         )
 
     def set_commitmsg(self, msg: str, notify: bool = True) -> None:
@@ -239,7 +241,7 @@ class MainModel(QtCore.QObject):
         try:
             if not msg.endswith('\n'):
                 msg += '\n'
-            core.write(path, msg)
+            self.context.ops.write_file(path, msg)
         except OSError:
             pass
         return path
@@ -422,10 +424,12 @@ class MainModel(QtCore.QObject):
         merge_head = self.git.git_path('MERGE_HEAD')
         rebase_merge = self.git.git_path('rebase-merge')
         rebase_apply = self.git.git_path('rebase-apply', 'applying')
-        self.is_cherry_picking = cherry_pick_head and core.exists(cherry_pick_head)
-        self.is_merging = merge_head and core.exists(merge_head)
-        self.is_rebasing = rebase_merge and core.exists(rebase_merge)
-        self.is_applying_patch = rebase_apply and core.exists(rebase_apply)
+        self.is_cherry_picking = cherry_pick_head and self.context.ops.exists(
+            cherry_pick_head
+        )
+        self.is_merging = merge_head and self.context.ops.exists(merge_head)
+        self.is_rebasing = rebase_merge and self.context.ops.exists(rebase_merge)
+        self.is_applying_patch = rebase_apply and self.context.ops.exists(rebase_apply)
         if self.mode == self.mode_amend and (
             self.is_merging or self.is_cherry_picking or self.is_applying_patch
         ):
@@ -471,7 +475,7 @@ class MainModel(QtCore.QObject):
             return
         if mtime == self._cola_commitmsg_mtime:
             return
-        msg = core.read(path)
+        msg = self.context.ops.file_read(path)
         self._cola_commitmsg_mtime = mtime
         if msg != self._cola_commitmsg:
             # needs stripping, as the empty commitmsg is saved as \n during close but initialized as ''
@@ -550,7 +554,7 @@ class MainModel(QtCore.QObject):
         """If we've chosen a directory then use it, otherwise use current"""
         if self.directory:
             return self.directory
-        return core.getcwd()
+        return self.context.ops.getcwd()
 
     def cycle_ref_sort(self) -> None:
         """Choose the next ref sort type (version, reverse-chronological)"""

--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -20,7 +20,9 @@ from ..interaction import Interaction
 from . import prefs
 
 if TYPE_CHECKING:
+    from ..app import ApplicationContext
     from ..types import TextType
+
 
 FETCH = 'fetch'
 FETCH_HEAD = 'FETCH_HEAD'
@@ -715,13 +717,13 @@ def autodetect_proxy(context, kwargs: dict[Any, Any]) -> None:
         return
     # This function has the side-effect of updating the kwargs dict.
     # The "_add_env" parameter gets forwarded to the __getattr__ git function's
-    # _add_env option which forwards to core.run_command()'s add_env option.
-    add_env = autodetect_proxy_environ()
+    # _add_env option which forwards to ops.run_command()'s add_env option.
+    add_env = autodetect_proxy_environ(context)
     if add_env:
         kwargs['_add_env'] = add_env
 
 
-def autodetect_proxy_environ() -> dict[Any, Any]:
+def autodetect_proxy_environ(ops) -> dict[Any, Any]:
     """Return the environment variables used for configuring proxies"""
     add_env = {}
     xdg_current_desktop = core.getenv('XDG_CURRENT_DESKTOP', default='')
@@ -731,16 +733,16 @@ def autodetect_proxy_environ() -> dict[Any, Any]:
     http_proxy: TextType | None = None
     https_proxy: TextType | None = None
     if xdg_current_desktop == 'KDE' or xdg_current_desktop.endswith(':KDE'):
-        kreadconfig = core.find_executable('kreadconfig5')
+        kreadconfig = context.ops.find_executable('kreadconfig5')
         if kreadconfig:
-            http_proxy = autodetect_proxy_kde(kreadconfig, 'http')
-            https_proxy = autodetect_proxy_kde(kreadconfig, 'https')
+            http_proxy = autodetect_proxy_kde(context, kreadconfig, 'http')
+            https_proxy = autodetect_proxy_kde(context, kreadconfig, 'https')
     elif xdg_current_desktop:
         # If we're not on KDE then we'll fallback to GNOME / gsettings.
-        gsettings = core.find_executable('gsettings')
-        if gsettings and autodetect_proxy_gnome_is_enabled(gsettings):
-            http_proxy = autodetect_proxy_gnome(gsettings, 'http')
-            https_proxy = autodetect_proxy_gnome(gsettings, 'https')
+        gsettings = context.ops.find_executable('gsettings')
+        if gsettings and autodetect_proxy_gnome_is_enabled(context, gsettings):
+            http_proxy = autodetect_proxy_gnome(context, gsettings, 'http')
+            https_proxy = autodetect_proxy_gnome(context, gsettings, 'https')
 
     if os.environ.get('http_proxy'):
         Interaction.log(
@@ -767,24 +769,28 @@ def autodetect_proxy_environ() -> dict[Any, Any]:
     return add_env
 
 
-def autodetect_proxy_gnome_is_enabled(gsettings: str) -> bool:
+def autodetect_proxy_gnome_is_enabled(
+    context: ApplicationContext, gsettings: str
+) -> bool:
     """Is the proxy manually configured on Gnome?"""
-    status, out, _ = core.run_command(
+    status, out, _ = context.ops.run_command(
         [gsettings, 'get', 'org.gnome.system.proxy', 'mode']
     )
     return status == 0 and out.strip().strip("'") == 'manual'
 
 
-def autodetect_proxy_gnome(gsettings: str, scheme: str) -> str | None:
+def autodetect_proxy_gnome(
+    context: ApplicationContext, gsettings: str, scheme: str
+) -> str | None:
     """Return the configured HTTP proxy for Gnome"""
-    status, out, _ = core.run_command(
+    status, out, _ = context.ops.run_command(
         [gsettings, 'get', f'org.gnome.system.proxy.{scheme}', 'host']
     )
     if status != 0:
         return None
     host = out.strip().strip("'")
     port = ''
-    status, out, _ = core.run_command(
+    status, out, _ = context.ops.run_command(
         [gsettings, 'get', f'org.gnome.system.proxy.{scheme}', 'port']
     )
     if status == 0:
@@ -793,7 +799,9 @@ def autodetect_proxy_gnome(gsettings: str, scheme: str) -> str | None:
     return proxy
 
 
-def autodetect_proxy_kde(kreadconfig: str, scheme: str) -> str | None:
+def autodetect_proxy_kde(
+    context: ApplicationContext, kreadconfig: str, scheme: str
+) -> str | None:
     """Return the configured HTTP proxy for KDE"""
     cmd = [
         kreadconfig,
@@ -804,7 +812,7 @@ def autodetect_proxy_kde(kreadconfig: str, scheme: str) -> str | None:
         '--key',
         'ProxyType',
     ]
-    status, out, err = core.run_command(cmd)
+    status, out, err = context.ops.run_command(cmd)
     if status == 0 and out.strip() == '1':
         cmd = [
             kreadconfig,
@@ -815,7 +823,7 @@ def autodetect_proxy_kde(kreadconfig: str, scheme: str) -> str | None:
             '--key',
             f'{scheme}Proxy',
         ]
-        status, out, _err = core.run_command(cmd)
+        status, out, _err = context.ops.run_command(cmd)
         if status == 0:
             proxy = out.strip().replace(' ', ':')
             return proxy

--- a/cola/models/stash.py
+++ b/cola/models/stash.py
@@ -3,7 +3,6 @@ import re
 from .. import cmds
 from .. import core
 from .. import gitcmds
-from .. import utils
 from ..git import STDOUT
 from ..i18n import N_
 from ..interaction import Interaction
@@ -209,7 +208,7 @@ class StashIndex(cmds.ContextCommand):
         # stash ref, so now we have to remove the staged changes from the
         # worktree.  We do this by applying a reverse diff of the staged
         # changes.  The diff from stash->HEAD is a reverse diff of the stash.
-        patch = utils.tmp_filename('stash')
+        patch = self.context.ops.tmp_filename('stash')
         with core.xopen(patch, mode='wb') as patch_fd:
             status, out, err = git.diff_tree(
                 'refs/stash', 'HEAD', '--', binary=True, _stdout=patch_fd
@@ -220,7 +219,7 @@ class StashIndex(cmds.ContextCommand):
 
         # Apply the patch
         status, out, err = git.apply(patch)
-        core.unlink(patch)
+        self.context.ops.unlink(patch)
         ok = status == 0
         if ok:
             # Finally, clear the index we just stashed

--- a/cola/operations.py
+++ b/cola/operations.py
@@ -1,0 +1,492 @@
+from __future__ import annotations
+import os
+from abc import ABC
+from abc import abstractmethod
+from typing import TYPE_CHECKING
+from typing import Any
+
+from . import core
+
+if TYPE_CHECKING:
+    from io import BufferedWriter
+    from os import stat_result
+
+
+IS_LOCAL = True
+
+
+class IOperations(ABC):
+    @abstractmethod
+    def is_remote(self) -> bool:
+        pass
+
+    @abstractmethod
+    def list2cmdline(self, cmd: list[str | Any | core.UStr]) -> str:
+        pass
+
+    @abstractmethod
+    def xopen(self, path: str, mode: str = 'r', encoding: str | None = None) -> Any:
+        pass
+
+    @abstractmethod
+    def file_append(self, path, text: str, encoding: str | None = None) -> None:
+        """Open a file for appending in UTF-8 text mode"""
+        pass
+
+    @abstractmethod
+    def file_read(self, path, text: str, encoding: str | None = None) -> str:
+        pass
+
+    @abstractmethod
+    def file_write(self, path: str, text: str, encoding: str | None = None) -> None:
+        pass
+
+    @abstractmethod
+    def print_stdout(self, msg, linesep: str = '\n') -> None:
+        pass
+
+    @abstractmethod
+    def print_stderr(self, msg, linesep: str = '\n') -> None:
+        pass
+
+    @abstractmethod
+    def error(self, msg, status, linesep: str = '\n') -> None:
+        pass
+
+    @abstractmethod
+    def node(
+        self,
+    ) -> str:
+        pass
+
+    @abstractmethod
+    def fsync(self, fd: int) -> None:
+        pass
+
+    @abstractmethod
+    def rename(self, old: str, new: str) -> None:
+        pass
+
+    @abstractmethod
+    def guess_mimetype(self, filename: str) -> str | None:
+        pass
+
+    @abstractmethod
+    def getenv(self, name: str, default=None) -> core.UStr | None:
+        pass
+
+    @abstractmethod
+    def write_file(
+        self,
+        path: str,
+        contents: str,
+        encoding: str | None = None,
+        append: bool = False,
+    ) -> int:
+        """Writes a Unicode string to a file"""
+        pass
+
+    @abstractmethod
+    def xwrite(self, fh: BufferedWriter, content: str, encoding: None = None) -> int:
+        """Write to a file handle and retry when interrupted"""
+        pass
+
+    @abstractmethod
+    def wait(self, proc) -> Any:
+        """Wait on a subprocess and retry when interrupted"""
+        pass
+
+    @abstractmethod
+    def find_executable(
+        self, executable: core.UStr | str, path: str | None = None
+    ) -> str | None:
+        pass
+
+    @abstractmethod
+    def getcwd(
+        self,
+    ) -> str:
+        pass
+
+    @abstractmethod
+    def isdir(self, s: str) -> bool:
+        pass
+
+    @abstractmethod
+    def realpath(self, s: str) -> str:
+        pass
+
+    @abstractmethod
+    def exists(self, path: str) -> bool:
+        pass
+
+    @abstractmethod
+    def abspath(self, s: str) -> str:
+        pass
+
+    @abstractmethod
+    def unlink(self, s: str) -> None:
+        pass
+
+    @abstractmethod
+    def stat(self, path: str) -> stat_result:
+        pass
+
+    @abstractmethod
+    def remove(self, path: str) -> None:
+        pass
+
+    @abstractmethod
+    def relpath(self, path: str) -> str | bytes:
+        pass
+
+    @abstractmethod
+    def isfile(self, path: str) -> bool:
+        pass
+
+    @abstractmethod
+    def islink(self, path: str) -> bool:
+        pass
+
+    @abstractmethod
+    def listdir(self, path: Any) -> list[Any]:
+        pass
+
+    @abstractmethod
+    def makedirs(self, name: str) -> None:
+        pass
+
+    @abstractmethod
+    def chdir(self, path: str) -> None:
+        pass
+
+    @abstractmethod
+    def expanduser(self, path: str) -> str:
+        pass
+
+    @abstractmethod
+    def fork(self, args: list[str], cwd: str | None = None, shell: bool = False) -> int:
+        pass
+
+    @abstractmethod
+    def run_command(
+        self, cmd: list[core.UStr | str], *args, **kwargs
+    ) -> tuple[int, core.UStr, core.UStr]:
+        pass
+
+    @abstractmethod
+    def get_environ(
+        self,
+    ) -> dict[str, str]:
+        pass
+
+    @abstractmethod
+    def environ_setdefault(self, key: str, value: str) -> str:
+        pass
+
+    @abstractmethod
+    def environ_pop(self, key: str, default: str) -> str | None:
+        pass
+
+    @abstractmethod
+    def environ_setvalue(self, key: str, value: str) -> None:
+        pass
+
+    @abstractmethod
+    def putenv(self, name: str | bytes, value: str | bytes) -> None:
+        pass
+
+    @abstractmethod
+    def unsetenv(self, name: str) -> None:
+        pass
+
+
+class LocalOperations(IOperations):
+    def is_remote(self) -> bool:
+        return False
+
+    def list2cmdline(self, cmd: list[str | Any | core.UStr]) -> str:
+        return core.list2cmdline(cmd)
+
+    def xopen(self, path: str, mode: str = 'r', encoding: str | None = None) -> Any:
+        return core.xopen(path, mode, encoding)
+
+    def file_append(self, path, text: str, encoding: str | None = None) -> None:
+        with core.open_append(path, encoding) as file:
+            file.write(text)
+
+    def file_read(self, path, text: str, encoding: str | None = None) -> str:
+        with core.open_read(path, encoding) as file:
+            return file.read()
+
+    def file_write(self, path: str, text: str, encoding: str | None = None) -> None:
+        with core.open_write(path, encoding) as file:
+            file.write(text)
+
+    def print_stdout(self, msg, linesep: str = '\n') -> None:
+        return core.print_stdout(msg, linesep)
+
+    def print_stderr(self, msg, linesep: str = '\n') -> None:
+        return core.print_stderr(msg, linesep)
+
+    def error(self, msg, status, linesep: str = '\n') -> None:
+        return core.error(msg, status, linesep)
+
+    def node(
+        self,
+    ) -> str:
+        return core.node()
+
+    def fsync(self, fd: int) -> None:
+        return core.fsync(fd)
+
+    def rename(self, old: str, new: str) -> None:
+        return core.rename(old, new)
+
+    def guess_mimetype(self, filename: str) -> str | None:
+        return core.guess_mimetype(filename)
+
+    def getenv(self, name: str, default: str | None = None) -> core.UStr | None:
+        if default:
+            return core.getenv(name, default)
+        return core.getenv(name)
+
+    def write_file(
+        self,
+        path: str,
+        contents: str,
+        encoding: str | None = None,
+        append: bool = False,
+    ) -> int:
+        """Writes a Unicode string to a file"""
+        return core.write(path, contents, encoding, append)
+
+    def xwrite(self, fh: BufferedWriter, content: str, encoding: None = None) -> int:
+        """Write to a file handle and retry when interrupted"""
+        return core.xwrite(fh, content, encoding)
+
+    def wait(self, proc) -> Any:
+        return core.wait(proc)
+
+    def find_executable(
+        self, executable: core.UStr | str, path: str | None = None
+    ) -> str | None:
+        return core.find_executable(executable, path)
+
+    def getcwd(
+        self,
+    ) -> str:
+        return core.getcwd()
+
+    def isdir(self, s: str) -> bool:
+        return core.isdir(s)
+
+    def realpath(self, s: str) -> str:
+        return core.realpath(s)
+
+    def exists(self, path: str) -> bool:
+        return core.exists(path)
+
+    def abspath(self, s: str) -> str:
+        return core.abspath(s)
+
+    def unlink(self, s: str) -> None:
+        return core.unlink(s)
+
+    def stat(self, path: str) -> stat_result:
+        return core.stat(path)
+
+    def remove(self, path: str) -> None:
+        return core.remove(path)
+
+    def relpath(self, path: str) -> str | bytes:
+        return core.relpath(path)
+
+    def isfile(self, path: str) -> bool:
+        return core.isfile(path)
+
+    def islink(self, path: str) -> bool:
+        return core.islink(path)
+
+    def listdir(self, path: Any) -> list[str | bytes]:
+        return core.listdir(path)
+
+    def makedirs(self, name: str) -> None:
+        return core.makedirs(name)
+
+    def chdir(self, path: str) -> None:
+        return core.chdir(path)
+
+    def expanduser(self, path: str) -> str:
+        return core.expanduser(path)
+
+    def fork(self, args: list[str], cwd: str | None = None, shell: bool = False) -> int:
+        return core.fork(args, cwd, shell, self)
+
+    def run_command(
+        self, cmd: list[core.UStr | str], *args, **kwargs
+    ) -> tuple[int, core.UStr, core.UStr]:
+        return core.run_command(cmd, *args, **kwargs)
+
+    def get_environ(
+        self,
+    ) -> dict[str, str]:
+        return dict(os.environ)
+
+    def environ_setdefault(self, key: str, value: str) -> str:
+        return os.environ.setdefault(key, value)
+
+    def environ_pop(self, key: str, default: str) -> str | None:
+        return os.environ.pop(key, None)
+
+    def environ_setvalue(self, key: str, value: str) -> None:
+        os.environ[key] = value
+
+    def putenv(self, name: str | bytes, value: str | bytes) -> None:
+        return os.putenv(name, value)
+
+    def unsetenv(self, name: str) -> None:
+        return os.unsetenv(name)
+
+
+class RemoteOperations(IOperations):
+    def is_remote(self) -> bool:
+        return True
+
+    def list2cmdline(self, cmd: list[str | Any | core.UStr]) -> str:
+        raise NotImplementedError('Not implemented')
+
+    def xopen(self, path: str, mode: str = 'r', encoding: str | None = None) -> Any:
+        raise NotImplementedError('Not implemented')
+
+    def file_append(self, path, text: str, encoding: str | None = None) -> None:
+        """Open a file for appending in UTF-8 text mode"""
+        raise NotImplementedError('Not implemented')
+
+    def file_read(self, path, text: str, encoding: str | None = None) -> str:
+        raise NotImplementedError('Not implemented')
+
+    def file_write(self, path: str, text: str, encoding: str | None = None) -> None:
+        raise NotImplementedError('Not implemented')
+
+    def print_stdout(self, msg, linesep: str = '\n') -> None:
+        raise NotImplementedError('Not implemented')
+
+    def print_stderr(self, msg, linesep: str = '\n') -> None:
+        raise NotImplementedError('Not implemented')
+
+    def error(self, msg, status, linesep: str = '\n') -> None:
+        raise NotImplementedError('Not implemented')
+
+    def node(
+        self,
+    ) -> str:
+        raise NotImplementedError('Not implemented')
+
+    def fsync(self, fd) -> None:
+        raise NotImplementedError('Not implemented')
+
+    def rename(self, old: str, new: str) -> None:
+        raise NotImplementedError('Not implemented')
+
+    def guess_mimetype(self, filename: str) -> str | None:
+        raise NotImplementedError('Not implemented')
+
+    def getenv(self, name: str, default: str | None = None) -> core.UStr | None:
+        raise NotImplementedError('Not implemented')
+
+    def write_file(
+        self,
+        path: str,
+        contents: str,
+        encoding: str | None = None,
+        append: bool = False,
+    ) -> int:
+        raise NotImplementedError('Not implemented')
+
+    def xwrite(self, fh: BufferedWriter, content: str, encoding: None = None) -> int:
+        """Write to a file handle and retry when interrupted"""
+        raise NotImplementedError('Not implemented')
+
+    def wait(self, proc) -> Any:
+        raise NotImplementedError('Not implemented')
+
+    def find_executable(
+        self, executable: core.UStr | str, path: str | None = None
+    ) -> str | None:
+        raise NotImplementedError('Not implemented')
+
+    def getcwd(
+        self,
+    ) -> str:
+        raise NotImplementedError('Not implemented')
+
+    def isdir(self, s: str) -> bool:
+        raise NotImplementedError('Not implemented')
+
+    def realpath(self, s: str) -> str:
+        raise NotImplementedError('Not implemented')
+
+    def exists(self, path: str) -> bool:
+        raise NotImplementedError('Not implemented')
+
+    def abspath(self, s: str) -> str:
+        raise NotImplementedError('Not implemented')
+
+    def unlink(self, s: str) -> None:
+        raise NotImplementedError('Not implemented')
+
+    def stat(self, path: str) -> stat_result:
+        raise NotImplementedError('Not implemented')
+
+    def remove(self, path: str) -> None:
+        raise NotImplementedError('Not implemented')
+
+    def relpath(self, path: str) -> str | bytes:
+        raise NotImplementedError('Not implemented')
+
+    def isfile(self, path: str) -> bool:
+        raise NotImplementedError('Not implemented')
+
+    def islink(self, path: str) -> bool:
+        raise NotImplementedError('Not implemented')
+
+    def listdir(self, path: Any) -> list[str | bytes]:
+        raise NotImplementedError('Not implemented')
+
+    def makedirs(self, name: str) -> None:
+        raise NotImplementedError('Not implemented')
+
+    def chdir(self, path: str) -> None:
+        raise NotImplementedError('Not implemented')
+
+    def expanduser(self, path: str) -> str:
+        raise NotImplementedError('Not implemented')
+
+    def fork(self, args: list[str], cwd: str | None = None, shell: bool = False) -> int:
+        raise NotImplementedError('Not implemented')
+
+    def run_command(
+        self, cmd: list[core.UStr | str], *args, **kwargs
+    ) -> tuple[int, core.UStr, core.UStr]:
+        raise NotImplementedError('Not implemented')
+
+    def get_environ(
+        self,
+    ) -> dict[str, str]:
+        raise NotImplementedError('Not implemented')
+
+    def environ_setdefault(self, key: str, value: str) -> str:
+        raise NotImplementedError('Not implemented')
+
+    def environ_pop(self, key: str, default: str) -> str | None:
+        raise NotImplementedError('Not implemented')
+
+    def environ_setvalue(self, key: str, value: str) -> None:
+        raise NotImplementedError('Not implemented')
+
+    def putenv(self, name: str | bytes, value: str | bytes) -> None:
+        raise NotImplementedError('Not implemented')
+
+    def unsetenv(self, name: str) -> None:
+        raise NotImplementedError('Not implemented')

--- a/cola/operations.py
+++ b/cola/operations.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 from typing import Any
 
 from . import core
+from . import server
+from . import utils
 
 if TYPE_CHECKING:
     from io import BufferedWriter
@@ -34,7 +36,7 @@ class IOperations(ABC):
         pass
 
     @abstractmethod
-    def file_read(self, path, text: str, encoding: str | None = None) -> str:
+    def file_read(self, path, encoding: str | None = None) -> str:
         pass
 
     @abstractmethod
@@ -121,7 +123,7 @@ class IOperations(ABC):
         pass
 
     @abstractmethod
-    def abspath(self, s: str) -> str:
+    def abspath(self, s: core.UStr | str) -> str:
         pass
 
     @abstractmethod
@@ -200,6 +202,10 @@ class IOperations(ABC):
     def unsetenv(self, name: str) -> None:
         pass
 
+    @abstractmethod
+    def tmp_filename(self, label: str, suffix: str = '') -> str:
+        pass
+
 
 class LocalOperations(IOperations):
     def is_remote(self) -> bool:
@@ -215,7 +221,7 @@ class LocalOperations(IOperations):
         with core.open_append(path, encoding) as file:
             file.write(text)
 
-    def file_read(self, path, text: str, encoding: str | None = None) -> str:
+    def file_read(self, path, encoding: str | None = None) -> str:
         with core.open_read(path, encoding) as file:
             return file.read()
 
@@ -287,7 +293,7 @@ class LocalOperations(IOperations):
     def exists(self, path: str) -> bool:
         return core.exists(path)
 
-    def abspath(self, s: str) -> str:
+    def abspath(self, s: core.UStr | str) -> str:
         return core.abspath(s)
 
     def unlink(self, s: str) -> None:
@@ -348,6 +354,9 @@ class LocalOperations(IOperations):
     def unsetenv(self, name: str) -> None:
         return os.unsetenv(name)
 
+    def tmp_filename(self, label: str, suffix: str = '') -> str:
+        return utils.tmp_filename(label, suffix)
+
 
 class RemoteOperations(IOperations):
     def is_remote(self) -> bool:
@@ -363,7 +372,7 @@ class RemoteOperations(IOperations):
         """Open a file for appending in UTF-8 text mode"""
         raise NotImplementedError('Not implemented')
 
-    def file_read(self, path, text: str, encoding: str | None = None) -> str:
+    def file_read(self, path, encoding: str | None = None) -> str:
         raise NotImplementedError('Not implemented')
 
     def file_write(self, path: str, text: str, encoding: str | None = None) -> None:
@@ -430,7 +439,7 @@ class RemoteOperations(IOperations):
     def exists(self, path: str) -> bool:
         raise NotImplementedError('Not implemented')
 
-    def abspath(self, s: str) -> str:
+    def abspath(self, s: core.UStr | str) -> str:
         raise NotImplementedError('Not implemented')
 
     def unlink(self, s: str) -> None:

--- a/cola/operations.py
+++ b/cola/operations.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import io
 import os
 from abc import ABC
 from abc import abstractmethod
@@ -6,14 +7,12 @@ from typing import TYPE_CHECKING
 from typing import Any
 
 from . import core
-from . import server
 from . import utils
 
 if TYPE_CHECKING:
-    from io import BufferedWriter
-    from os import stat_result
+    from . import server
 
-
+ENCODING = 'utf-8'
 IS_LOCAL = True
 
 
@@ -21,6 +20,14 @@ class IOperations(ABC):
     @abstractmethod
     def is_remote(self) -> bool:
         pass
+
+    @classmethod
+    def function_dict(cls):
+        return {
+            name: val
+            for name, val in cls.__dict__.items()
+            if callable(val) and not name.startswith('__')
+        }
 
     @abstractmethod
     def list2cmdline(self, cmd: list[str | Any | core.UStr]) -> str:
@@ -89,16 +96,6 @@ class IOperations(ABC):
         pass
 
     @abstractmethod
-    def xwrite(self, fh: BufferedWriter, content: str, encoding: None = None) -> int:
-        """Write to a file handle and retry when interrupted"""
-        pass
-
-    @abstractmethod
-    def wait(self, proc) -> Any:
-        """Wait on a subprocess and retry when interrupted"""
-        pass
-
-    @abstractmethod
     def find_executable(
         self, executable: core.UStr | str, path: str | None = None
     ) -> str | None:
@@ -131,7 +128,7 @@ class IOperations(ABC):
         pass
 
     @abstractmethod
-    def stat(self, path: str) -> stat_result:
+    def stat(self, path: str) -> dict[str, int]:
         pass
 
     @abstractmethod
@@ -164,10 +161,6 @@ class IOperations(ABC):
 
     @abstractmethod
     def expanduser(self, path: str) -> str:
-        pass
-
-    @abstractmethod
-    def fork(self, args: list[str], cwd: str | None = None, shell: bool = False) -> int:
         pass
 
     @abstractmethod
@@ -267,13 +260,6 @@ class LocalOperations(IOperations):
         """Writes a Unicode string to a file"""
         return core.write(path, contents, encoding, append)
 
-    def xwrite(self, fh: BufferedWriter, content: str, encoding: None = None) -> int:
-        """Write to a file handle and retry when interrupted"""
-        return core.xwrite(fh, content, encoding)
-
-    def wait(self, proc) -> Any:
-        return core.wait(proc)
-
     def find_executable(
         self, executable: core.UStr | str, path: str | None = None
     ) -> str | None:
@@ -299,8 +285,10 @@ class LocalOperations(IOperations):
     def unlink(self, s: str) -> None:
         return core.unlink(s)
 
-    def stat(self, path: str) -> stat_result:
-        return core.stat(path)
+    def stat(self, path: str) -> dict[str, int]:
+        st = core.stat(path)
+
+        return {'st_mtime': st.st_mtime}
 
     def remove(self, path: str) -> None:
         return core.remove(path)
@@ -325,9 +313,6 @@ class LocalOperations(IOperations):
 
     def expanduser(self, path: str) -> str:
         return core.expanduser(path)
-
-    def fork(self, args: list[str], cwd: str | None = None, shell: bool = False) -> int:
-        return core.fork(args, cwd, shell, self)
 
     def run_command(
         self, cmd: list[core.UStr | str], *args, **kwargs
@@ -359,50 +344,179 @@ class LocalOperations(IOperations):
 
 
 class RemoteOperations(IOperations):
+    def __init__(self, socket_client: server.SocketClient):
+        from . import server
+
+        self.client = server.SyncSocketClient(socket_client)
+        self.seq_number = 0
+
+    def _send_op(self, data: dict[str, Any]):
+        data['seq_number'] = self.seq_number
+        received = self.client.send_message_msgpack(data)
+        if received.get('seq_number') != data.get('seq_number'):
+            raise OSError('seq_number was not correct')
+        self.seq_number += 1
+
+        if received.get('is_exception', False):
+            raise OSError(f"Error was found: {received.get('result')}")
+
+        if 'error' in received:
+            raise RuntimeError(received['error'])
+
+        return received.get('result')
+
     def is_remote(self) -> bool:
         return True
 
     def list2cmdline(self, cmd: list[str | Any | core.UStr]) -> str:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'list2cmdline',
+            'args': [],
+            'kwargs': {
+                'cmd': cmd,
+            },
+        }
+        return self._send_op(data)
 
     def xopen(self, path: str, mode: str = 'r', encoding: str | None = None) -> Any:
-        raise NotImplementedError('Not implemented')
+        """Open a file for appending in UTF-8 text mode"""
+        data = {
+            'op': 'file_read',
+            'args': [],
+            'kwargs': {
+                'path': path,
+                'encoding': encoding,
+            },
+        }
+        if mode == 'rb':
+            result = self._send_op(data)
+            if not isinstance(result, bytes):
+                result = result.encode('utf-8')
+            return io.BytesIO(result)
+
+        return io.StringIO(self._send_op(data))
 
     def file_append(self, path, text: str, encoding: str | None = None) -> None:
         """Open a file for appending in UTF-8 text mode"""
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'file_append',
+            'args': [],
+            'kwargs': {
+                'path': path,
+                'text': text,
+                'encoding': encoding,
+            },
+        }
+        return self._send_op(data)
 
     def file_read(self, path, encoding: str | None = None) -> str:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'file_read',
+            'args': [],
+            'kwargs': {
+                'path': path,
+                'encoding': encoding,
+            },
+        }
+        return self._send_op(data)
 
     def file_write(self, path: str, text: str, encoding: str | None = None) -> None:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'file_write',
+            'args': [],
+            'kwargs': {
+                'path': path,
+                'text': text,
+                'encoding': encoding,
+            },
+        }
+        return self._send_op(data)
 
     def print_stdout(self, msg, linesep: str = '\n') -> None:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'print_stdout',
+            'args': [],
+            'kwargs': {
+                'msg': msg,
+                'linesep': linesep,
+            },
+        }
+        return self._send_op(data)
 
     def print_stderr(self, msg, linesep: str = '\n') -> None:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'print_stderr',
+            'args': [],
+            'kwargs': {
+                'msg': msg,
+                'linesep': linesep,
+            },
+        }
+        return self._send_op(data)
 
     def error(self, msg, status, linesep: str = '\n') -> None:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'error',
+            'args': [],
+            'kwargs': {
+                'msg': msg,
+                'status': status,
+                'linesep': linesep,
+            },
+        }
+        return self._send_op(data)
 
     def node(
         self,
     ) -> str:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'node',
+            'args': [],
+            'kwargs': {},
+        }
+        return self._send_op(data)
 
     def fsync(self, fd) -> None:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'fsync',
+            'args': [],
+            'kwargs': {
+                'fd': fd,
+            },
+        }
+        return self._send_op(data)
 
     def rename(self, old: str, new: str) -> None:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'rename',
+            'args': [],
+            'kwargs': {
+                'old': old,
+                'new': new,
+            },
+        }
+        return self._send_op(data)
 
     def guess_mimetype(self, filename: str) -> str | None:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'guess_mimetype',
+            'args': [],
+            'kwargs': {
+                'filename': filename,
+            },
+        }
+        return self._send_op(data)
 
     def getenv(self, name: str, default: str | None = None) -> core.UStr | None:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'getenv',
+            'args': [],
+            'kwargs': {
+                'name': name,
+                'default': default,
+            },
+        }
+        return self._send_op(data)
 
     def write_file(
         self,
@@ -411,91 +525,242 @@ class RemoteOperations(IOperations):
         encoding: str | None = None,
         append: bool = False,
     ) -> int:
-        raise NotImplementedError('Not implemented')
-
-    def xwrite(self, fh: BufferedWriter, content: str, encoding: None = None) -> int:
-        """Write to a file handle and retry when interrupted"""
-        raise NotImplementedError('Not implemented')
-
-    def wait(self, proc) -> Any:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'write_file',
+            'args': [],
+            'kwargs': {
+                'path': path,
+                'contents': contents,
+                'encoding': encoding,
+                'append': append,
+            },
+        }
+        return self._send_op(data)
 
     def find_executable(
         self, executable: core.UStr | str, path: str | None = None
     ) -> str | None:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'find_executable',
+            'args': [],
+            'kwargs': {'executable': executable, 'path': path},
+        }
+        return self._send_op(data)
 
     def getcwd(
         self,
     ) -> str:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'getcwd',
+            'args': [],
+            'kwargs': {},
+        }
+        return self._send_op(data)
 
     def isdir(self, s: str) -> bool:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'isdir',
+            'args': [],
+            'kwargs': {'s': s},
+        }
+        return self._send_op(data)
 
     def realpath(self, s: str) -> str:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'realpath',
+            'args': [],
+            'kwargs': {'s': s},
+        }
+        return self._send_op(data)
 
     def exists(self, path: str) -> bool:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'exists',
+            'args': [],
+            'kwargs': {'path': path},
+        }
+        return self._send_op(data)
 
     def abspath(self, s: core.UStr | str) -> str:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'abspath',
+            'args': [],
+            'kwargs': {'s': s},
+        }
+        return self._send_op(data)
 
     def unlink(self, s: str) -> None:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'unlink',
+            'args': [],
+            'kwargs': {'s': s},
+        }
+        return self._send_op(data)
 
-    def stat(self, path: str) -> stat_result:
-        raise NotImplementedError('Not implemented')
+    def stat(self, path: str) -> dict[str, int]:
+        def validate_path(path: str):
+            if not path:
+                raise ValueError('Empty path')
+
+            if '\t' in path or '\n' in path:
+                path = path.replace('b\t', '')
+                if '\t' in path or '\n' in path:
+                    raise ValueError(f'Invalid control chars in path: {repr(path)}')
+
+                return path
+
+            if path.startswith('b"') or path.startswith("b'"):
+                raise ValueError(f'Looks like raw bytes: {repr(path)}')
+
+            return path
+
+        data = {
+            'op': 'stat',
+            'args': [],
+            'kwargs': {'path': validate_path(path)},
+        }
+        return self._send_op(data)
 
     def remove(self, path: str) -> None:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'remove',
+            'args': [],
+            'kwargs': {'path': path},
+        }
+        return self._send_op(data)
 
     def relpath(self, path: str) -> str | bytes:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'relpath',
+            'args': [],
+            'kwargs': {'path': path},
+        }
+        return self._send_op(data)
 
     def isfile(self, path: str) -> bool:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'isfile',
+            'args': [],
+            'kwargs': {'path': path},
+        }
+        return self._send_op(data)
 
     def islink(self, path: str) -> bool:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'islink',
+            'args': [],
+            'kwargs': {'path': path},
+        }
+        return self._send_op(data)
 
     def listdir(self, path: Any) -> list[str | bytes]:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'listdir',
+            'args': [],
+            'kwargs': {'path': path},
+        }
+        return self._send_op(data)
 
     def makedirs(self, name: str) -> None:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'makedirs',
+            'args': [],
+            'kwargs': {'name': name},
+        }
+        return self._send_op(data)
 
     def chdir(self, path: str) -> None:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'chdir',
+            'args': [],
+            'kwargs': {'path': path},
+        }
+        return self._send_op(data)
 
     def expanduser(self, path: str) -> str:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'expanduser',
+            'args': [],
+            'kwargs': {'path': path},
+        }
+        return self._send_op(data)
 
-    def fork(self, args: list[str], cwd: str | None = None, shell: bool = False) -> int:
-        raise NotImplementedError('Not implemented')
+    def run_command(self, cmd, *args, **kwargs):
+        supported_kwargs = {}
 
-    def run_command(
-        self, cmd: list[core.UStr | str], *args, **kwargs
-    ) -> tuple[int, core.UStr, core.UStr]:
-        raise NotImplementedError('Not implemented')
+        # Filter keyword arguments to those supported by the msgpack.
+        # This avoids serialization failures caused by non-serializable
+        # Python objects, such as builtin functions passed via preexec_fn.
+        if 'cwd' in kwargs and isinstance(kwargs['cwd'], str):
+            supported_kwargs['cwd'] = kwargs['cwd']
+
+        if 'env' in kwargs and isinstance(kwargs['env'], dict):
+            supported_kwargs['env'] = dict(kwargs['env'])
+
+        data = {
+            'op': 'run_command',
+            'args': [cmd],
+            'kwargs': supported_kwargs,
+        }
+
+        status, out, err = self._send_op(data)
+
+        return status, core.UStr(out, ENCODING), core.UStr(err, ENCODING)
 
     def get_environ(
         self,
     ) -> dict[str, str]:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'get_environ',
+            'args': [],
+            'kwargs': {},
+        }
+        return self._send_op(data)
 
     def environ_setdefault(self, key: str, value: str) -> str:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'environ_setdefault',
+            'args': [],
+            'kwargs': {'key': key, 'value': value},
+        }
+        return self._send_op(data)
 
     def environ_pop(self, key: str, default: str) -> str | None:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'environ_pop',
+            'args': [],
+            'kwargs': {'key': key, 'default': default},
+        }
+        return self._send_op(data)
 
     def environ_setvalue(self, key: str, value: str) -> None:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'environ_setvalue',
+            'args': [],
+            'kwargs': {'key': key, 'value': value},
+        }
+        return self._send_op(data)
 
     def putenv(self, name: str | bytes, value: str | bytes) -> None:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'putenv',
+            'args': [],
+            'kwargs': {'name': name, 'value': value},
+        }
+        return self._send_op(data)
 
     def unsetenv(self, name: str) -> None:
-        raise NotImplementedError('Not implemented')
+        data = {
+            'op': 'unsetenv',
+            'args': [],
+            'kwargs': {'name': name},
+        }
+        return self._send_op(data)
+
+    def tmp_filename(self, label: str, suffix: str = '') -> str:
+        data = {
+            'op': 'tmp_filename',
+            'args': [],
+            'kwargs': {'label': label, 'suffix': suffix},
+        }
+        return self._send_op(data)

--- a/cola/polib.py
+++ b/cola/polib.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import array
 import codecs
 import io
-import os
 import re
 import struct
 import sys
@@ -25,6 +24,7 @@ from io import TextIOWrapper
 from typing import Any
 
 from . import compat
+from . import core
 
 __author__ = 'David Jean Louis <izimobil@gmail.com>'
 __version__ = '1.1.1'
@@ -93,7 +93,7 @@ def _pofile_or_mofile(f, filetype, **kwargs) -> MOFile | POFile:
 
 def _is_file(filename_or_contents: str) -> bool:
     """
-    Safely returns the value of os.path.exists(filename_or_contents).
+    Safely returns the value of core.exists(filename_or_contents).
 
     Arguments:
 
@@ -102,7 +102,7 @@ def _is_file(filename_or_contents: str) -> bool:
         In the latter case, this function will always return False.
     """
     try:
-        return os.path.isfile(filename_or_contents)
+        return core.isfile(filename_or_contents)
     except (TypeError, ValueError, UnicodeEncodeError):
         return False
 

--- a/cola/qtutils.py
+++ b/cola/qtutils.py
@@ -1249,7 +1249,7 @@ def mimedata_from_paths(
     Older versions of gnome-terminal expected a UTF-16 encoding, but that
     behavior is no longer needed.
     """
-    abspaths = [core.abspath(path) for path in paths]
+    abspaths = [context.ops.abspath(path) for path in paths]
     paths_text = core.list2cmdline(abspaths)
 
     # The text/x-moz-list format is always included by Qt, and doing

--- a/cola/qtutils.py
+++ b/cola/qtutils.py
@@ -39,6 +39,8 @@ if TYPE_CHECKING:
     from qtpy.QtCore import QEvent
     from qtpy.QtCore import QMimeData
 
+    from .app import ApplicationContext
+
 STRETCH = object()
 SKIPPED = object()
 
@@ -538,24 +540,33 @@ class TreeWidgetItem(QtWidgets.QTreeWidgetItem):
 
 
 def paths_from_indexes(
-    model: Any, indexes: list[int], item_type=TreeWidgetItem.TYPE, item_filter=None
+    context: ApplicationContext,
+    model: Any,
+    indexes: list[int],
+    item_type=TreeWidgetItem.TYPE,
+    item_filter=None,
 ):
     """Return paths from a list of QStandardItemModel indexes"""
     items = [model.itemFromIndex(i) for i in indexes]
-    return paths_from_items(items, item_type=item_type, item_filter=item_filter)
+    return paths_from_items(
+        context, items, item_type=item_type, item_filter=item_filter
+    )
 
 
-def _true_filter(_value) -> bool:
+def _true_filter(context: ApplicationContext, _value) -> bool:
     return True
 
 
 def paths_from_items(
-    items: Any, item_type=TreeWidgetItem.TYPE, item_filter: Any = None
+    context: ApplicationContext,
+    items: Any,
+    item_type=TreeWidgetItem.TYPE,
+    item_filter: Any = None,
 ):
     """Return a list of paths from a list of items"""
     if item_filter is None:
         item_filter = _true_filter
-    return [i.path for i in items if i.type() == item_type and item_filter(i)]
+    return [i.path for i in items if i.type() == item_type and item_filter(context, i)]
 
 
 def tree_selection(tree_item: QtWidgets.QTreeWidgetItem, items: list[Any]) -> list[Any]:
@@ -662,12 +673,14 @@ def existing_file(directory: Any, title: str = 'Open File...') -> tuple[Any, Any
     return result[0]
 
 
-def copy_path(filename: str, absolute: bool = True) -> None:
+def copy_path(
+    context: ApplicationContext, filename: str, absolute: bool = True
+) -> None:
     """Copy a filename to the clipboard"""
     if filename is None:
         return
     if absolute:
-        filename = core.abspath(filename)
+        filename = context.ops.abspath(filename)
     set_clipboard(filename)
 
 

--- a/cola/resources.py
+++ b/cola/resources.py
@@ -91,7 +91,7 @@ def doc(*args) -> str:
     # hotkey files as cola/data/ package data. This is a fallback location for when
     # users did not use the garden.yaml or Makefile to install cola.
     path = share('doc', 'git-cola', *args)
-    if not os.path.exists(path):
+    if not core.exists(path):
         path = prefix('docs', *args)
     return path
 
@@ -158,9 +158,9 @@ def icon_dir(theme: str) -> str:
         icons = package_data('icons')
     else:
         theme_dir = package_data('icons', theme)
-        if os.path.isabs(theme) and os.path.isdir(theme):
+        if os.path.isabs(theme) and core.isdir(theme):
             icons = theme
-        elif os.path.isdir(theme_dir):
+        elif core.isdir(theme_dir):
             icons = theme_dir
         else:
             icons = package_data('icons')
@@ -193,18 +193,18 @@ def xdg_data_dirs() -> list[TextType]:
     """
     paths: list[TextType] = []
     xdg_data_home_dir = xdg_data_home()
-    if os.path.isdir(xdg_data_home_dir):
+    if core.isdir(xdg_data_home_dir):
         paths.append(xdg_data_home_dir)
 
     xdg_data_dirs_env: TextType | None = core.getenv('XDG_DATA_DIRS', '')
     if not xdg_data_dirs_env:
         xdg_data_dirs_env: TextType | None = '/usr/local/share:/usr/share'
-    paths.extend(path for path in xdg_data_dirs_env.split(':') if os.path.isdir(path))
+    paths.extend(path for path in xdg_data_dirs_env.split(':') if core.isdir(path))
     return paths
 
 
 def find_first(
-    subpath: str, paths: list[TextType], validate: Callable = os.path.isfile
+    subpath: str, paths: list[TextType], validate: Callable = core.isfile
 ) -> str | None:
     """Return the first `subpath` found in the specified directory paths"""
     if os.path.isabs(subpath):

--- a/cola/server.py
+++ b/cola/server.py
@@ -1,0 +1,163 @@
+""" """
+from __future__ import annotations
+import asyncio
+import sys
+import threading
+from typing import Any
+
+try:
+    import msgpack
+except ImportError:
+    msgpack = None
+
+try:
+    import websockets
+except ImportError:
+    websockets = None
+
+from . import operations
+
+
+def check_dependencies() -> None:
+    if msgpack is None:
+        print('msgpack package was not found')
+        sys.exit(1)
+
+    if websockets is None:
+        print('websockets package was not found')
+        sys.exit(1)
+
+
+class SocketServer:
+    def __init__(self, port: int = 49178):
+        check_dependencies()
+        self.port = port
+        self.ops = operations.LocalOperations()
+
+    async def message_handler(self, websocket):
+        async for message_bytes in websocket:
+            message = msgpack.unpackb(message_bytes)
+            try:
+                print(f'Received: {message}')
+
+                func_dict = self.ops.function_dict()
+
+                if message.get('op') in func_dict:
+                    method = func_dict.get(message.get('op'))
+                    args = message.get('args', [])
+                    kwargs = message.get('kwargs', {})
+
+                    result = method(self.ops, *args, **kwargs)
+
+                    await websocket.send(
+                        msgpack.packb({
+                            'seq_number': message.get('seq_number'),
+                            'op': 'response',
+                            'result': result,
+                        })
+                    )
+                else:
+                    await websocket.send(
+                        msgpack.packb({
+                            'seq_number': message.get('seq_number'),
+                            'op': 'response',
+                            'result': 'Unknown command',
+                            'is_exception': True,
+                        })
+                    )
+
+            except Exception as e:
+                import traceback
+
+                await websocket.send(
+                    msgpack.packb({
+                        'seq_number': message.get('seq_number'),
+                        'op': 'response',
+                        'result': str(e),
+                        'is_exception': True,
+                        'traceback': traceback.format_exc(),
+                    })
+                )
+
+    async def run_async(self):
+        async with websockets.serve(
+            self.message_handler, '0.0.0.0', self.port, max_size=10 * 1024 * 1024
+        ):
+            print(f'Server running on ws://0.0.0.0:{self.port}')
+            await asyncio.Future()  # run forever
+
+    def run(self):
+        asyncio.run(self.run_async())
+
+
+class SocketClient:
+    def __init__(self, ip: str, port: int = 49178, protocol: str = 'ws'):
+        check_dependencies()
+        self.ip = ip
+        self.port = port
+        self.protocol = protocol
+        self.websocket = None
+        self._recv_lock = None
+
+    async def connect(self):
+        try:
+            self._recv_lock = asyncio.Lock()
+            self.websocket = await websockets.connect(
+                f'{self.protocol}://{self.ip}:{self.port}',
+                max_size=10 * 1024 * 1024,
+            )
+        except Exception as err:
+            print(f'Connection failure! {err}')
+            sys.exit(1)
+
+    async def send_message_msgpack(self, message: dict[str, Any]) -> Any:
+        packed_message = msgpack.packb(message)
+        return await self.send_message(
+            packed_message,
+            message.get('seq_number'),
+        )
+
+    async def send_message(self, message: str, seq_number: int):
+        if self.websocket is None:
+            raise RuntimeError('WebSocket is not connected')
+
+        await self.websocket.send(message)
+        async with self._recv_lock:
+            result = msgpack.unpackb(await self.websocket.recv())
+            while result.get('seq_number') != seq_number:
+                result = msgpack.unpackb(await self.websocket.recv())
+            return result
+
+
+class SyncSocketClient:
+    def __init__(self, async_client: SocketClient):
+        check_dependencies()
+        self.client = async_client
+        self.loop = asyncio.new_event_loop()
+        self.thread = threading.Thread(target=self._run_loop, daemon=True)
+        self.thread.start()
+
+        self._run(self.client.connect())
+
+    def _run_loop(self):
+        asyncio.set_event_loop(self.loop)
+        self.loop.run_forever()
+
+    def _run(self, coro):
+        future = asyncio.run_coroutine_threadsafe(coro, self.loop)
+        return future.result()  # blocks until done
+
+    def send_message_msgpack(self, message: dict[str, Any]):
+        return self._run(self.client.send_message_msgpack(message))
+
+    def send_message(self, message: str, seq_number: int):
+        return self._run(self.client.send_message(message, seq_number))
+
+
+def run() -> None:
+    """Start the websocket server."""
+    SocketServer().run()
+
+
+if __name__ == '__main__':
+    run()

--- a/cola/spellcheck.py
+++ b/cola/spellcheck.py
@@ -131,10 +131,10 @@ class NorvigSpellCheck:
         words = self.dictwords
         propernames = self.propernames
 
-        if use_common_files and words and os.path.exists(words):
+        if use_common_files and words and core.exists(words):
             paths.append(words)
 
-        if use_common_files and propernames and os.path.exists(propernames):
+        if use_common_files and propernames and core.exists(propernames):
             paths.append(propernames)
 
         for path in self.extra_dictionaries:
@@ -207,6 +207,6 @@ def get_available_dictionaries() -> list[str]:
         # Create a "/usr/share/hunspell/*.dic" glob pattern.
         hunspell_pattern = os.path.join(hunspell_prefix, 'share', 'hunspell', '*.dic')
         dictionaries.extend(
-            path for path in glob.glob(hunspell_pattern) if not os.path.islink(path)
+            path for path in glob.glob(hunspell_pattern) if not core.islink(path)
         )
     return dictionaries

--- a/cola/themes.py
+++ b/cola/themes.py
@@ -736,7 +736,7 @@ def get_all_themes() -> list[Theme]:
 
     # check if themes path exists in user folder
     path = resources.config_home('themes')
-    if not os.path.isdir(path):
+    if not core.isdir(path):
         return themes
 
     # Gather Qt .qss stylesheet themes

--- a/cola/utils.py
+++ b/cola/utils.py
@@ -18,10 +18,12 @@ from typing import TypeVar
 
 from . import compat
 from . import core
+from . import operations
 
 if TYPE_CHECKING:
     from qtpy.QtWidgets import QAction
 
+    from .app import ApplicationContext
     from .types import TextType
 
 _SSH_REGEX = re.compile(r'^(?P<user>[^@]+)@(?P<hostname>[^:]+):(?P<path>.+)')
@@ -243,16 +245,16 @@ def pathset(path: str) -> list[str]:
     return result
 
 
-def select_directory(paths: list[str]) -> str:
+def select_directory(ops: operations.IOperations, paths: list[str]) -> str:
     """Return the first directory in a list of paths"""
     if not paths:
-        return core.getcwd()
+        return ops.getcwd()
 
     for path in paths:
-        if core.isdir(path):
+        if ops.isdir(path):
             return path
 
-    return os.path.dirname(paths[0]) or core.getcwd()
+    return os.path.dirname(paths[0]) or ops.getcwd()
 
 
 def strip_prefix(prefix, string: str) -> str:
@@ -310,7 +312,7 @@ def tmp_filename(label: str, suffix: str = '') -> str:
         return handle.name
 
 
-def find_bash_exe() -> str | None:
+def find_bash_exe(ops: operations.IOperations) -> str | None:
     """
     Locate bash.exe bundled with Git for Windows.
 
@@ -324,7 +326,7 @@ def find_bash_exe() -> str | None:
         return None
 
     # Estimate Git root directory (e.g., C:\Program Files\Git)
-    cmd_dir = os.path.dirname(os.path.abspath(git_path))
+    cmd_dir = os.path.dirname(ops.abspath(git_path))
     git_root = os.path.dirname(cmd_dir)
 
     # Typical relative locations for bash.exe under Git for Windows
@@ -333,7 +335,7 @@ def find_bash_exe() -> str | None:
     # Search and return the first match
     for rel in candidates:
         bash = os.path.join(git_root, rel, 'bash.exe')
-        if os.path.exists(bash):
+        if ops.exists(bash):
             return bash.replace('\\', '/')
 
     return None
@@ -346,7 +348,7 @@ def is_linux() -> bool:
 
 def is_debian() -> bool:
     """Is this a Debian/Linux machine?"""
-    return os.path.exists('/usr/bin/apt-get')
+    return core.exists('/usr/bin/apt-get')
 
 
 def is_darwin() -> bool:
@@ -359,12 +361,12 @@ def is_win32() -> bool:
     return sys.platform in {'win32', 'cygwin'}
 
 
-def launch_default_app(paths) -> None:
+def launch_default_app(context: ApplicationContext, paths) -> None:
     """Execute the default application on the specified paths"""
     if is_win32():
         for path in paths:
             if hasattr(os, 'startfile'):
-                os.startfile(os.path.abspath(path))
+                os.startfile(context.ops.abspath(path))
         return
 
     if is_darwin():

--- a/cola/widgets/about.py
+++ b/cola/widgets/about.py
@@ -1,4 +1,3 @@
-import os
 import platform
 import sys
 import webbrowser
@@ -9,6 +8,7 @@ from qtpy import QtGui
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt
 
+from .. import core
 from .. import hotkeys
 from .. import icons
 from .. import qtutils
@@ -523,7 +523,7 @@ def show_shortcuts():
         hotkeys_url = 'file:///' + hotkeys_html.replace('\\', '/')
     else:
         hotkeys_url = 'file://' + hotkeys_html
-    if not os.path.isfile(hotkeys_html):
+    if not core.isfile(hotkeys_html):
         hotkeys_url = 'https://git-cola.gitlab.io/share/doc/git-cola/hotkeys.html'
         hotkeys_html = None
     try:

--- a/cola/widgets/archive.py
+++ b/cola/widgets/archive.py
@@ -7,7 +7,6 @@ from qtpy.QtCore import Qt
 from qtpy.QtCore import Signal
 
 from .. import cmds
-from .. import core
 from .. import icons
 from .. import qtutils
 from ..git import STDOUT
@@ -103,7 +102,7 @@ class Archive(Dialog):
         # outputs
         self.fmt = None
 
-        filename = f'{os.path.basename(core.getcwd())}-{shortref}'
+        filename = f'{os.path.basename(context.ops.getcwd())}-{shortref}'
         self.prefix = filename + '/'
         self.filename = filename
 
@@ -200,7 +199,7 @@ class Archive(Dialog):
         filename = self.filename
         if not filename:
             return
-        if core.exists(filename):
+        if self.context.ops.exists(filename):
             title = N_('Overwrite File?')
             msg = N_('The file "%s" exists and will be overwritten.') % filename
             info_txt = N_('Overwrite "%s"?') % filename

--- a/cola/widgets/bookmarks.py
+++ b/cola/widgets/bookmarks.py
@@ -8,7 +8,6 @@ from qtpy.QtCore import Qt
 from qtpy.QtCore import Signal
 
 from .. import cmds
-from .. import core
 from .. import git
 from .. import hotkeys
 from .. import icons
@@ -464,18 +463,18 @@ class BookmarksTreeView(standard.TreeView):
         self.toggle_switcher.emit(False)
 
     def add_bookmark(self):
-        normpath = utils.expandpath(core.getcwd())
+        normpath = utils.expandpath(self.context.ops.getcwd())
         name = os.path.basename(normpath)
         prompt = (
             (N_('Name'), name),
-            (N_('Path'), core.getcwd()),
+            (N_('Path'), self.context.ops.getcwd()),
         )
         ok, values = qtutils.prompt_n(N_('Add Favorite'), prompt)
         if not ok:
             return
         name, path = values
         normpath = utils.expandpath(path)
-        if git.is_git_worktree(normpath):
+        if git.is_git_worktree(self.context.ops, normpath):
             settings = self.context.settings
             settings.load()
             settings.add_bookmark(normpath, name)

--- a/cola/widgets/browse.py
+++ b/cola/widgets/browse.py
@@ -67,6 +67,7 @@ class Browser(standard.Widget):
         self.setLayout(self.mainlayout)
 
         self.model = context.model
+        self.context = context
         self.model.updated.connect(self._updated_callback, type=Qt.QueuedConnection)
         if parent is None:
             qtutils.add_close_action(self)
@@ -85,7 +86,7 @@ class Browser(standard.Widget):
 
     def _updated_callback(self):
         branch = self.model.currentbranch
-        curdir = core.getcwd()
+        curdir = self.context.ops.getcwd()
         msg = N_('Repository: %s') % curdir
         msg += '\n'
         msg += N_('Branch: %s') % branch
@@ -473,7 +474,7 @@ class RepoTreeView(standard.TreeView):
 
     def paths_from_indexes(self, indexes):
         return qtutils.paths_from_indexes(
-            self.model(), indexes, item_type=GitRepoNameItem.TYPE
+            self.context, self.model(), indexes, item_type=GitRepoNameItem.TYPE
         )
 
     def selected_paths(self):

--- a/cola/widgets/cfgactions.py
+++ b/cola/widgets/cfgactions.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 
 from qtpy import QtCore

--- a/cola/widgets/clone.py
+++ b/cola/widgets/clone.py
@@ -6,7 +6,6 @@ from qtpy import QtWidgets
 from qtpy.QtCore import Qt
 
 from .. import cmds
-from .. import core
 from .. import icons
 from .. import qtutils
 from .. import utils
@@ -180,7 +179,7 @@ class Clone(standard.Dialog):
         default = default.removesuffix('.git')
         if url == '.':
             # The URL is the current repo
-            default = os.path.basename(core.getcwd())
+            default = os.path.basename(self.context.ops.getcwd())
         if not default:
             Interaction.information(
                 N_('Error Cloning'), N_('Could not parse Git URL: "%s"') % url
@@ -196,13 +195,13 @@ class Clone(standard.Dialog):
         count = 1
         destdir = os.path.join(dirname, default)
         olddestdir = destdir
-        if core.exists(destdir):
+        if self.context.ops.exists(destdir):
             # An existing path can be specified
             msg = N_('"%s" already exists, cola will create a new directory') % destdir
             Interaction.information(N_('Directory Exists'), msg)
 
         # Make sure the directory doesn't exist
-        while core.exists(destdir):
+        while self.context.ops.exists(destdir):
             destdir = olddestdir + str(count)
             count += 1
 

--- a/cola/widgets/commitmsg.py
+++ b/cola/widgets/commitmsg.py
@@ -9,7 +9,6 @@ from qtpy.QtCore import Signal
 
 from .. import actions
 from .. import cmds
-from .. import core
 from .. import display
 from .. import gitcmds
 from .. import hotkeys
@@ -291,7 +290,7 @@ class CommitMessageEditor(QtWidgets.QFrame):
         commit_msg = ''
         commit_msg_path = commit_message_path(context)
         if commit_msg_path:
-            commit_msg = core.read(commit_msg_path)
+            commit_msg = context.ops.file_read(commit_msg_path)
         model.set_commitmsg(commit_msg)
 
         # Allow tab to jump from the summary to the description

--- a/cola/widgets/commitmsg.py
+++ b/cola/widgets/commitmsg.py
@@ -78,6 +78,9 @@ class CommitMessageEditor(QtWidgets.QFrame):
 
         self.launch_editor = actions.launch_editor_at_line(context, self)
         self.launch_difftool = actions.launch_difftool(context, self)
+        if context.ops.is_remote():
+            self.launch_editor.setEnabled(False)
+            self.launch_difftool.setEnabled(False)
 
         self.move_up = actions.move_up(self)
         self.move_down = actions.move_down(self)

--- a/cola/widgets/common.py
+++ b/cola/widgets/common.py
@@ -77,7 +77,7 @@ def terminal_action(context, parent, func=None, hotkey=None):
             parent,
             cmds.LaunchTerminal,
             context,
-            lambda: utils.select_directory(func()),
+            lambda: utils.select_directory(context.ops, func()),
         )
         action.setIcon(icons.terminal())
         if hotkey is not None:

--- a/cola/widgets/common.py
+++ b/cola/widgets/common.py
@@ -82,4 +82,8 @@ def terminal_action(context, parent, func=None, hotkey=None):
         action.setIcon(icons.terminal())
         if hotkey is not None:
             action.setShortcut(hotkey)
+
+        if context.ops.is_remote():
+            action.setEnabled(False)
+
     return action

--- a/cola/widgets/diff.py
+++ b/cola/widgets/diff.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
 import os
 import re
 import time
 from functools import partial
-from typing import Optional
+from typing import TYPE_CHECKING
 
 from qtpy import QtCore
 from qtpy import QtGui
@@ -37,6 +38,9 @@ from .text import TextDecorator
 from .text import TextSearchWidget
 from .text import VimHintedPlainTextEdit
 from .text import label_selection_timer
+
+if TYPE_CHECKING:
+    from ..app import ApplicationContext
 
 ENABLE_INTRALINE_DIFF = True
 
@@ -398,7 +402,7 @@ class DiffTextEdit(VimHintedPlainTextEdit):
 
     def _build_intraline_diff_config(
         self,
-    ) -> Optional[intraline_diff.IntralineDiffConfig]:
+    ) -> intraline_diff.IntralineDiffConfig | None:
         """Build the intra-line diff config for the current preset."""
         preset_item = diff_intraline.intraline_diff_preset_item(
             self._intraline_diff_preset
@@ -439,7 +443,7 @@ class DiffTextEdit(VimHintedPlainTextEdit):
     ) -> tuple[
         intraline_diff.SpansByLineIndex,
         float,
-        Optional[intraline_diff.IntralineDiffResult],
+        intraline_diff.IntralineDiffResult | None,
     ]:
         """Try to compute intra-line spans and return output details."""
         intraline_spans = {}
@@ -790,7 +794,7 @@ class Viewer(QtWidgets.QFrame):
     def dragEnterEvent(self, event):
         """Accepts drops if the mimedata contains patches"""
         super().dragEnterEvent(event)
-        patches = get_patches_from_mimedata(event.mimeData())
+        patches = get_patches_from_mimedata(self.context, event.mimeData())
         if patches:
             event.acceptProposedAction()
             self._drag_has_patches = True
@@ -813,7 +817,7 @@ class Viewer(QtWidgets.QFrame):
         super().dropEvent(event)
         self._drag_has_patches = False
 
-        patches = get_patches_from_mimedata(event.mimeData())
+        patches = get_patches_from_mimedata(self.context, event.mimeData())
         if patches:
             apply_patches(self.context, patches=patches)
 
@@ -947,8 +951,8 @@ class Viewer(QtWidgets.QFrame):
 
     def cleanup(self):
         for image, unlink in self.images:
-            if unlink and core.exists(image):
-                os.unlink(image)
+            if unlink and self.context.ops.exists(image):
+                self.context.ops.unlink(image)
         self.images = []
 
     def set_images(self, images):
@@ -1480,7 +1484,7 @@ class DiffEditor(DiffTextEdit):
         if model.is_partially_stageable():
             item = s.modified[0] if s.modified else None
             if item in model.submodules:
-                path = core.abspath(item)
+                path = self.context.ops.abspath(item)
                 action = qtutils.add_action_with_icon(
                     menu,
                     icons.add(),
@@ -1526,7 +1530,7 @@ class DiffEditor(DiffTextEdit):
                 add_action(self.action_revert_unstaged_edits)
                 # Do not show the "edit" action when the file does not exist.
                 add_action(qtutils.menu_separator(menu))
-                if filename and core.exists(filename):
+                if filename and self.context.ops.exists(filename):
                     add_action(self.launch_editor)
                 # Removed files can still be diffed.
                 add_action(self.launch_difftool)
@@ -1543,7 +1547,7 @@ class DiffEditor(DiffTextEdit):
         if s.staged and model.is_unstageable():
             item = s.staged[0]
             if item in model.submodules:
-                path = core.abspath(item)
+                path = self.context.ops.abspath(item)
                 action = qtutils.add_action_with_icon(
                     menu,
                     icons.remove(),
@@ -1568,7 +1572,7 @@ class DiffEditor(DiffTextEdit):
             elif item not in model.staged_deleted:
                 # Do not show the "edit" action when the file does not exist.
                 add_action(qtutils.menu_separator(menu))
-                if filename and core.exists(filename):
+                if filename and self.context.ops.exists(filename):
                     add_action(self.launch_editor)
                 # Removed files can still be diffed.
                 add_action(self.launch_difftool)
@@ -1587,7 +1591,7 @@ class DiffEditor(DiffTextEdit):
             add_action(qtutils.menu_separator(menu))
             # Do not show the "edit" action when the file does not exist.
             # Untracked files exist by definition.
-            if filename and core.exists(filename):
+            if filename and self.context.ops.exists(filename):
                 add_action(self.launch_editor)
 
             # Removed files can still be diffed.
@@ -1785,13 +1789,13 @@ def _build_patch_append_menu(widget, context, menu):
     path = prefs.patches_directory(context)
     patches = get_patches_from_dir(path)
     for patch in patches:
-        relpath = os.path.relpath(patch, start=path)
+        relpath = context.ops.relpath(patch, start=path)
         sub_menu = _add_patch_subdirs(menu, subdir_menus, relpath)
         patch_basename = os.path.basename(relpath)
         append_action = qtutils.add_action(
             sub_menu,
             patch_basename,
-            lambda patch_file=patch: _append_patch(widget, patch_file),
+            lambda patch_file=patch: _append_patch(context, widget, patch_file),
         )
         append_action.setIcon(icons.save())
         sub_menu.addAction(append_action)
@@ -1833,25 +1837,27 @@ def _export_patch(diff_editor, context, append=False):
         filename = qtutils.save_as(default_filename)
     if not filename:
         return
-    _write_patch_to_file(diff_editor, patch, filename, append=append)
+    _write_patch_to_file(context, diff_editor, patch, filename, append=append)
 
 
-def _append_patch(diff_editor, filename):
+def _append_patch(context: ApplicationContext, diff_editor, filename):
     """Append diffs to the specified patch file"""
     if diff_editor.selection_model.is_empty():
         return
     patch = diff_editor.extract_patch(reverse=False)
     if not patch.has_changes():
         return
-    _write_patch_to_file(diff_editor, patch, filename, append=True)
+    _write_patch_to_file(context, diff_editor, patch, filename, append=True)
 
 
-def _write_patch_to_file(diff_editor, patch, filename, append=False):
+def _write_patch_to_file(
+    context: ApplicationContext, diff_editor, patch, filename, append=False
+):
     """Write diffs from the Diff Editor to the specified patch file"""
     encoding = diff_editor.patch_encoding()
     content = patch.as_text()
     try:
-        core.write(filename, content, encoding=encoding, append=append)
+        context.ops.write_file(filename, content, encoding=encoding, append=append)
     except OSError as exc:
         _, details = utils.format_exception(exc)
         title = N_('Error writing patch')
@@ -2239,24 +2245,26 @@ def new_apply_patches(context, patches=None, parent=None):
     return dlg
 
 
-def get_patches_from_paths(paths):
+def get_patches_from_paths(context: ApplicationContext, paths):
     """Returns all patches beneath a given path"""
     paths = [core.decode(p) for p in paths]
-    patches = [p for p in paths if core.isfile(p) and p.endswith(('.patch', '.mbox'))]
-    dirs = [p for p in paths if core.isdir(p)]
+    patches = [
+        p for p in paths if context.ops.isfile(p) and p.endswith(('.patch', '.mbox'))
+    ]
+    dirs = [p for p in paths if context.ops.isdir(p)]  # TODO Batch this to improve efficiency in RemoteOperations mode.
     dirs.sort()
     for d in dirs:
         patches.extend(get_patches_from_dir(d))
     return patches
 
 
-def get_patches_from_mimedata(mimedata):
+def get_patches_from_mimedata(context: ApplicationContext, mimedata):
     """Extract path files from a QMimeData payload"""
     urls = mimedata.urls()
     if not urls:
         return []
     paths = [x.path() for x in urls]
-    return get_patches_from_paths(paths)
+    return get_patches_from_paths(context, paths)
 
 
 def get_patches_from_dir(path):
@@ -2277,7 +2285,7 @@ class ApplyPatches(standard.Dialog):
         if parent is not None:
             self.setWindowModality(Qt.WindowModal)
 
-        self.curdir = core.getcwd()
+        self.curdir = self.context.ops.getcwd()
         self.inner_drag = False
 
         self.usage = QtWidgets.QLabel()
@@ -2378,25 +2386,25 @@ class ApplyPatches(standard.Dialog):
         if not files:
             return
         self.curdir = os.path.dirname(files[0])
-        self.add_paths([core.relpath(f) for f in files])
+        self.add_paths([self.context.ops.relpath(f) for f in files])  # TODO Batch this to improve efficiency in RemoteOperations mode.
 
     def dragEnterEvent(self, event):
         """Accepts drops if the mimedata contains patches"""
         super().dragEnterEvent(event)
-        patches = get_patches_from_mimedata(event.mimeData())
+        patches = get_patches_from_mimedata(self.context, event.mimeData())
         if patches:
             event.acceptProposedAction()
 
     def dropEvent(self, event):
         """Add dropped patches"""
         event.accept()
-        patches = get_patches_from_mimedata(event.mimeData())
+        patches = get_patches_from_mimedata(self.context, event.mimeData())
         if not patches:
             return
         self.add_paths(patches)
 
     def add_paths(self, paths):
-        self.tree.add_paths(paths)
+        self.tree.add_paths(self.context, paths)
 
     def _tree_selection_changed(self):
         items = self.tree.selected_items()
@@ -2404,7 +2412,7 @@ class ApplyPatches(standard.Dialog):
             return
         item = items[-1]  # take the last item
         path = item.data(0, Qt.UserRole)
-        if not core.exists(path):
+        if not self.context.ops.exists(path):
             return
         commit = parse_patch(path)
         self.diffwidget.set_details(
@@ -2429,8 +2437,8 @@ class ApplyPatches(standard.Dialog):
 
 
 class PatchTreeWidget(standard.DraggableTreeWidget):
-    def add_paths(self, paths):
-        patches = get_patches_from_paths(paths)
+    def add_paths(self, context: ApplicationContext, paths):
+        patches = get_patches_from_paths(context, paths)
         if not patches:
             return
         items = []

--- a/cola/widgets/editremotes.py
+++ b/cola/widgets/editremotes.py
@@ -513,6 +513,6 @@ class RemoteWidget(QtWidgets.QWidget):
     def open_repo(self):
         """Set the URL from a repository on disk"""
         git = self.context.git
-        repo = qtutils.opendir_dialog(N_('Open Git Repository'), core.getcwd())
+        repo = qtutils.opendir_dialog(N_('Open Git Repository'), core.getcwd())  # TODO make this work on remote
         if repo and git.is_git_repository(repo):
             self.url = repo

--- a/cola/widgets/filetree.py
+++ b/cola/widgets/filetree.py
@@ -1,15 +1,22 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
 from qtpy import QtCore
 from qtpy import QtWidgets
 
 from .. import icons
 from . import standard
 
+if TYPE_CHECKING:
+    from .app import ApplicationContext
+
 
 class FileTree(standard.TreeWidget):
     """A flag list of files presented using a tree widget"""
 
-    def __init__(self, parent=None):
+    def __init__(self, context: ApplicationContext, parent=None):
         standard.TreeWidget.__init__(self, parent=parent)
+        self.context = context
         self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
         self.setHeaderHidden(True)
 

--- a/cola/widgets/finder.py
+++ b/cola/widgets/finder.py
@@ -8,7 +8,6 @@ from qtpy.QtCore import Qt
 from qtpy.QtCore import Signal
 
 from .. import cmds
-from .. import core
 from .. import gitcmds
 from .. import hotkeys
 from .. import icons
@@ -132,13 +131,13 @@ class Finder(standard.Dialog):
         if ref is None:
             ref = 'HEAD'
         self.ref = ref
-        label = os.path.basename(core.getcwd()) + '/'
+        label = os.path.basename(self.context.ops.getcwd()) + '/'
         self.input_label = QtWidgets.QLabel(label)
         self.input_txt = completion.GitPathsFromRefLineEdit(
             context, ref, hint=N_('<path> ...')
         )
 
-        self.tree = filetree.FileTree(parent=self)
+        self.tree = filetree.FileTree(self.context, parent=self)
         self.browser = text.VimTextBrowser(context, parent=self)
         self.filename = None
 

--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -705,8 +705,8 @@ class MainView(standard.MainWindow):
         self.patches_menu.addAction(self.apply_patches_abort_action)
 
         # Git Annex / Git LFS
-        annex = core.find_executable('git-annex')
-        lfs = core.find_executable('git-lfs')
+        annex = self.context.ops.find_executable('git-annex')
+        lfs = self.context.ops.find_executable('git-lfs')
         if annex or lfs:
             self.file_menu.addSeparator()
         if annex:

--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -625,7 +625,9 @@ class MainView(standard.MainWindow):
         # We can do this because can_rebase == not is_rebasing
         self.rebase_start_action_proxy = utils.Proxy(
             self.rebase_start_action,
-            setEnabled=lambda x: self.rebase_start_action.setEnabled(not x),
+            setEnabled=lambda x: self.rebase_start_action.setEnabled(
+                False if context.ops.is_remote() else not x
+            ),
         )
 
         self.rebase_group = utils.Group(
@@ -681,6 +683,7 @@ class MainView(standard.MainWindow):
         self.file_menu.addAction(self.quick_repository_search)
         # File->Open Recent menu
         self.open_recent_menu = self.file_menu.addMenu(N_('Open Recent'))
+
         self.open_recent_menu.setIcon(icons.folder())
         self.file_menu.addAction(self.open_repo_action)
         self.file_menu.addAction(self.open_repo_new_action)
@@ -703,6 +706,18 @@ class MainView(standard.MainWindow):
         self.patches_menu.addAction(self.apply_patches_continue_action)
         self.patches_menu.addAction(self.apply_patches_skip_action)
         self.patches_menu.addAction(self.apply_patches_abort_action)
+
+        if context.ops.is_remote():
+            self.quick_repository_search.setEnabled(False)
+            self.open_recent_menu.setEnabled(False)
+            self.open_repo_action.setEnabled(False)
+            self.open_repo_new_action.setEnabled(False)
+            self.new_repository_action.setEnabled(False)
+            self.new_bare_repository_action.setEnabled(False)
+            self.clone_repo_action.setEnabled(False)
+            self.rebase_start_action_proxy.setEnabled(True)
+            self.save_tarball_action.setEnabled(False)
+            self.patches_menu.setEnabled(False)
 
         # Git Annex / Git LFS
         annex = self.context.ops.find_executable('git-annex')

--- a/cola/widgets/main.py
+++ b/cola/widgets/main.py
@@ -1,5 +1,4 @@
 """Main UI for authoring commits and other Git Cola interactions"""
-import os
 from functools import partial
 
 from qtpy import QtCore
@@ -1126,7 +1125,7 @@ class MainView(standard.MainWindow):
         is_cherry_picking = self.model.is_rebasing
 
         try:
-            curdir = core.getcwd()
+            curdir = self.context.ops.getcwd()
         except FileNotFoundError:
             return
         msg = N_('Repository: %s') % curdir
@@ -1232,7 +1231,7 @@ class MainView(standard.MainWindow):
     def update_menu_actions(self):
         # Enable the Prepare Commit Message action if the hook exists
         hook = gitcmds.prepare_commit_message_hook(self.context)
-        enabled = os.path.exists(hook)
+        enabled = self.context.ops.exists(hook)
         self.prepare_commitmsg_hook_action.setEnabled(enabled)
 
     def export_state(self):

--- a/cola/widgets/prefs.py
+++ b/cola/widgets/prefs.py
@@ -136,7 +136,9 @@ class RepoFormWidget(FormWidget):
             'Absolute path are used as-is.'
         )
         patches_directory = prefs.patches_directory(context)
-        self.patches_directory = standard.DirectoryPathLineEdit(patches_directory, self)
+        self.patches_directory = standard.DirectoryPathLineEdit(
+            context, patches_directory, self
+        )
         self.patches_directory.setToolTip(tooltip)
 
         tooltip = N_(

--- a/cola/widgets/remote.py
+++ b/cola/widgets/remote.py
@@ -1,6 +1,5 @@
 """Widgets for Fetch, Push, and Pull"""
 import fnmatch
-import os
 import time
 
 from qtpy import QtCore
@@ -948,7 +947,7 @@ class RemoteActionDialog(standard.Dialog):
         """Prune stale worktrees from the persistent selected_remotes_by_worktree"""
         worktrees = list(self.selected_remotes_by_worktree.keys())
         for worktree in worktrees:
-            if not os.path.exists(worktree):
+            if not self.context.ops.exists(worktree):  # TODO this is loop with guts that could be batched to minimize network request round trips.
                 self.selected_remotes_by_worktree.pop(worktree, None)
 
 

--- a/cola/widgets/search.py
+++ b/cola/widgets/search.py
@@ -317,7 +317,7 @@ class Search(SearchWidget):
         if not paths:
             return
         filepaths = []
-        curdir = core.getcwd()
+        curdir = self.context.ops.getcwd()
         prefix_len = len(curdir) + 1
         for path in paths:
             if not path.startswith(curdir):

--- a/cola/widgets/standard.py
+++ b/cola/widgets/standard.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
 import os
 import time
 from functools import partial
+from typing import TYPE_CHECKING
 
 from qtpy import QtCore
 from qtpy import QtGui
@@ -21,6 +23,9 @@ from ..models import prefs
 from ..settings import Settings
 from ..settings import mklist
 from . import defs
+
+if TYPE_CHECKING:
+    from ..app import ApplicationContext
 
 # Magic header emitted by QWidget::saveGeometry() (Qt 5/6).
 _QWIDGET_GEOMETRY_MAGIC = b'\x01\xd9\xd0\xcb'
@@ -257,7 +262,7 @@ class MainWindowMixin(WidgetMixin):
                 settings = context.settings
                 settings.load()
             try:
-                cwd = core.getcwd()
+                cwd = self.context.ops.getcwd()
             except FileNotFoundError:
                 pass
             else:
@@ -918,9 +923,10 @@ class SpinBox(QtWidgets.QSpinBox):
 class DirectoryPathLineEdit(QtWidgets.QWidget):
     """A combined line edit and file browser button"""
 
-    def __init__(self, path, parent):
+    def __init__(self, context: ApplicationContext, path, parent):
         QtWidgets.QWidget.__init__(self, parent)
 
+        self.context = context
         self.line_edit = QtWidgets.QLineEdit()
         self.line_edit.setText(path)
 
@@ -952,11 +958,11 @@ class DirectoryPathLineEdit(QtWidgets.QWidget):
             return
         # Make the directory relative only if it the current directory or
         # or subdirectory from the current directory.
-        current_dir = core.getcwd()
+        current_dir = self.context.ops.getcwd()
         if output_dir == current_dir:
             output_dir = '.'
         elif output_dir.startswith(current_dir + os.sep):
-            output_dir = os.path.relpath(output_dir)
+            output_dir = self.context.ops.relpath(output_dir)
         self.set_value(output_dir)
 
 

--- a/cola/widgets/startup.py
+++ b/cola/widgets/startup.py
@@ -6,7 +6,6 @@ from qtpy import QtWidgets
 from qtpy.QtCore import Qt
 
 from .. import cmds
-from .. import core
 from .. import display
 from .. import guicmds
 from .. import hotkeys
@@ -217,7 +216,7 @@ class StartupDialog(standard.Dialog):
         self.repodir = self.get_selected_bookmark()
         if not self.repodir:
             self.repodir = qtutils.opendir_dialog(
-                N_('Open Git Repository'), core.getcwd()
+                N_('Open Git Repository'), self.context.ops.getcwd()
             )
         if self.repodir:
             self.accept()
@@ -253,7 +252,7 @@ class StartupDialog(standard.Dialog):
             self.repodir = self.bookmarks_model.data(index, Qt.UserRole)
             if not self.repodir:
                 return
-            if not core.exists(self.repodir):
+            if not self.context.ops.exists(self.repodir):
                 self.handle_broken_repo(index)
                 return
             self.accept()

--- a/cola/widgets/status.py
+++ b/cola/widgets/status.py
@@ -958,11 +958,13 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
                 menu.addAction(self.move_to_trash_action)
             menu.addAction(self.delete_untracked_files_action)
             menu.addSeparator()
-            menu.addAction(
+            action = menu.addAction(
                 icons.edit(),
                 N_('Ignore...'),
                 partial(gitignore.gitignore_view, self.context),
             )
+            if self.context.ops.is_remote():
+                action.setEnabled(False)
 
         if not self.selection_model.is_empty():
             menu.addAction(self.view_history_action)

--- a/cola/widgets/status.py
+++ b/cola/widgets/status.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
 import itertools
 import os
 from functools import partial
+from typing import TYPE_CHECKING
 
 from qtpy import QtCore
 from qtpy import QtWidgets
@@ -27,6 +29,10 @@ from . import completion
 from . import defs
 from . import diff
 from . import text
+
+if TYPE_CHECKING:
+    from ..app import ApplicationContext
+
 
 # Top-level status widget item indexes.
 HEADER_IDX = -1
@@ -652,7 +658,7 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
 
     def _set_unmerged(self, items):
         """Adds items to the 'Unmerged' sub-tree."""
-        deleted_set = {path for path in items if not core.exists(path)}
+        deleted_set = {path for path in items if not self.context.ops.exists(path)}
         with qtutils.BlockSignals(self):
             self._set_subtree(
                 items, UNMERGED_IDX, N_('Unmerged'), deleted_set=deleted_set
@@ -679,7 +685,10 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
         for item in items:
             deleted = deleted_set is not None and item in deleted_set
             treeitem = qtutils.create_treeitem(
-                item, staged=staged, deleted=deleted, untracked=untracked
+                item,
+                staged=staged,
+                deleted=deleted,
+                untracked=untracked,
             )
             parent.addChild(treeitem)
         self._expand_items(idx, items)
@@ -846,7 +855,7 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
 
         # Do all of the selected items exist?
         all_exist = all(
-            i not in self._model.staged_deleted and core.exists(i)
+            i not in self._model.staged_deleted and self.context.ops.exists(i)
             for i in self.staged()
         )
 
@@ -862,7 +871,7 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
 
     def _create_staged_submodule_context_menu(self, menu, s):
         context = self.context
-        path = core.abspath(s.staged[0])
+        path = self.context.ops.abspath(s.staged[0])
         if len(self.staged()) == 1:
             menu.addAction(
                 icons.cola(),
@@ -923,7 +932,7 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
 
         # Do all of the selected items exist?
         all_exist = all(
-            i not in self._model.unstaged_deleted and core.exists(i)
+            i not in self._model.unstaged_deleted and self.context.ops.exists(i)
             for i in self.staged()
         )
 
@@ -963,7 +972,7 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
 
     def _create_modified_submodule_context_menu(self, menu, s):
         context = self.context
-        path = core.abspath(s.modified[0])
+        path = self.context.ops.abspath(s.modified[0])
         if len(self.unstaged()) == 1:
             menu.addAction(
                 icons.cola(),
@@ -1276,7 +1285,7 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
     def mimeData(self, items):
         """Return a list of absolute-path URLs"""
         context = self.context
-        paths = qtutils.paths_from_items(items, item_filter=_item_filter)
+        paths = qtutils.paths_from_items(context, items, item_filter=_item_filter)
         include_urls = not self._alt_drag
         return qtutils.mimedata_from_paths(context, paths, include_urls=include_urls)
 
@@ -1285,9 +1294,9 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
         return qtutils.path_mimetypes(include_urls=not self._alt_drag)
 
 
-def _item_filter(item):
+def _item_filter(context: ApplicationContext, item):
     """Filter items down to just those that exist on disk"""
-    return not item.deleted and core.exists(item.path)
+    return not item.deleted and context.ops.exists(item.path)
 
 
 def view_blame(context):
@@ -1306,7 +1315,7 @@ def copy_path(context, absolute=True):
     if not filenames:
         return
     if absolute:
-        filenames = [core.abspath(f) for f in filenames]
+        filenames = [context.ops.abspath(f) for f in filenames]
     qtutils.set_clipboard('\n'.join(filenames))
 
 
@@ -1352,7 +1361,7 @@ def copy_format(context, fmt):
     for path in filenames:
         values = {}
         values['path'] = path
-        values['abspath'] = abspath = os.path.abspath(path)
+        values['abspath'] = abspath = context.ops.abspath(path)
         values['absdirname'] = os.path.dirname(abspath)
         values['dirname'] = os.path.dirname(path)
         values['filename'] = os.path.basename(path)

--- a/cola/widgets/status.py
+++ b/cola/widgets/status.py
@@ -10,7 +10,6 @@ from qtpy.QtCore import Qt
 
 from .. import actions
 from .. import cmds
-from .. import core
 from .. import difftool
 from .. import fields
 from .. import hotkeys
@@ -946,7 +945,7 @@ class StatusTreeWidget(QtWidgets.QTreeWidget):
         if all_exist and s.untracked:
             # Git Annex / Git LFS
             annex = self._model.annex
-            lfs = core.find_executable('git-lfs')
+            lfs = self.context.ops.find_executable('git-lfs')
             if annex or lfs:
                 menu.addSeparator()
             if annex:

--- a/cola/widgets/submodules.py
+++ b/cola/widgets/submodules.py
@@ -6,7 +6,6 @@ from qtpy.QtCore import Signal
 
 from .. import cmds
 from .. import compat
-from .. import core
 from .. import icons
 from .. import qtutils
 from ..i18n import N_
@@ -196,7 +195,7 @@ class SubmodulesTreeWidget(standard.TreeWidget):
         return super().showEvent(event)
 
     def tree_double_clicked(self, item, _column):
-        path = core.abspath(item.path)
+        path = self.context.ops.abspath(item.path)
         cmds.do(cmds.OpenRepo, self.context, path)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ description = "Git Cola is a powerful Git GUI with a slick and intuitive user in
 dependencies = [
     "polib >= 1.0.0",
     "qtpy >= 1.1.0",
+
 ]
 dynamic = ["version"]
 readme = {file = "README.md", content-type = "text/markdown"}
@@ -45,6 +46,9 @@ extras = [
     "pyobjc; sys_platform == 'darwin'",
     # Enables the "Send to Trash" feature.
     "send2trash",
+    # Enables server/client functionality.
+    "websockets == 15.0.1",
+    "msgpack >= 1.1.2",
 ]
 # Developer tools.
 dev = [

--- a/test/compat_test.py
+++ b/test/compat_test.py
@@ -2,16 +2,18 @@
 import os
 
 from cola import compat
+from cola import operations
 
 
 def test_setenv():
     """Test the core.decode function"""
     key = 'COLA_UNICODE_TEST'
     value = '字龍'
-    compat.setenv(key, value)
+    ops = operations.LocalOperations()
+    compat.setenv(ops, key, value)
     assert key in os.environ
     assert os.getenv(key)
 
-    compat.unsetenv(key)
+    compat.unsetenv(ops, key)
     assert key not in os.environ
     assert not os.getenv(key)

--- a/test/git_test.py
+++ b/test/git_test.py
@@ -1,9 +1,11 @@
 """Test the cola.git module"""
 import os
 import pathlib
+from unittest.mock import call
 from unittest.mock import patch
 
 from cola import git
+from cola import operations
 from cola.git import STDOUT
 
 # 16k+1 bytes to exhaust any output buffers.
@@ -12,7 +14,7 @@ BUFFER_SIZE = (16 * 1024) + 1
 
 @patch('cola.git.is_git_dir')
 def test_find_git_dir_None(is_git_dir):
-    paths = git.find_git_directory(None)
+    paths = git.find_git_directory(operations.LocalOperations(), None)
 
     assert not is_git_dir.called
     assert paths.git_dir is None
@@ -22,7 +24,7 @@ def test_find_git_dir_None(is_git_dir):
 
 @patch('cola.git.is_git_dir')
 def test_find_git_dir_empty_string(is_git_dir):
-    paths = git.find_git_directory('')
+    paths = git.find_git_directory(operations.LocalOperations(), '')
 
     assert not is_git_dir.called
     assert paths.git_dir is None
@@ -33,8 +35,8 @@ def test_find_git_dir_empty_string(is_git_dir):
 @patch('cola.git.is_git_dir')
 def test_find_git_dir_never_found(is_git_dir):
     is_git_dir.return_value = False
-
-    paths = git.find_git_directory(str(pathlib.Path('/does/not/exist').resolve()))
+    ops = operations.LocalOperations()
+    paths = git.find_git_directory(ops, str(pathlib.Path('/does/not/exist').resolve()))
 
     assert is_git_dir.called
     assert paths.git_dir is None
@@ -45,14 +47,14 @@ def test_find_git_dir_never_found(is_git_dir):
     actual = is_git_dir.call_count
     assert expect == actual
     is_git_dir.assert_has_calls([
-        ((str(pathlib.Path('/does/not/exist').resolve()),), {}),
-        ((str(pathlib.Path('/does/not/exist/.git').resolve()),), {}),
-        ((str(pathlib.Path('/does/not').resolve()),), {}),
-        ((str(pathlib.Path('/does/not/.git').resolve()),), {}),
-        ((str(pathlib.Path('/does').resolve()),), {}),
-        ((str(pathlib.Path('/does/.git').resolve()),), {}),
-        ((str(pathlib.Path('/').resolve()),), {}),
-        ((str(pathlib.Path('/.git').resolve()),), {}),
+        call(ops, str(pathlib.Path('/does/not/exist').resolve())),
+        call(ops, str(pathlib.Path('/does/not/exist/.git').resolve())),
+        call(ops, str(pathlib.Path('/does/not').resolve())),
+        call(ops, str(pathlib.Path('/does/not/.git').resolve())),
+        call(ops, str(pathlib.Path('/does').resolve())),
+        call(ops, str(pathlib.Path('/does/.git').resolve())),
+        call(ops, str(pathlib.Path('/').resolve())),
+        call(ops, str(pathlib.Path('/.git').resolve())),
     ])
 
 
@@ -62,7 +64,7 @@ def test_find_git_dir_found_right_away(is_git_dir):
     worktree = str(pathlib.Path('/seems/to/exist').resolve())
     is_git_dir.return_value = True
 
-    paths = git.find_git_directory(git_dir)
+    paths = git.find_git_directory(operations.LocalOperations(), git_dir)
 
     assert is_git_dir.called
     assert git_dir == paths.git_dir
@@ -74,9 +76,9 @@ def test_find_git_dir_found_right_away(is_git_dir):
 def test_find_git_does_discovery(is_git_dir):
     git_dir = str(pathlib.Path('/the/root/.git').resolve())
     worktree = str(pathlib.Path('/the/root').resolve())
-    is_git_dir.side_effect = lambda x: x == git_dir
+    is_git_dir.side_effect = lambda ops, path: path == git_dir
 
-    paths = git.find_git_directory('/the/root/sub/dir')
+    paths = git.find_git_directory(operations.LocalOperations(), '/the/root/sub/dir')
 
     assert git_dir == paths.git_dir
     assert paths.git_file is None
@@ -91,11 +93,14 @@ def test_find_git_honors_git_files(is_git_dir, is_git_file, read_git_file):
     worktree = str(pathlib.Path('/the/root').resolve())
     git_dir = str(pathlib.Path('/super/module/.git/modules/root').resolve())
 
-    is_git_dir.side_effect = lambda x: x == git_file
-    is_git_file.side_effect = lambda x: x == git_file
+    is_git_dir.side_effect = lambda ops, path: path == git_file
+    is_git_file.side_effect = lambda ops, path: path == git_file
     read_git_file.return_value = git_dir
 
-    paths = git.find_git_directory(str(pathlib.Path('/the/root/sub/dir').resolve()))
+    ops = operations.LocalOperations()
+    paths = git.find_git_directory(
+        ops, str(pathlib.Path('/the/root/sub/dir').resolve())
+    )
 
     assert git_dir == paths.git_dir
     assert git_file == paths.git_file
@@ -105,14 +110,14 @@ def test_find_git_honors_git_files(is_git_dir, is_git_file, read_git_file):
     actual = is_git_dir.call_count
     assert expect == actual
     is_git_dir.assert_has_calls([
-        ((str(pathlib.Path('/the/root/sub/dir').resolve()),), {}),
-        ((str(pathlib.Path('/the/root/sub/dir/.git').resolve()),), {}),
-        ((str(pathlib.Path('/the/root/sub').resolve()),), {}),
-        ((str(pathlib.Path('/the/root/sub/.git').resolve()),), {}),
-        ((str(pathlib.Path('/the/root').resolve()),), {}),
-        ((str(pathlib.Path('/the/root/.git').resolve()),), {}),
+        call(ops, str(pathlib.Path('/the/root/sub/dir').resolve())),
+        call(ops, str(pathlib.Path('/the/root/sub/dir/.git').resolve())),
+        call(ops, str(pathlib.Path('/the/root/sub').resolve())),
+        call(ops, str(pathlib.Path('/the/root/sub/.git').resolve())),
+        call(ops, str(pathlib.Path('/the/root').resolve())),
+        call(ops, str(pathlib.Path('/the/root/.git').resolve())),
     ])
-    read_git_file.assert_called_once_with(git_file)
+    read_git_file.assert_called_once_with(ops, git_file)
 
 
 @patch('cola.core.getenv')
@@ -123,25 +128,26 @@ def test_find_git_honors_ceiling_dirs(is_git_dir, getenv):
         str(pathlib.Path(path).resolve())
         for path in ('/tmp', '/ceiling', '/other/ceiling')
     )
-    is_git_dir.side_effect = lambda x: x == git_dir
+    is_git_dir.side_effect = lambda path, *args: path == git_dir
 
     def mock_getenv(k, v=None):
         if k == 'GIT_CEILING_DIRECTORIES':
             return ceiling
         return v
 
+    ops = operations.LocalOperations()
     getenv.side_effect = mock_getenv
-    paths = git.find_git_directory(str(pathlib.Path('/ceiling/sub/dir').resolve()))
+    paths = git.find_git_directory(ops, str(pathlib.Path('/ceiling/sub/dir').resolve()))
 
     assert paths.git_dir is None
     assert paths.git_file is None
     assert paths.worktree is None
     assert is_git_dir.call_count == 4
     is_git_dir.assert_has_calls([
-        ((str(pathlib.Path('/ceiling/sub/dir').resolve()),), {}),
-        ((str(pathlib.Path('/ceiling/sub/dir/.git').resolve()),), {}),
-        ((str(pathlib.Path('/ceiling/sub').resolve()),), {}),
-        ((str(pathlib.Path('/ceiling/sub/.git').resolve()),), {}),
+        call(ops, str(pathlib.Path('/ceiling/sub/dir').resolve())),
+        call(ops, str(pathlib.Path('/ceiling/sub/dir/.git').resolve())),
+        call(ops, str(pathlib.Path('/ceiling/sub').resolve())),
+        call(ops, str(pathlib.Path('/ceiling/sub/.git').resolve())),
     ])
 
 
@@ -173,9 +179,13 @@ def test_is_git_dir_finds_linked_repository(isfile, isdir, islink):
     islink.return_value = False
     isfile.side_effect = lambda x: x in files
     isdir.side_effect = lambda x: x in dirs
+    ops = operations.LocalOperations()
 
-    assert git.is_git_dir(str(pathlib.Path('/foo/.git/worktrees/foo').resolve()))
-    assert git.is_git_dir(str(pathlib.Path('/foo/.git').resolve()))
+    assert git.is_git_dir(
+        ops,
+        str(pathlib.Path('/foo/.git/worktrees/foo').resolve()),
+    )
+    assert git.is_git_dir(ops, str(pathlib.Path('/foo/.git').resolve()))
 
 
 @patch('cola.core.getenv')
@@ -186,7 +196,7 @@ def test_find_git_worktree_from_GIT_DIR(is_git_dir, getenv):
     is_git_dir.return_value = True
     getenv.side_effect = lambda x: x == 'GIT_DIR' and git_dir or None
 
-    paths = git.find_git_directory(git_dir)
+    paths = git.find_git_directory(operations.LocalOperations(), git_dir)
     assert is_git_dir.called
     assert git_dir == paths.git_dir
     assert paths.git_file is None
@@ -199,7 +209,7 @@ def test_finds_no_worktree_from_bare_repo(is_git_dir):
     worktree = None
     is_git_dir.return_value = True
 
-    paths = git.find_git_directory(git_dir)
+    paths = git.find_git_directory(operations.LocalOperations(), git_dir)
     assert is_git_dir.called
     assert git_dir == paths.git_dir
     assert paths.git_file is None
@@ -212,7 +222,7 @@ def test_find_git_directory_uses_GIT_WORK_TREE(is_git_dir, getenv):
     git_dir = str(pathlib.Path('/repo/worktree/.git').resolve())
     worktree = str(pathlib.Path('/repo/worktree').resolve())
 
-    def is_git_dir_func(path):
+    def is_git_dir_func(ops: operations.IOperations, path):
         return path == git_dir
 
     is_git_dir.side_effect = is_git_dir_func
@@ -224,7 +234,7 @@ def test_find_git_directory_uses_GIT_WORK_TREE(is_git_dir, getenv):
 
     getenv.side_effect = getenv_func
 
-    paths = git.find_git_directory(worktree)
+    paths = git.find_git_directory(operations.LocalOperations(), worktree)
     assert is_git_dir.called
     assert git_dir == paths.git_dir
     assert paths.git_file is None
@@ -244,12 +254,12 @@ def test_uses_cwd_for_worktree_with_GIT_DIR(is_git_dir, getenv):
 
     getenv.side_effect = getenv_func
 
-    def is_git_dir_func(path):
+    def is_git_dir_func(ops: operations.IOperations, path):
         return path == git_dir
 
     is_git_dir.side_effect = is_git_dir_func
 
-    paths = git.find_git_directory(worktree)
+    paths = git.find_git_directory(operations.LocalOperations(), worktree)
     assert is_git_dir.called
     assert getenv.called
     assert git_dir == paths.git_dir
@@ -329,7 +339,7 @@ def test_transform_double_single_dash_string():
 
 def test_version():
     """Test running 'git version'"""
-    gitcmd = git.Git()
+    gitcmd = git.Git(operations.LocalOperations())
     version = gitcmd.version()[STDOUT]
     assert version.startswith('git version')
 
@@ -433,7 +443,7 @@ def test_git_path_in_linked_worktree(tmp_path):
     # A message in the main repository's git dir must not be picked up.
     (repo / '.git' / 'GIT_COLA_MSG').write_text('main message\n')
 
-    gitcmd = git.Git()
+    gitcmd = git.Git(operations.LocalOperations())
     gitcmd.set_worktree(str(worktree))
     expect = str(worktree_git_dir := repo / '.git' / 'worktrees' / 'wt')
     assert gitcmd.paths.git_dir == expect

--- a/test/helper.py
+++ b/test/helper.py
@@ -11,6 +11,7 @@ from cola import core
 from cola import git
 from cola import gitcfg
 from cola import gitcmds
+from cola import operations
 from cola.models import main
 
 # prevent unused imports lint errors.
@@ -90,7 +91,8 @@ def app_context():
 
     initialize_repo()
     context = Mock()
-    context.git = git.create()
+    context.ops = operations.LocalOperations()
+    context.git = git.create(context.ops)
     context.git.set_worktree(core.getcwd())
     context.cfg = gitcfg.create(context)
     context.model = main.create(context)

--- a/test/main_model_test.py
+++ b/test/main_model_test.py
@@ -5,6 +5,7 @@ import pytest
 
 from cola import core
 from cola import git
+from cola import operations
 from cola.models import main
 from cola.models.main import FETCH
 from cola.models.main import FETCH_HEAD
@@ -26,7 +27,7 @@ REMOTE_BRANCH = 'remote'
 def mock_context():
     """Return a Mock context for testing"""
     context = Mock()
-    context.git = git.create()
+    context.git = git.create(operations.LocalOperations())
     return context
 
 

--- a/test/server_test.py
+++ b/test/server_test.py
@@ -1,0 +1,317 @@
+import multiprocessing
+import os
+import time
+
+from cola import operations
+from cola import server
+
+
+class create_test_server:
+    def __init__(self):
+        app = server.SocketServer()
+
+        self.server_thread = multiprocessing.Process(target=app.run, daemon=True)
+        self.server_thread.start()
+        time.sleep(0.4)
+
+    def __enter__(self):
+        port = int(os.environ.get('GIT-COLA_SERVER_PORT', 49178))
+        self.socket = server.SocketClient(ip='127.0.0.1', port=port)
+        self.ops_remote = operations.RemoteOperations(self.socket)
+        self.ops_local = operations.LocalOperations()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.server_thread.terminate()
+
+
+def test_server_getcwd():
+    with create_test_server() as s:
+        assert s.ops_local.getcwd() == s.ops_remote.getcwd()
+
+
+def test_server_isdir():
+    with create_test_server() as s:
+        assert s.ops_local.isdir('./testdir') == s.ops_remote.isdir('./testdir')
+
+
+def test_server_realpath():
+    with create_test_server() as s:
+        assert s.ops_local.realpath('./testdir') == s.ops_remote.realpath('./testdir')
+
+
+def test_server_exists():
+    with create_test_server() as s:
+        assert s.ops_local.exists('./testdir') == s.ops_remote.exists('./testdir')
+
+
+def test_server_abspath():
+    with create_test_server() as s:
+        assert s.ops_local.abspath('./testdir') == s.ops_remote.abspath('./testdir')
+
+
+def test_server_unlink():
+    with create_test_server() as s:
+        with open('./testfile_local', 'w') as f:
+            f.write('test.file')
+        with open('./testfile_remote', 'w') as f:
+            f.write('test.file')
+
+        assert s.ops_local.unlink('./testfile_local') == s.ops_remote.unlink(
+            './testfile_remote'
+        )
+
+
+def test_server_remove():
+    with create_test_server() as s:
+        for i in range(2):
+            with open('test.file', 'w') as f:
+                f.close()
+            if i == 0:
+                rez_local = s.ops_local.remove('./test.file')
+            else:
+                rez_remote = s.ops_remote.remove('./test.file')
+
+        assert rez_local == rez_remote
+
+
+def test_server_relpath():
+    with create_test_server() as s:
+        assert s.ops_local.relpath('./testdir') == s.ops_remote.relpath('./testdir')
+
+
+def test_server_isfile():
+    with create_test_server() as s:
+        assert s.ops_local.isfile('./testdir') == s.ops_remote.isfile('./testdir')
+
+
+def test_server_islink():
+    with create_test_server() as s:
+        assert s.ops_local.islink('./testdir') == s.ops_remote.islink('./testdir')
+
+
+def test_server_listdir():
+    with create_test_server() as s:
+        assert s.ops_local.listdir('./') == s.ops_remote.listdir('./')
+
+
+def test_server_makedirs():
+    with create_test_server() as s:
+        rez_local = s.ops_local.makedirs('./test_dir')
+        if os.path.exists('./test_dir'):
+            os.rmdir('./test_dir')
+
+        rez_remote = s.ops_remote.makedirs('./test_dir')
+        if os.path.exists('./test_dir'):
+            os.rmdir('./test_dir')
+
+        assert rez_local == rez_remote
+
+
+def test_server_chdir():
+    with create_test_server() as s:
+        assert s.ops_local.chdir('./') == s.ops_remote.chdir('./')
+
+
+def test_server_expanduser():
+    with create_test_server() as s:
+        assert s.ops_local.expanduser('./') == s.ops_remote.expanduser('./')
+
+
+def test_server_find_executable():
+    with create_test_server() as s:
+        assert s.ops_local.find_executable('git', '/') == s.ops_remote.find_executable(
+            'git', '/'
+        )
+
+
+def test_server_write_file():
+    with create_test_server() as s:
+        rez_local = s.ops_local.write_file('./test.file', 'weee')
+        if os.path.exists('./test.file'):
+            os.remove('./test.file')
+
+        rez_remote = s.ops_remote.write_file('./test.file', 'weee')
+        if os.path.exists('./test.file'):
+            os.remove('./test.file')
+
+        assert rez_local == rez_remote
+
+
+def test_server_guess_mimetype():
+    with create_test_server() as s:
+        assert s.ops_local.guess_mimetype('test.file') == s.ops_remote.guess_mimetype(
+            'test.file'
+        )
+
+
+def test_server_rename():
+    with create_test_server() as s:
+        with open('test.file', 'w') as f:
+            f.close()
+        rez_local = s.ops_local.rename('test.file', 'test2')
+        if os.path.exists('test2'):
+            os.remove('test2')
+
+        with open('test.file', 'w') as f:
+            f.close()
+        rez_remote = s.ops_remote.rename('test.file', 'test2')
+        if os.path.exists('test2'):
+            os.remove('test2')
+
+        assert rez_local == rez_remote
+
+
+def test_server_fsync():
+    with create_test_server() as s:
+        assert s.ops_local.fsync(1) == s.ops_remote.fsync(1)
+
+
+def test_server_node():
+    with create_test_server() as s:
+        assert s.ops_local.node() == s.ops_remote.node()
+
+
+def test_server_print_stderr():
+    with create_test_server() as s:
+        assert s.ops_local.print_stderr('test.file') == s.ops_remote.print_stderr(
+            'test.file'
+        )
+
+
+def test_server_print_stdout():
+    with create_test_server() as s:
+        assert s.ops_local.print_stdout('test.file') == s.ops_remote.print_stdout(
+            'test.file'
+        )
+
+
+def test_server_file_write():
+    with create_test_server() as s:
+        with open('test.file', 'w') as f:
+            f.close()
+        assert s.ops_local.file_write(
+            'test.file', 'Hello, 世界! 👋 Привет, мир! 🌍 Café ☕ ∑∞'
+        ) == s.ops_remote.file_write(
+            'test.file', 'Hello, 世界! 👋 Привет, мир! 🌍 Café ☕ ∑∞'
+        )
+        if os.path.exists('test.file'):
+            os.remove('test.file')
+
+
+def test_server_file_read():
+    with create_test_server() as s:
+        with open('test.file', 'w') as f:
+            f.close()
+        assert s.ops_local.file_read('test.file') == s.ops_remote.file_read('test.file')
+        if os.path.exists('test.file'):
+            os.remove('test.file')
+
+
+def test_server_file_append():
+    with create_test_server() as s:
+        with open('test.file', 'w') as f:
+            f.close()
+        assert s.ops_local.file_append(
+            'test.file', 'Hello, 世界! 👋 Привет, мир! 🌍 Café ☕ ∑∞'
+        ) == s.ops_remote.file_append(
+            'test.file', 'Hello, 世界! 👋 Привет, мир! 🌍 Café ☕ ∑∞'
+        )
+        if os.path.exists('test.file'):
+            os.remove('test.file')
+
+
+def test_server_list2cmdline():
+    with create_test_server() as s:
+        assert s.ops_local.list2cmdline('test.file') == s.ops_remote.list2cmdline(
+            'test.file'
+        )
+
+
+def test_server_xopen():
+    with open('test.file', 'w') as f:
+        f.write('Hello, 世界! 👋 Привет, мир! 🌍 Café ☕ ∑∞\n')
+        f.write('2\n')
+        f.write('3')
+
+    with create_test_server() as s:
+        results_local = []
+        with s.ops_local.xopen('test.file') as f:
+            for line in f:
+                results_local.append(line)
+
+        results_remote = []
+        with s.ops_remote.xopen('test.file') as f:
+            for line in f:
+                results_remote.append(line)
+
+        assert results_local == results_remote
+
+    os.remove('test.file')
+
+
+def test_server_run_command():
+    with create_test_server() as s:
+        assert s.ops_local.run_command(
+            ['echo', 'Hello, 世界! 👋 Привет, мир! 🌍 Café ☕ ∑∞']
+        ) == s.ops_remote.run_command(['echo', 'Hello, 世界! 👋 Привет, мир! 🌍 Café ☕ ∑∞'])
+
+
+def test_server_get_environ():
+    with create_test_server() as s:
+        s.ops_local.environ_setvalue('key_test', 'test_value_世界_🌍_Café_Привет')
+        s.ops_remote.environ_setvalue('key_test', 'test_value_世界_🌍_Café_Привет')
+
+        assert (
+            s.ops_local.get_environ()['key_test']
+            == s.ops_remote.get_environ()['key_test']
+        )
+
+
+def test_server_environ_setdefault():
+    with create_test_server() as s:
+        assert s.ops_local.environ_setdefault(
+            'key_test', 'test_value_世界_🌍_Café_Привет'
+        ) == s.ops_remote.environ_setdefault('key_test', 'test_value_世界_🌍_Café_Привет')
+
+
+def test_server_environ_setvalue():
+    with create_test_server() as s:
+        s.ops_local.environ_setvalue('key_test', 'test_value_世界_🌍_Café_Привет')
+        s.ops_remote.environ_setvalue('key_test', 'test_value_世界_🌍_Café_Привет')
+
+        assert (
+            s.ops_local.get_environ()['key_test']
+            == s.ops_remote.get_environ()['key_test']
+        )
+
+
+def test_server_environ_pop():
+    with create_test_server() as s:
+        s.ops_local.environ_setvalue('key_test', 'test_value_世界_🌍_Café_Привет')
+        s.ops_remote.environ_setvalue('key_test', 'test_value_世界_🌍_Café_Привет')
+
+        assert s.ops_local.environ_pop('key_test', 'none') == s.ops_remote.environ_pop(
+            'key_test', 'none'
+        )
+
+
+def test_server_putenv():
+    with create_test_server() as s:
+        s.ops_local.putenv('key_test', 'test_value_世界_🌍_Café_Привет')
+        s.ops_remote.putenv('key_test', 'test_value_世界_🌍_Café_Привет')
+
+        assert s.ops_local.getenv('key_test') == s.ops_remote.getenv('key_test')
+
+
+def test_server_unsetenv():
+    with create_test_server() as s:
+        s.ops_local.putenv('key_test', 'test_value_世界_🌍_Café_Привет')
+        s.ops_remote.putenv('key_test', 'test_value_世界_🌍_Café_Привет')
+
+        s.ops_local.unsetenv('key_test')
+        s.ops_remote.unsetenv('key_test')
+
+        assert (s.ops_local.getenv('key_test') is None) == (
+            s.ops_remote.getenv('key_test') is None
+        )

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -2,6 +2,7 @@
 import os
 
 from cola import core
+from cola import operations
 from cola import utils
 
 
@@ -94,7 +95,7 @@ def test_select_directory():
     filename = utils.tmp_filename('test')
     try:
         expect = os.path.dirname(filename)
-        actual = utils.select_directory([filename])
+        actual = utils.select_directory(operations.LocalOperations(), [filename])
         assert expect == actual
     finally:
         os.remove(filename)
@@ -104,7 +105,7 @@ def test_select_directory_prefers_directories():
     filename = utils.tmp_filename('test')
     try:
         expect = '.'
-        actual = utils.select_directory([filename, '.'])
+        actual = utils.select_directory(operations.LocalOperations(), [filename, '.'])
         assert expect == actual
     finally:
         os.remove(filename)

--- a/test/widgets_status_copy_test.py
+++ b/test/widgets_status_copy_test.py
@@ -7,6 +7,7 @@ strings on the clipboard, not just the first file.
 """
 from unittest.mock import patch
 
+from cola import operations
 from cola.widgets import status
 
 
@@ -35,6 +36,7 @@ class _FakeSelection:
 class _FakeContext:
     def __init__(self, selection):
         self.selection = selection
+        self.ops = operations.LocalOperations()
 
 
 def _ctx(**kwargs):


### PR DESCRIPTION
This PR adds basic client/server support to `git-cola` using WebSockets. [Feature request](https://github.com/git-cola/git-cola/issues/1540)

## Usage

Start the server:

```bash
python -m cola.server
```

Connect a client to a remote repository:

```bash
python -m cola connect <ip:port> </path/to/repo>
```

## Current Limitations
- `fsmonitor.py` is not yet implemented for remote mode. As a result, any features or UI actions that depend on the `fsmonitor.py` are currently disabled when connected to a remote server.