### PR TITLE
stage: add undo support for Stage and Unstage commands

### DIFF
--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -2900,6 +2900,8 @@ def should_stage_conflicts(path) -> bool:
 class Stage(ContextCommand):
     """Stage a set of paths."""
 
+    UNDOABLE = True
+
     @staticmethod
     def name() -> str:
         return N_('Stage')
@@ -2907,11 +2909,36 @@ class Stage(ContextCommand):
     def __init__(self, context: ApplicationContext, paths: list[str]) -> None:
         super().__init__(context)
         self.paths = paths
+        self._old_diff = ''
 
     def do(self) -> tuple[int, str, str]:
+        if not super().do():
+            return (0, '', '')
+        if self.paths:
+            status, out, _ = self.git.diff(
+                '--', *self.paths, cached=True, _readonly=True
+            )
+            if status == 0:
+                self._old_diff = out
         msg = N_('Staging: %s') % (', '.join(self.paths))
         Interaction.log(msg)
         return self.stage_paths()
+
+    def undo(self) -> None:
+        super().undo()
+        if not self.paths:
+            return
+        self.git.reset('--', *self.paths)
+        if self._old_diff:
+            tmp_file = utils.tmp_filename('undo-stage')
+            core.write(tmp_file, self._old_diff)
+            try:
+                status, out, err = gitcmds.apply_diff(self.context, tmp_file)
+            finally:
+                core.unlink(tmp_file)
+            if status != 0:
+                Interaction.log_status(status, out, err)
+        self.model.update_files(emit=True)
 
     def stage_paths(self) -> tuple[int, str, str]:
         """Stages add/removals to git."""
@@ -3174,6 +3201,8 @@ class Tag(ContextCommand):
 class Unstage(ContextCommand):
     """Unstage a set of paths."""
 
+    UNDOABLE = True
+
     @staticmethod
     def name() -> str:
         return N_('Unstage')
@@ -3181,12 +3210,20 @@ class Unstage(ContextCommand):
     def __init__(self, context: ApplicationContext, paths: list[str]) -> None:
         super().__init__(context)
         self.paths = paths
+        self._old_diff = ''
 
     def do(self) -> tuple[int, str, str]:
         """Unstage paths"""
+        if not super().do():
+            return (0, '', '')
         context = self.context
         head = self.model.head
         paths = self.paths
+
+        if paths:
+            status, out, _ = self.git.diff('--', *paths, cached=True, _readonly=True)
+            if status == 0:
+                self._old_diff = out
 
         msg = N_('Unstaging: %s') % (', '.join(paths))
         Interaction.log(msg)
@@ -3196,6 +3233,20 @@ class Unstage(ContextCommand):
         Interaction.command(N_('Error'), 'git reset', status, out, err)
         self.model.update_file_status()
         return (status, out, err)
+
+    def undo(self) -> None:
+        super().undo()
+        if not self.paths or not self._old_diff:
+            return
+        tmp_file = utils.tmp_filename('undo-unstage')
+        core.write(tmp_file, self._old_diff)
+        try:
+            status, out, err = gitcmds.apply_diff(self.context, tmp_file)
+        finally:
+            core.unlink(tmp_file)
+        if status != 0:
+            Interaction.log_status(status, out, err)
+        self.model.update_file_status()
 
 
 class UnstageAll(ContextCommand):

--- a/test/cmds_test.py
+++ b/test/cmds_test.py
@@ -220,3 +220,53 @@ def test_undo_last_commit_confirms_action(prefs, interaction):
     assert cmd.confirm()
     context.model.is_commit_published.assert_called_once()
     interaction.confirm.assert_called_once()
+
+
+from cola import core
+from cola import gitcmds
+
+from . import helper
+from .helper import app_context
+
+# Prevent unused imports lint errors.
+assert app_context is not None
+
+
+def test_stage_undo_restores_untracked_state(app_context):
+    """Undoing a Stage on a new file returns it to untracked"""
+    app_context.timestamp = time.time()
+    model = app_context.model
+    helper.touch('new_file.txt')
+    model.update_status()
+    assert 'new_file.txt' in model.untracked
+
+    cmd = cmds.Stage(app_context, ['new_file.txt'])
+    cmd.do()
+    model.update_status()
+    assert 'new_file.txt' in model.staged
+
+    cmd.undo()
+    model.update_status()
+    assert 'new_file.txt' not in model.staged
+    assert 'new_file.txt' in model.untracked
+
+
+def test_unstage_undo_restores_staged_state(app_context):
+    """Undoing an Unstage on a modified file returns it to staged"""
+    app_context.timestamp = time.time()
+    helper.commit_files()
+    helper.write_file('A', 'change')
+    helper.run_git('add', 'A')
+    model = app_context.model
+    model.update_status()
+    assert 'A' in model.staged
+
+    cmd = cmds.Unstage(app_context, ['A'])
+    cmd.do()
+    model.update_status()
+    assert 'A' not in model.staged
+    assert 'A' in model.modified
+
+    cmd.undo()
+    model.update_status()
+    assert 'A' in model.staged


### PR DESCRIPTION
## Summary

Fixes #1550

Adds undo support to the `Stage` and `Unstage` commands. Previously,
staging or unstaging a file (whole-file or line-based/hunk staging)
had no way to be undone — a single accidental click could discard
carefully prepared partial staging with no recovery path.

## Approach

Before staging/unstaging, the command snapshots whatever was already
staged for the affected paths using `git diff --cached`. On undo, the
paths are reset and the snapshot is re-applied via `git apply --cached`,
restoring the exact prior state — whether that was nothing staged,
fully staged, or partially staged via hunks.

This matches the approach discussed in the issue: storing a patch
(rather than a full index snapshot) keeps undo fast and avoids writing
extra objects into the repository.

## Testing

Added two new tests in `test/cmds_test.py` that exercise undo against
a real temporary git repository (not mocks):

- `test_stage_undo_restores_untracked_state` — stages a new file, then
  undoes it, confirming the file returns to untracked.
- `test_unstage_undo_restores_staged_state` — unstages a modified file,
  then undoes it, confirming it returns to staged.

Full test suite passes (274 passed; 2 pre-existing unrelated failures
on Windows due to CRLF line-ending differences in commit message tests).

## Notes

This covers whole-file and line-based staging via `Stage`/`Unstage`.
Wiring this into the UI (e.g. an "Undo" button/shortcut after staging)
is a natural follow-up but is out of scope for this PR, which focuses
on the underlying undo capability.