### PR TITLE
cmds: show a preview diff when confirming a revert

### DIFF
--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -2556,20 +2556,31 @@ class RevertEditsCommand(ConfirmAction):
     def checkout_from_head(self) -> bool:
         return False
 
+    def path_list(self) -> list[str]:
+        """Return the paths that will be checked out"""
+        s = self.selection.selection()
+        if s.staged:
+            return s.staged
+        else:
+            return s.modified
+
     def checkout_args(self) -> list[str]:
         args = []
-        s = self.selection.selection()
         if self.checkout_from_head():
             args.append(self.model.head)
         args.append('--')
 
-        if s.staged:
-            items = s.staged
-        else:
-            items = s.modified
+        items = self.path_list()
         args.extend(items)
 
         return args
+
+    def preview_diff(self) -> str:
+        """Return a diff of the changes that will be reverted"""
+        paths = self.path_list()
+        return gitcmds.diff_patch_with_stat(
+            self.context, paths, self.checkout_from_head()
+        )
 
     def action(self) -> tuple[int, str, str]:
         checkout_args = self.checkout_args()

--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -2612,8 +2612,9 @@ class RevertUnstagedEdits(RevertEditsCommand):
         )
         info = N_('Revert the unstaged changes?')
         ok_text = N_('Revert Unstaged Changes')
+        details = self.preview_diff()
         return Interaction.confirm(
-            title, text, info, ok_text, default=True, icon=self.icon
+            title, text, info, ok_text, default=True, icon=self.icon, details=details
         )
 
 
@@ -2634,8 +2635,9 @@ class RevertUncommittedEdits(RevertEditsCommand):
         )
         info = N_('Revert the uncommitted changes?')
         ok_text = N_('Revert Uncommitted Changes')
+        details = self.preview_diff()
         return Interaction.confirm(
-            title, text, info, ok_text, default=True, icon=self.icon
+            title, text, info, ok_text, default=True, icon=self.icon, details=details
         )
 
 

--- a/cola/gitcmds.py
+++ b/cola/gitcmds.py
@@ -853,6 +853,21 @@ def diff_upstream(context: ApplicationContext, head: str) -> list[Any | str]:
     return diff_filenames(context, base, tracked)
 
 
+def diff_patch_with_stat(
+    context: ApplicationContext, paths: list[str], head: bool
+) -> str:
+    """Return a patch with a diffstat for paths, against HEAD when head is True"""
+    if not paths:
+        return ''
+    args = []
+    if head:
+        args.append('HEAD')
+    args.append('--')
+    args.extend(paths)
+    result = context.git.diff(*args, patch_with_stat=True)
+    return result[STDOUT]
+
+
 def list_submodule(context: ApplicationContext) -> list[Any]:
     """Return submodules in the format(state, sha_1, path, describe)"""
     status, data, _ = context.git.submodule('status')

--- a/cola/interaction.py
+++ b/cola/interaction.py
@@ -108,11 +108,14 @@ class Interaction:
         icon=None,
         default: bool = True,
         cancel_text: str | None = None,
+        details: str | None = None,
     ) -> bool:
         cancel_text = cancel_text or 'Cancel'
         icon = icon or '?'
 
-        cls.information(title, message=text, informative_text=informative_text)
+        cls.information(
+            title, message=text, informative_text=informative_text, details=details
+        )
         if default:
             prompt = '%s? [Y/n] ' % ok_text
         else:

--- a/cola/widgets/standard.py
+++ b/cola/widgets/standard.py
@@ -1005,6 +1005,7 @@ class MessageBox(Dialog):
         ok_text='',
         cancel_text=None,
         cancel_icon=None,
+        expand_details=True,
     ):
         Dialog.__init__(self, parent=parent)
 
@@ -1034,6 +1035,8 @@ class MessageBox(Dialog):
         self.button_ok = qtutils.create_button(text=ok_text, icon=ok_icon)
 
         self.button_close = qtutils.close_button(text=cancel_text, icon=cancel_icon)
+        self.button_details = qtutils.create_button(text=N_('Show Details...'))
+        self.button_details.setCheckable(True)
 
         if ok_text:
             self.button_ok.setText(ok_text)
@@ -1045,8 +1048,13 @@ class MessageBox(Dialog):
         if details:
             self.details_text.setFont(qtutils.default_monospace_font())
             self.details_text.setPlainText(details)
+            if expand_details:
+                self.button_details.hide()
+            else:
+                self.details_text.hide()
         else:
             self.details_text.hide()
+            self.button_details.hide()
 
         self.info_layout = qtutils.vbox(
             defs.large_margin,
@@ -1067,6 +1075,7 @@ class MessageBox(Dialog):
         self.buttons_layout = qtutils.hbox(
             defs.no_margin,
             defs.button_spacing,
+            self.button_details,
             qtutils.STRETCH,
             self.button_close,
             self.button_ok,
@@ -1091,6 +1100,7 @@ class MessageBox(Dialog):
 
         qtutils.connect_button(self.button_ok, self.accept)
         qtutils.connect_button(self.button_close, self.reject)
+        self.button_details.toggled.connect(self.details_text.setVisible)
         self.init_state(None, self.set_initial_size)
 
     def set_initial_size(self):
@@ -1155,6 +1165,7 @@ def confirm(
     default=True,
     cancel_text=None,
     cancel_icon=None,
+    details=None,
 ):
     """Confirm that an action should take place"""
     cancel_text = cancel_text or N_('Cancel')
@@ -1171,6 +1182,8 @@ def confirm(
         cancel_icon=cancel_icon,
         logo=logo,
         default=default,
+        details=details,
+        expand_details=False,
     )
 
     return mbox.run() == mbox.Accepted

--- a/test/gitcmds_test.py
+++ b/test/gitcmds_test.py
@@ -218,3 +218,32 @@ def test_diff_helper(app_context):
     expect_rn = '+A change\r\n'
     actual = gitcmds.diff_helper(app_context, ref='HEAD', cached=True)
     assert expect_n in actual or expect_rn in actual
+
+
+def test_diff_patch_with_stat(app_context):
+    """diff_patch_with_stat() previews the changes that a revert will discard"""
+    helper.commit_files()
+    helper.write_file('A', 'A content\n')
+    helper.write_file('B', 'B content\n')
+    helper.run_git('add', 'A', 'B')
+    helper.run_git('commit', '-m', 'add A and B')
+
+    # An empty path list produces no diff.
+    assert gitcmds.diff_patch_with_stat(app_context, [], head=False) == ''
+
+    # Unstaged edits are diffed against the index.
+    helper.append_file('A', 'A change\n')
+    actual = gitcmds.diff_patch_with_stat(app_context, ['A'], head=False)
+    assert '1 file changed' in actual
+    assert '+A change' in actual
+
+    # Only the requested paths are included in the diff.
+    helper.append_file('B', 'B change\n')
+    actual = gitcmds.diff_patch_with_stat(app_context, ['A'], head=False)
+    assert 'B change' not in actual
+
+    # Staged edits do not appear in the index diff but do appear against HEAD.
+    helper.run_git('add', 'A')
+    assert gitcmds.diff_patch_with_stat(app_context, ['A'], head=False) == ''
+    actual = gitcmds.diff_patch_with_stat(app_context, ['A'], head=True)
+    assert '+A change' in actual


### PR DESCRIPTION
Fixes #1548

The revert confirmation dialogs ask for confirmation without showing which changes are about to be discarded, which makes it easy to destroy uncommitted work by mistake.

Attach a diff with a diffstat for the exact paths that will be checked out to the confirmation dialog. The preview is diffed against the index for unstaged edits and against HEAD for uncommitted edits, matching what `git checkout` is about to discard. The path selection is shared between the preview and the checkout so the two cannot diverge.

Per the discussion on #1548, the diff is collapsed by default behind a "Show Details..." toggle to keep the dialog compact, and scrolls rather than truncates for large diffs. `MessageBox` gains an `expand_details` option so that `critical()` error dialogs keep showing their details expanded, unchanged. In text mode the diff is printed before the confirmation prompt.

Testing: added `test_diff_patch_with_stat` covering the new `gitcmds` helper (empty-path guard, index vs HEAD diff base, path filtering); the full test suite passes; verified by hand in the GUI (both revert commands, toggle expand/collapse, Y/N hotkeys, cancel and confirm paths).

Dialog Collapsed:
<img width="700" height="400" alt="dialog_collapsed" src="https://github.com/user-attachments/assets/39cd9f67-63ef-4a9d-808d-bea32d65bdbf" />

Dialog Expanded:
<img width="700" height="400" alt="dialog_expanded" src="https://github.com/user-attachments/assets/6858b33a-96b8-4b5a-9e09-3df4c5b01337" />

