### PR TITLE
Improve MacOS settings display

### DIFF
--- a/cola/themes.py
+++ b/cola/themes.py
@@ -593,10 +593,16 @@ def style_sheet_default(palette: QPalette, bold_fonts: bool) -> str:
     else:
         font_weight = ''
 
-    return """
-        * {{
-            {font_weight}
-        }}
+    # macOS renders native checkboxes and radios that align correctly and look
+    # like the rest of the platform. Restyling their indicators via a stylesheet
+    # resizes the box but leaves QMacStyle positioning it against the native
+    # (smaller) metrics, which pushes the indicator out of vertical alignment
+    # with its label. Keep the native controls there and only restyle the
+    # indicators on platforms where the palette-based default looks out of place.
+    if utils.is_darwin():
+        checkbox_style = ''
+    else:
+        checkbox_style = """
         QCheckBox::indicator {{
             width: {checkbox_size}px;
             height: {checkbox_size}px;
@@ -626,7 +632,16 @@ def style_sheet_default(palette: QPalette, bold_fonts: bool) -> str:
             border-radius: {radio_radius}px;
             background: {base_rgb};
         }}
+        """
 
+    style_sheet = (
+        """
+        * {{
+            {font_weight}
+        }}
+        """
+        + checkbox_style
+        + """
         QSplitter::handle:hover {{
             background: {highlight_rgb};
         }}
@@ -640,7 +655,9 @@ def style_sheet_default(palette: QPalette, bold_fonts: bool) -> str:
             background: {highlight_rgb};
         }}
 
-        """.format(
+        """
+    )
+    return style_sheet.format(
         font_weight=font_weight,
         separator=defs.separator,
         highlight_rgb=highlight_rgb,

--- a/cola/widgets/prefs.py
+++ b/cola/widgets/prefs.py
@@ -38,6 +38,15 @@ class FormWidget(QtWidgets.QWidget):
         self.setLayout(QtWidgets.QFormLayout())
 
     def add_row(self, label, widget):
+        # QFormLayout aligns a plain label to the baseline of a bare checkbox,
+        # which leaves the native macOS indicator sitting a few pixels above its
+        # label text. Wrapping the button in a layout (which has no text
+        # baseline) makes the form vertically centre the row so the indicator
+        # lines up with the label.
+        if isinstance(widget, (QtWidgets.QCheckBox, QtWidgets.QRadioButton)):
+            widget = qtutils.hbox(
+                defs.no_margin, defs.no_spacing, widget, qtutils.STRETCH
+            )
         self.layout().addRow(label, widget)
 
     def set_config(self, config_dict):


### PR DESCRIPTION
The settings menu is off on MacOS, this fixes it just for MacOS, to not break rendering on other OSs - worth testing Linux KDE/Gnome/xfce/etc.

Before:

<img width="635" height="557" alt="image" src="https://github.com/user-attachments/assets/dc96f8f6-c1be-4b09-8413-4c810603aa93" />

After:

<img width="1244" height="1075" alt="image" src="https://github.com/user-attachments/assets/dba439b0-a3c7-4c35-9628-bd63db72c000" />

The checkboxes were also slightly off, so I had to tweak the widget. I don't know how to check the type without using isinstance, so if there is an idiomatic way to do this with Qt, please let me know. :-)