### PR TITLE
GIT_COLA_MSG: resolve it per worktree and keep it when switching repos

### DIFF
--- a/cola/cmds.py
+++ b/cola/cmds.py
@@ -2165,6 +2165,9 @@ class OpenRepo(EditModel):
 
     def do(self) -> None:
         old_repo = self.git.getcwd()
+        # Keep the message being written for the repository we are leaving,
+        # the same way that closing the window preserves it.
+        self.model.save_commitmsg()
         if self.model.set_worktree(self.repo_path):
             self.fsmonitor.stop()
             self.fsmonitor.start()
@@ -2174,6 +2177,10 @@ class OpenRepo(EditModel):
                 template_loader = LoadCommitMessageFromTemplate(self.context)
                 template_loader.do()
             else:
+                # Load the message prepared for the newly opened repository.
+                msg_path = gitcmds.commit_message_path(self.context)
+                if msg_path:
+                    self.new_commitmsg = core.read(msg_path)
                 self.model.set_commitmsg(self.new_commitmsg)
             settings = self.context.settings
             settings.load()

--- a/cola/git.py
+++ b/cola/git.py
@@ -235,11 +235,18 @@ class Git:
 
         return valid
 
-    def git_path(self, *paths) -> str:
+    def git_path(self, *paths, common: bool = True) -> str:
+        """Return a path inside the git directory
+
+        Existing paths in the common git directory are preferred over
+        non-existent per-worktree paths. Pass "common=False" for per-worktree
+        files, which is what "git rev-parse --git-path" reports.
+
+        """
         result = None
         if self.paths.git_dir:
             result = join(self.paths.git_dir, *paths)
-        if result and self.paths.common_dir and not core.exists(result):
+        if common and result and self.paths.common_dir and not core.exists(result):
             common_result = join(self.paths.common_dir, *paths)
             if core.exists(common_result):
                 result = common_result

--- a/cola/gitcmds.py
+++ b/cola/gitcmds.py
@@ -982,8 +982,13 @@ def rev_list_range(context: ApplicationContext, start, end) -> list[tuple[str, s
 
 
 def commit_message_path(context: ApplicationContext) -> str:
-    """Return the path to .git/GIT_COLA_MSG"""
-    path = context.git.git_path('GIT_COLA_MSG')
+    """Return the path to .git/GIT_COLA_MSG
+
+    The message belongs to a single worktree, so linked worktrees use
+    .git/worktrees/<name>/GIT_COLA_MSG.
+
+    """
+    path = context.git.git_path('GIT_COLA_MSG', common=False)
     if core.exists(path):
         return path
     return None

--- a/cola/models/main.py
+++ b/cola/models/main.py
@@ -235,7 +235,7 @@ class MainModel(QtCore.QObject):
     def save_commitmsg(self, msg: str | None = None) -> str:
         if msg is None:
             msg = self.commitmsg
-        path = self.git.git_path('GIT_COLA_MSG')
+        path = self.git.git_path('GIT_COLA_MSG', common=False)
         try:
             if not msg.endswith('\n'):
                 msg += '\n'

--- a/docs/git-cola.rst
+++ b/docs/git-cola.rst
@@ -452,6 +452,13 @@ message will be updated on the next refresh.
 This feature is useful as it allows scripts or agents to prepare a message for manual
 review.
 
+The commit message belongs to a single worktree. Linked worktrees created by
+`git worktree add` use `.git/worktrees/<name>/GIT_COLA_MSG` inside the main
+repository instead of `.git/GIT_COLA_MSG`. Scripts should ask Git for the path
+rather than assuming it::
+
+    git rev-parse --git-path GIT_COLA_MSG
+
 Sign Off
 --------
 

--- a/test/cmds_test.py
+++ b/test/cmds_test.py
@@ -1,4 +1,5 @@
 """Test the cmds module"""
+import os
 import time
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -266,3 +267,38 @@ def test_unstage_undo_restores_staged_state(app_context):
     cmd.undo()
     model.update_status()
     assert 'A' in model.staged
+
+
+def test_open_repo_loads_prepared_commit_message(app_context):
+    """Switching to a linked worktree loads that worktree's GIT_COLA_MSG"""
+    app_context.timestamp = time.time()
+    helper.commit_files()
+    worktree = os.path.join(os.getcwd(), 'wt')
+    helper.run_git('worktree', 'add', '--quiet', worktree, '-b', 'feature')
+    helper.write_file(
+        os.path.join(os.getcwd(), '.git', 'worktrees', 'wt', 'GIT_COLA_MSG'),
+        'prepared\n',
+    )
+    model = app_context.model
+    model.set_commitmsg('message for the old repository')
+
+    cmds.OpenRepo(app_context, worktree).do()
+
+    assert model.commitmsg == 'prepared\n'
+
+
+def test_open_repo_preserves_edited_commit_message(app_context):
+    """A message typed by hand survives switching repositories and back"""
+    app_context.timestamp = time.time()
+    helper.commit_files()
+    worktree = os.path.join(os.getcwd(), 'wt')
+    main_repo = os.getcwd()
+    helper.run_git('worktree', 'add', '--quiet', worktree, '-b', 'feature')
+    model = app_context.model
+    model.set_commitmsg('typed by hand')
+
+    cmds.OpenRepo(app_context, worktree).do()
+    assert model.commitmsg != 'typed by hand'
+
+    cmds.OpenRepo(app_context, main_repo).do()
+    assert model.commitmsg == 'typed by hand\n'

--- a/test/git_test.py
+++ b/test/git_test.py
@@ -417,3 +417,29 @@ def test_it_doesnt_deadlock():
 
     actual = err
     assert expect == actual
+
+
+def test_git_path_in_linked_worktree(tmp_path):
+    """Per-worktree paths do not fall back to the main repository's git dir"""
+    repo = tmp_path / 'repo'
+    worktree = tmp_path / 'wt'
+    git.Git.execute(['git', 'init', '--quiet', str(repo)])
+
+    def run(*args):
+        return git.Git.execute(['git', *args], _cwd=str(repo))
+
+    run('commit', '--quiet', '--allow-empty', '-m', 'init')
+    run('worktree', 'add', '--quiet', str(worktree), '-b', 'feature')
+    # A message in the main repository's git dir must not be picked up.
+    (repo / '.git' / 'GIT_COLA_MSG').write_text('main message\n')
+
+    gitcmd = git.Git()
+    gitcmd.set_worktree(str(worktree))
+    expect = str(worktree_git_dir := repo / '.git' / 'worktrees' / 'wt')
+    assert gitcmd.paths.git_dir == expect
+
+    actual = gitcmd.git_path('GIT_COLA_MSG', common=False)
+    assert actual == str(worktree_git_dir / 'GIT_COLA_MSG')
+    # The default still prefers an existing path in the common git dir.
+    actual = gitcmd.git_path('GIT_COLA_MSG')
+    assert actual == str(repo / '.git' / 'GIT_COLA_MSG')


### PR DESCRIPTION
Follow-up to #1565. While using the `GIT_COLA_MSG` feature in a linked
worktree, the message was not loaded after switching the repo.

The solution holds two key elements:

- separate the message per worktree
- keep any message when switching projects (the same as when closing cola)

The latter affects not only worktrees and is a nice side-effect I was annoyed by a lot.

I had an Agent helping me with the code. No Attribution as per request.
