### PR TITLE
fix(ui): fix recent repository path elision

### DIFF
--- a/cola/models/prefs.py
+++ b/cola/models/prefs.py
@@ -2,6 +2,7 @@ import sys
 from typing import Any
 
 from qtpy import QtCore
+from qtpy.QtCore import Qt
 from qtpy.QtCore import Signal
 
 from .. import core
@@ -67,6 +68,7 @@ STATUS_SHOW_TOTALS = 'cola.statusshowtotals'
 THEME = 'cola.theme'
 TABWIDTH = 'cola.tabwidth'
 TEXTWIDTH = 'cola.textwidth'
+TEXT_ELIDE_MODE = 'cola.textelidemode'
 USER_EMAIL = 'user.email'
 USER_NAME = 'user.name'
 UPDATE_INDEX = 'cola.updateindex'
@@ -187,6 +189,7 @@ class Defaults:
     patches_directory = 'patches'
     status_indent = False
     status_show_totals = False
+    text_elide_mode = 'middle'
     logdate = DateFormat.DEFAULT
     update_index = True
     verbosity = 0
@@ -415,6 +418,17 @@ def patches_directory(context) -> str:
 def sort_bookmarks(context) -> bool:
     """Should we sort bookmarks by name?"""
     return context.cfg.get(SORT_BOOKMARKS, default=Defaults.sort_bookmarks)
+
+
+def text_elide_mode(context) -> Qt.TextElideMode:
+    """Return the configured text elision mode for UI widgets."""
+    value = context.cfg.get(TEXT_ELIDE_MODE, default=Defaults.text_elide_mode)
+    return {
+        'left': Qt.ElideLeft,
+        'middle': Qt.ElideMiddle,
+        'right': Qt.ElideRight,
+        'none': Qt.ElideNone,
+    }.get(value, Qt.ElideMiddle)
 
 
 def tabwidth(context) -> int:

--- a/cola/widgets/prefs.py
+++ b/cola/widgets/prefs.py
@@ -468,10 +468,20 @@ class AppearanceFormWidget(FormWidget):
         self.status_show_totals = qtutils.checkbox()
         self.status_indent = qtutils.checkbox()
         self.block_cursor = qtutils.checkbox(checked=True)
+        self.text_elide_mode = qtutils.combo_mapped([
+            (N_('Left'), 'left'),
+            (N_('Middle'), 'middle'),
+            (N_('Right'), 'right'),
+            (N_('None'), 'none'),
+        ])
+        self.text_elide_mode.setToolTip(
+            N_('Choose how overly long text is truncated in the UI.')
+        )
 
         self.add_row(N_('Fixed-Width Font'), self.fixed_font)
         self.add_row(N_('Font Size'), self.fixed_font_size)
         self.add_row(N_('Font Size (UI)'), self.font_size)
+        self.add_row(N_('Text Elide Mode'), self.text_elide_mode)
         self.add_row(N_('GUI theme'), self.theme)
         self.add_row(N_('Icon theme'), self.icon_theme)
         self.add_row(N_('High DPI'), self.high_dpi)
@@ -480,7 +490,6 @@ class AppearanceFormWidget(FormWidget):
         self.add_row(N_('Show File Counts in Status Titles'), self.status_show_totals)
         self.add_row(N_('Indent Status paths'), self.status_indent)
         self.add_row(N_('Use a Block Cursor in Diff Editors'), self.block_cursor)
-
         self.set_config({
             prefs.BOLD_FONTS: (self.bold_fonts, Defaults.bold_fonts),
             prefs.BOLD_HEADERS: (self.bold_headers, Defaults.bold_headers),
@@ -497,6 +506,10 @@ class AppearanceFormWidget(FormWidget):
             prefs.THEME: (self.theme, Defaults.theme),
             prefs.ICON_THEME: (self.icon_theme, Defaults.icon_theme),
             prefs.BLOCK_CURSOR: (self.block_cursor, Defaults.block_cursor),
+            prefs.TEXT_ELIDE_MODE: (
+                self.text_elide_mode,
+                Defaults.text_elide_mode,
+            ),
         })
 
         self.fixed_font.currentFontChanged.connect(self.current_font_changed)

--- a/cola/widgets/startup.py
+++ b/cola/widgets/startup.py
@@ -332,6 +332,7 @@ class BookmarksListView(QtWidgets.QListView):
 
         self.setModel(model)
         self.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
+        self.setTextElideMode(prefs.text_elide_mode(context))
         self.setViewMode(QtWidgets.QListView.IconMode)
         self.setResizeMode(QtWidgets.QListView.Adjust)
         self.setGridSize(make_size(defs.large_icon))

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest configuration for Qt-based tests."""
+
+import os
+
+
+# Use an offscreen Qt backend in CI and headless local sessions.
+# This prevents QApplication from aborting when the display server is unavailable
+# or the active platform plugin is unstable.
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')


### PR DESCRIPTION
Fix the startup recent/bookmarks list so long repository
paths are elided in the middle instead of losing the most useful
part of the path.
Closes #1627