### PR TITLE
startup: elide recent-repo paths in the middle (#1627)

### DIFF
--- a/cola/widgets/startup.py
+++ b/cola/widgets/startup.py
@@ -338,6 +338,9 @@ class BookmarksListView(QtWidgets.QListView):
         self.setIconSize(make_size(defs.medium_icon))
         self.setDragEnabled(False)
         self.setWordWrap(True)
+        # Elide long paths in the middle so the trailing repository name stays
+        # visible instead of being cut off by the default right-side elision.
+        self.setTextElideMode(Qt.ElideMiddle)
 
         # Context Menu
         self.open_action = qtutils.add_action(

--- a/test/startup_test.py
+++ b/test/startup_test.py
@@ -1,10 +1,28 @@
 """Test Startup Dialog (git cola --prompt) Context Menu and related classes"""
+from qtpy import QtGui
+from qtpy.QtCore import Qt
+
 from cola.widgets import startup
 
 from .helper import app_context
 
 # Prevent unused imports lint errors.
 assert app_context is not None
+
+
+def test_recent_list_elides_in_middle(app_context):
+    """Long repository paths elide in the middle, keeping the trailing name.
+
+    The default right-side elision cut off the repository name, which is the
+    most useful part of a recent-repository path.
+    """
+    view = startup.BookmarksListView(
+        app_context,
+        QtGui.QStandardItemModel(),
+        lambda *args: None,
+        lambda *args: None,
+    )
+    assert view.textElideMode() == Qt.ElideMiddle
 
 
 def test_get_with_default_repo(app_context):


### PR DESCRIPTION
## What & why

Closes #1627.

The recent-repositories list on the startup dialog (`BookmarksListView` in `cola/widgets/startup.py`) relied on Qt's default text elide mode, `Qt.ElideRight`. When a path is wider than the item, the **right** end is replaced with `…`, which cuts off the repository name — the most identifying part of the path. As reported, two `/repos/…`-style entries become indistinguishable without hovering for the tooltip.

## Change

Set the view's elide mode to `Qt.ElideMiddle`:

```python
self.setTextElideMode(Qt.ElideMiddle)
```

Now long paths keep both the leading context and the trailing name — `/home/user/…/myproject` instead of `/home/user/very/long/pa…` — which matches the reporter's request and your note that entries should stay unambiguous. `Qt` is already imported in the module, so this is a one-line change.

## Test

Adds `test_recent_list_elides_in_middle`, which constructs a `BookmarksListView` and asserts `textElideMode() == Qt.ElideMiddle`.

Verified locally (PyQt6, offscreen): the constructed view reports `TextElideMode.ElideMiddle`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
