### PR TITLE
fix: refresh diff line numbers on palette change

### DIFF
--- a/cola/widgets/diff.py
+++ b/cola/widgets/diff.py
@@ -292,8 +292,6 @@ class DiffTextEdit(VimHintedPlainTextEdit):
     def refresh_appearance(self) -> None:
         """Update palette-derived colors after a system appearance change."""
         self.highlighter.refresh_palette(self.context)
-        if self.numbers:
-            self.numbers.refresh_palette()
 
     def changeEvent(self, event):
         if event.type() == QtCore.QEvent.PaletteChange:
@@ -591,6 +589,11 @@ class DiffLineNumbers(TextDecorator):
         self._window = palette.color(QPalette.Window)
         self._disabled = palette.color(QPalette.Disabled, QPalette.Text)
         self.update()
+
+    def changeEvent(self, event):
+        if event.type() == QtCore.QEvent.PaletteChange:
+            self.refresh_palette()
+        super().changeEvent(event)
 
     def set_diff(self, diff, lines=None):
         """Update to a new diff display"""

--- a/test/appearance_test.py
+++ b/test/appearance_test.py
@@ -5,7 +5,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from cola import app as cola_app
+from cola.widgets.diff import DiffLineNumbers
 from cola.widgets.diff import DiffSyntaxHighlighter
+from qtpy import QtCore
 from qtpy import QtGui
 from qtpy import QtWidgets
 
@@ -105,3 +107,15 @@ def test_diff_syntax_highlighter_refresh_palette_rehighlights(qapp):
     highlighter.refresh_palette(context)
 
     highlighter.rehighlight.assert_called_once()
+
+
+def test_diff_line_numbers_change_event_refreshes_on_palette_change(qapp):
+    """DiffLineNumbers must refresh itself on PaletteChange events."""
+    context = MagicMock()
+    context.cfg.get.return_value = None
+    numbers = DiffLineNumbers(context, QtWidgets.QPlainTextEdit())
+    numbers.refresh_palette = MagicMock()
+
+    numbers.changeEvent(QtCore.QEvent(QtCore.QEvent.PaletteChange))
+
+    numbers.refresh_palette.assert_called_once()


### PR DESCRIPTION
This is an update to PR #1603, with improvement to
the diff line number theme change logic.

### Before 
<img width="1804" height="838" alt="2026-08-03_22-09" src="https://github.com/user-attachments/assets/395c96ed-5f50-4586-92eb-ce884ee93fb9" />

###After
<img width="1798" height="838" alt="2026-08-03_22-08" src="https://github.com/user-attachments/assets/e844e0e1-505a-4959-98ca-0e32870e0f13" />
