### PR TITLE
Prefer `cola.*` config keys for editor, difftool, mergetool, and history browser (#1632)

### DIFF
--- a/cola/models/prefs.py
+++ b/cola/models/prefs.py
@@ -76,6 +76,7 @@ COLA_HISTORY_BROWSER = 'cola.historybrowser'
 COLA_DIFFTOOL = 'cola.difftool'
 COLA_MERGETOOL = 'cola.mergetool'
 
+
 class DateFormat:
     DEFAULT = 'default'
     RELATIVE = 'relative'

--- a/cola/models/prefs.py
+++ b/cola/models/prefs.py
@@ -71,7 +71,10 @@ USER_EMAIL = 'user.email'
 USER_NAME = 'user.name'
 UPDATE_INDEX = 'cola.updateindex'
 VERBOSITY = 'cola.verbosity'
-
+COLA_EDITOR = 'cola.editor'
+COLA_HISTORY_BROWSER = 'cola.historybrowser'
+COLA_DIFFTOOL = 'cola.difftool'
+COLA_MERGETOOL = 'cola.mergetool'
 
 class DateFormat:
     DEFAULT = 'default'
@@ -266,7 +269,11 @@ def display_untracked(context) -> bool:
 
 def editor(context) -> str:
     """Return the configured editor"""
-    app = context.cfg.get(EDITOR, default=fallback_editor())
+    app = context.cfg.get(COLA_EDITOR, default=None)
+    if app is None:
+        app = context.cfg.get(EDITOR, default=None)
+    if app is None:
+        app = fallback_editor()
     return _remap_editor(app)
 
 
@@ -274,6 +281,22 @@ def background_editor(context) -> str:
     """Return the configured non-blocking background editor"""
     app = context.cfg.get(BACKGROUND_EDITOR, default=editor(context))
     return _remap_editor(app)
+
+
+def difftool(context) -> str:
+    """Return the configured diff tool"""
+    return context.cfg.get(
+        COLA_DIFFTOOL,
+        default=context.cfg.get(DIFFTOOL, default=Defaults.difftool),
+    )
+
+
+def mergetool(context) -> str:
+    """Return the configured merge tool"""
+    return context.cfg.get(
+        COLA_MERGETOOL,
+        default=context.cfg.get(MERGETOOL, default=Defaults.mergetool),
+    )
 
 
 def enable_popups(context) -> bool:
@@ -345,7 +368,10 @@ def default_history_browser() -> str:
 def history_browser(context) -> str:
     """Return the configured history browser"""
     default = default_history_browser()
-    return context.cfg.get(HISTORY_BROWSER, default=default)
+    return context.cfg.get(
+        COLA_HISTORY_BROWSER,
+        default=context.cfg.get(HISTORY_BROWSER, default=default),
+    )
 
 
 def http_proxy(context) -> str:

--- a/cola/widgets/prefs.py
+++ b/cola/widgets/prefs.py
@@ -105,9 +105,18 @@ class FormWidget(QtWidgets.QWidget):
             getter = self.cfg.get
 
         for config, widget in self.widget_to_config.items():
-            value = getter(config)
-            if value is None:
-                value = self.defaults[config]
+            if config == prefs.COLA_EDITOR:
+                value = prefs.editor(self.context)
+            elif config == prefs.COLA_HISTORY_BROWSER:
+                value = prefs.history_browser(self.context)
+            elif config == prefs.COLA_DIFFTOOL:
+                value = prefs.difftool(self.context)
+            elif config == prefs.COLA_MERGETOOL:
+                value = prefs.mergetool(self.context)
+            else:
+                value = getter(config)
+                if value is None:
+                    value = self.defaults[config]
             set_widget_value(widget, value)
 
 
@@ -405,13 +414,13 @@ class SettingsFormWidget(FormWidget):
                 Defaults.fixup_commit_count,
             ),
             prefs.SORT_BOOKMARKS: (self.sort_bookmarks, Defaults.sort_bookmarks),
-            prefs.DIFFTOOL: (self.difftool, Defaults.difftool),
-            prefs.EDITOR: (self.editor, fallback_editor()),
+            prefs.COLA_DIFFTOOL: (self.difftool, Defaults.difftool),
+            prefs.COLA_EDITOR: (self.editor, fallback_editor()),
             prefs.BACKGROUND_EDITOR: (
                 self.background_editor,
                 Defaults.background_editor,
             ),
-            prefs.HISTORY_BROWSER: (
+            prefs.COLA_HISTORY_BROWSER: (
                 self.historybrowser,
                 prefs.default_history_browser(),
             ),
@@ -425,7 +434,7 @@ class SettingsFormWidget(FormWidget):
                 self.keep_merge_backups,
                 Defaults.merge_keep_backup,
             ),
-            prefs.MERGETOOL: (self.mergetool, Defaults.mergetool),
+            prefs.COLA_MERGETOOL: (self.mergetool, Defaults.mergetool),
             prefs.REFRESH_ON_FOCUS: (self.refresh_on_focus, Defaults.refresh_on_focus),
             prefs.RESIZE_BROWSER_COLUMNS: (
                 self.resize_browser_columns,

--- a/docs/git-cola.rst
+++ b/docs/git-cola.rst
@@ -1422,21 +1422,34 @@ The default text editor to use is defined in `gui.editor`.
 The config variable overrides the VISUAL environment variable.
 Defaults to `gvim -f -p`.
 
+Git Cola also honors the `cola.editor` key. When set, it takes precedence over
+`gui.editor` for Git Cola-specific editor settings.
+
 gui.historybrowser
 ------------------
 
 The history browser to use when visualizing history.
 Defaults to `gitk`.
 
+Git Cola also honors the `cola.historybrowser` key. When set, it takes
+precedence over `gui.historybrowser` for Git Cola-specific history browser
+settings.
+
 diff.tool
 ---------
 
 The default diff tool to use.
 
+Git Cola also honors the `cola.difftool` key. When set, it takes precedence
+over `diff.tool` for Git Cola-specific difftool settings.
+
 merge.tool
 ----------
 
 The default merge tool to use.
+
+Git Cola also honors the `cola.mergetool` key. When set, it takes precedence
+over `merge.tool` for Git Cola-specific mergetool settings.
 
 user.email
 ----------

--- a/test/prefs_test.py
+++ b/test/prefs_test.py
@@ -1,0 +1,96 @@
+import sys
+from unittest.mock import Mock
+
+import pytest
+from qtpy import QtWidgets
+
+from cola.models import prefs
+from cola.widgets import prefs as prefs_widgets
+from . import helper
+from .helper import app_context
+
+
+def _qapp():
+    instance = QtWidgets.QApplication.instance()
+    if instance is None:
+        instance = QtWidgets.QApplication(sys.argv[:1] if sys.argv else ['git-cola-test'])
+    return instance
+
+
+@pytest.fixture(scope='module')
+def qapp():
+    yield _qapp()
+
+
+def test_editor_pref_uses_cola_editor_over_gui_editor(app_context):
+    helper.run_git('config', 'cola.editor', 'colaedit')
+    helper.run_git('config', 'gui.editor', 'guiedit')
+    app_context.cfg.reset()
+
+    assert prefs.editor(app_context) == 'colaedit'
+
+
+def test_editor_pref_falls_back_to_gui_editor(app_context):
+    helper.run_git('config', 'gui.editor', 'guiedit2')
+    app_context.cfg.reset()
+
+    assert prefs.editor(app_context) == 'guiedit2'
+
+
+def test_difftool_pref_uses_cola_difftool_over_diff_tool(app_context):
+    helper.run_git('config', 'cola.difftool', 'cola-diff')
+    helper.run_git('config', 'diff.tool', 'git-diff')
+    app_context.cfg.reset()
+
+    assert prefs.difftool(app_context) == 'cola-diff'
+
+
+def test_difftool_pref_falls_back_to_diff_tool(app_context):
+    helper.run_git('config', 'diff.tool', 'git-diff-2')
+    app_context.cfg.reset()
+
+    assert prefs.difftool(app_context) == 'git-diff-2'
+
+
+def test_mergetool_pref_uses_cola_mergetool_over_merge_tool(app_context):
+    helper.run_git('config', 'cola.mergetool', 'cola-merge')
+    helper.run_git('config', 'merge.tool', 'git-merge')
+    app_context.cfg.reset()
+
+    assert prefs.mergetool(app_context) == 'cola-merge'
+
+
+def test_mergetool_pref_falls_back_to_merge_tool(app_context):
+    helper.run_git('config', 'merge.tool', 'git-merge-2')
+    app_context.cfg.reset()
+
+    assert prefs.mergetool(app_context) == 'git-merge-2'
+
+
+def test_history_browser_pref_uses_cola_historybrowser_over_gui_historybrowser(app_context):
+    helper.run_git('config', 'cola.historybrowser', 'cola-hist')
+    helper.run_git('config', 'gui.historybrowser', 'gitk-hist')
+    app_context.cfg.reset()
+
+    assert prefs.history_browser(app_context) == 'cola-hist'
+
+
+def test_history_browser_pref_falls_back_to_gui_historybrowser(app_context):
+    helper.run_git('config', 'gui.historybrowser', 'gitk-hist-2')
+    app_context.cfg.reset()
+
+    assert prefs.history_browser(app_context) == 'gitk-hist-2'
+
+
+def test_settings_form_widget_uses_cola_config_keys(qapp, app_context):
+    widget = prefs_widgets.SettingsFormWidget(app_context, Mock(), None)
+
+    assert prefs.COLA_EDITOR in widget.widget_to_config
+    assert prefs.COLA_HISTORY_BROWSER in widget.widget_to_config
+    assert prefs.COLA_DIFFTOOL in widget.widget_to_config
+    assert prefs.COLA_MERGETOOL in widget.widget_to_config
+
+    assert prefs.EDITOR not in widget.widget_to_config
+    assert prefs.HISTORY_BROWSER not in widget.widget_to_config
+    assert prefs.DIFFTOOL not in widget.widget_to_config
+    assert prefs.MERGETOOL not in widget.widget_to_config

--- a/test/prefs_test.py
+++ b/test/prefs_test.py
@@ -13,7 +13,9 @@ from .helper import app_context
 def _qapp():
     instance = QtWidgets.QApplication.instance()
     if instance is None:
-        instance = QtWidgets.QApplication(sys.argv[:1] if sys.argv else ['git-cola-test'])
+        instance = QtWidgets.QApplication(
+            sys.argv[:1] if sys.argv else ['git-cola-test']
+        )
     return instance
 
 
@@ -67,7 +69,9 @@ def test_mergetool_pref_falls_back_to_merge_tool(app_context):
     assert prefs.mergetool(app_context) == 'git-merge-2'
 
 
-def test_history_browser_pref_uses_cola_historybrowser_over_gui_historybrowser(app_context):
+def test_history_browser_pref_uses_cola_historybrowser_over_gui_historybrowser(
+    app_context,
+):
     helper.run_git('config', 'cola.historybrowser', 'cola-hist')
     helper.run_git('config', 'gui.historybrowser', 'gitk-hist')
     app_context.cfg.reset()


### PR DESCRIPTION
close #1632 
## Summary
- Prefer `cola.*` config keys for Git Cola preferences.
- Fall back to the legacy Git config keys for backward compatibility.

## Changes
- Updated preference accessors in `cola/models/prefs.py`.
- Updated the Preferences UI in `cola/widgets/prefs.py`.
- Added unit tests covering priority, fallback behavior, and UI mapping.

## Rationale
- Keep Git Cola preferences separate from Git's global tool configuration while remaining fully backward compatible.

## Testing
- Unit tests pass locally.

## Note
- Existing legacy keys continue to work; users can opt in by configuring the new `cola.*` keys.