### PR TITLE
commitmsg: derive the Commit button shortcut hint from the action

### DIFF
--- a/cola/widgets/commitmsg.py
+++ b/cola/widgets/commitmsg.py
@@ -109,7 +109,16 @@ class CommitMessageEditor(QtWidgets.QFrame):
         )
         self.description.menu_actions.extend(menu_actions)
 
-        commit_button_tooltip = N_('Commit staged changes\nShortcut: Ctrl+Enter')
+        # Render the shortcut from the action so it matches the platform --
+        # Qt maps Ctrl to Command on macOS -- instead of hardcoding "Ctrl+Enter".
+        commit_shortcut = self.commit_action.shortcut().toString(
+            QtGui.QKeySequence.NativeText
+        )
+        commit_button_tooltip = N_('Commit staged changes')
+        if commit_shortcut:
+            commit_button_tooltip = '{}\n{}'.format(
+                commit_button_tooltip, N_('Shortcut: %s') % commit_shortcut
+            )
         self.commit_button = qtutils.create_button(
             text=N_('Commit@@verb'), tooltip=commit_button_tooltip, icon=icons.commit()
         )

--- a/test/commitmsg_test.py
+++ b/test/commitmsg_test.py
@@ -1,0 +1,62 @@
+"""Tests for the commit message editor (cola.widgets.commitmsg)."""
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from cola import core
+from cola import git
+from cola import gitcfg
+from cola import gitcmds
+from cola import hotkeys
+from cola.models import main as main_model
+from cola.widgets.commitmsg import CommitMessageEditor
+from qtpy import QtGui
+from qtpy import QtWidgets
+
+from . import helper
+
+
+@pytest.fixture(scope='module')
+def qapp():
+    """Provide a QApplication for the widget tests."""
+    instance = QtWidgets.QApplication.instance()
+    if instance is None:
+        instance = QtWidgets.QApplication(
+            sys.argv[:1] if sys.argv else ['git-cola-test']
+        )
+    yield instance
+
+
+@pytest.fixture
+def commit_editor(qapp, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    helper.initialize_repo()
+
+    context = MagicMock()
+    context.git = git.create()
+    context.git.set_worktree(core.getcwd())
+    context.cfg = gitcfg.create(context)
+    context.model = main_model.create(context)
+    context.cfg.reset()
+    gitcmds.reset()
+
+    editor = CommitMessageEditor(context, None)
+    try:
+        yield editor
+    finally:
+        editor.close()
+
+
+def test_commit_button_tooltip_uses_the_native_shortcut(commit_editor):
+    """The tooltip shows the platform shortcut, not a hardcoded 'Ctrl+Enter'.
+
+    Qt maps Ctrl to Command on macOS, so the literal string was wrong there
+    and, being translated, wrong in every locale.
+    """
+    tooltip = commit_editor.commit_button.toolTip()
+    native = hotkeys.APPLY.toString(QtGui.QKeySequence.NativeText)
+
+    assert 'Commit staged changes' in tooltip
+    assert native in tooltip
+    assert 'Ctrl+Enter' not in tooltip


### PR DESCRIPTION
The Commit button's tooltip hardcodes `Shortcut: Ctrl+Enter`. Qt maps Ctrl to Command on macOS, so the hint is wrong there -- and because the whole string was translated as one unit, the wrong shortcut was included with every locale too.

Instead, what we can do is render the shortcut from the commit action itself with [`QKeySequence.NativeText`](https://doc.qt.io/qt-6/qkeysequence.html#SequenceFormat-enum), which shows the Command "glyph" (I think that's the term?) on macOS and `Ctrl+Return` elsewhere.

If the shortcut ever changes, the tooltip now follows it for free instead of drifting.

New tests in `test/commitmsg_test.py` assert the tooltip contains the action's actual native-text shortcut rather than a hardcoded string.

---

Before:
<img width="596" height="295" alt="image" src="https://github.com/user-attachments/assets/62fa945d-79e4-4f1f-9ded-dfb0681cedf1" />


After:
<img width="202" height="127" alt="image" src="https://github.com/user-attachments/assets/2bddffbf-2108-4411-881e-fd32b807a8fb" />
