### PR TITLE
Correct the add_env type annotation in cola/core.py

### DIFF
--- a/cola/core.py
+++ b/cola/core.py
@@ -198,7 +198,7 @@ def readline(fh, encoding=None) -> UStr | None:
 def start_command(
     cmd: list[UStr | str],
     cwd: UStr | None = None,
-    add_env: None = None,
+    add_env: dict[str, str] | None = None,
     universal_newlines: bool = False,
     stdin: int | None = subprocess.PIPE,
     stdout: int | None = subprocess.PIPE,


### PR DESCRIPTION
Tiny one: `add_env` in `cola/core.py` is annotated as `None`, but it has always been a mapping -- `start_command()` copies `os.environ` and calls `.update()` on the value, and `git.py` already passes a dict straight through the Git wrapper.

This just corrects the annotation to match what the code has always done. No behaviour change.

(I've got a bunch of changes and split them into smaller PRs, hopefully making it easier to review, I promise this is the smallest/dumbest one)