### PR TITLE
Align and pad the Diff Options menu rows

### DIFF
--- a/cola/widgets/diff.py
+++ b/cola/widgets/diff.py
@@ -1078,6 +1078,15 @@ class Options(QtWidgets.QWidget):
         # Create widgets
         self.widget = parent
         self.filename = filename  # The filename plain text display.
+        # Width of the leading gutter for the embedded menu rows below, sized so
+        # their labels line up with the native checkable items' text. Read from
+        # the active style rather than hardcoded so it tracks the platform --
+        # macOS uses different padding/inset values than Fusion. Falls back to
+        # the icon-size constant if the style reports 0.
+        menu_icon_gutter = (
+            self.style().pixelMetric(QtWidgets.QStyle.PM_SmallIconSize)
+            or defs.default_icon
+        )
         self.ignore_space_at_eol = self.add_option(
             N_('Ignore changes in whitespace at EOL')
         )
@@ -1108,12 +1117,19 @@ class Options(QtWidgets.QWidget):
         )
         self.max_diff_spinbox.setSpecialValueText(N_('Unlimited'))
         self.max_diff_widget = QtWidgets.QWidget(self)
+        # The leading gutter lines the label up with the checkable items below
+        # (which are indented past the check/icon column), and the margins keep
+        # the spin box off the menu's right edge.
         self.max_diff_layout = qtutils.hbox(
             defs.no_margin,
-            defs.button_spacing,
+            defs.titlebar_spacing,
+            menu_icon_gutter,
             self.max_diff_label,
             qtutils.STRETCH,
             self.max_diff_spinbox,
+        )
+        self.max_diff_layout.setContentsMargins(
+            defs.small_margin, defs.small_margin, defs.margin, defs.small_margin
         )
         self.max_diff_widget.setLayout(self.max_diff_layout)
         self.max_diff_action = QtWidgets.QWidgetAction(self)
@@ -1173,11 +1189,19 @@ class Options(QtWidgets.QWidget):
         except Exception:
             pass
 
+        # Match the max-diff row: the same gutter aligns the label with the
+        # checkable items, a stretch right-aligns the combo, and the margins
+        # keep it off the menu's right edge.
         intraline_layout = qtutils.hbox(
             defs.no_margin,
-            defs.button_spacing,
+            defs.titlebar_spacing,
+            menu_icon_gutter,
             self.intraline_diff_preset_label,
+            qtutils.STRETCH,
             self.intraline_diff_preset_combo,
+        )
+        intraline_layout.setContentsMargins(
+            defs.small_margin, defs.small_margin, defs.margin, defs.small_margin
         )
         self.intraline_diff_widget.setLayout(intraline_layout)
 


### PR DESCRIPTION
The two embedded rows in the Diff Options menu (Intra-line diff mode and Maximum diff size) are `QWidgetAction`s built with `no_margin`, so on macOS they sit flush against the menu edges -- their labels start LEFT of the native checkable items, whose text is indented past the check/icon column, and the combo/spin box touch the menu's right edge.

Before:

<img width="1193" height="440" alt="image" src="https://github.com/user-attachments/assets/814ca931-5b7f-444c-8e9e-63fbc89deb83" />

After:

<img width="1427" height="645" alt="image" src="https://github.com/user-attachments/assets/2408f483-5b45-4955-884c-c4adeb286588" />

The fix gives both rows a leading gutter so their labels line up with the checkable items, a stretch so the combo and spin box right-align consistently, and small content margins so the controls no longer touch the menu edge.

Rather than hardcoding the gutter width, it's read from the active style via [`PM_SmallIconSize`](https://doc.qt.io/qt-6/qstyle.html#PixelMetric-enum) so it tracks the platform -- the macOS style uses different padding and inset values than Fusion -- falling back to the icon-size constant when the metric reports 0.

This is the shared `Options` widget, so both the main window and the Git DAG diff panes pick it up. Worth a quick look on Linux (KDE/GNOME/etc) to confirm it still looks right there -- it should, since the gutter comes from the active style's own metric.