### PR TITLE
Implement `cola.*` configuration overrides

### DIFF
--- a/cola/difftool.py
+++ b/cola/difftool.py
@@ -12,6 +12,7 @@ from . import git
 from . import gitcmds
 from . import hotkeys
 from . import icons
+from .models import prefs
 from . import qtutils
 from . import utils
 from .i18n import N_
@@ -48,7 +49,11 @@ class LaunchDifftool(cmds.ContextCommand):
                 shellquote_terms = {'xfce4-terminal'}
                 shellquote_default = terminal in shellquote_terms
 
-                mergetool = ['git', 'mergetool', '--no-prompt', '--']
+                mergetool = ['git', 'mergetool', '--no-prompt']
+                tool = prefs.mergetool(self.context)
+                if tool:
+                    mergetool.append(f'--tool={tool}')
+                mergetool.append('--')
                 mergetool.extend(paths)
                 needs_shellquote = cfg.get(
                     'cola.terminalshellquote', shellquote_default
@@ -334,6 +339,9 @@ def difftool_launch(
         'no_prompt': True,
         '_readonly': True,
     }
+    tool = prefs.difftool(context)
+    if tool:
+        kwargs['tool'] = tool
     if staged:
         kwargs['cached'] = True
     if dir_diff:

--- a/cola/models/prefs.py
+++ b/cola/models/prefs.py
@@ -28,8 +28,10 @@ COMMIT_CLEANUP = 'commit.cleanup'
 DICTIONARY = 'cola.dictionary'
 DIFFCONTEXT = 'gui.diffcontext'
 DIFFTOOL = 'diff.tool'
+OVERRIDE_DIFFTOOL = 'cola.difftool'
 DISPLAY_UNTRACKED = 'gui.displayuntracked'
 EDITOR = 'gui.editor'
+OVERRIDE_EDITOR = 'cola.editor'
 ENABLE_GRAVATAR = 'cola.gravatar'
 ENABLE_POPUPS = 'cola.enablepopups'
 EXPANDTAB = 'cola.expandtab'
@@ -38,6 +40,7 @@ FONTDIFF = 'cola.fontdiff'
 FONTSIZE = 'cola.fontsize'
 HIDPI = 'cola.hidpi'
 HISTORY_BROWSER = 'gui.historybrowser'
+OVERRIDE_HISTORY_BROWSER = 'cola.historybrowser'
 HTTP_PROXY = 'http.proxy'
 ICON_THEME = 'cola.icontheme'
 INOTIFY = 'cola.inotify'
@@ -52,6 +55,7 @@ MERGE_KEEPBACKUP = 'merge.keepbackup'
 MERGE_SUMMARY = 'merge.summary'
 MERGE_VERBOSITY = 'merge.verbosity'
 MERGETOOL = 'merge.tool'
+OVERRIDE_MERGETOOL = 'cola.mergetool'
 MOUSE_ZOOM = 'cola.mousezoom'
 PATCHES_DIRECTORY = 'cola.patchesdirectory'
 PULL_REBASE = 'pull.rebase'
@@ -269,7 +273,7 @@ def display_untracked(context) -> bool:
 
 def editor(context) -> str:
     """Return the configured editor"""
-    app = context.cfg.get(EDITOR, default=fallback_editor())
+    app = _config_with_override(context, OVERRIDE_EDITOR, EDITOR, default=fallback_editor())
     return _remap_editor(app)
 
 
@@ -303,6 +307,14 @@ def fallback_editor() -> str:
             return env_editor
 
     return Defaults.editor
+
+
+def _config_with_override(context, override_key: str, fallback_key: str, default='') -> str:
+    """Return a cola.* override when configured, else fall back to the git key."""
+    value = context.cfg.get(override_key, default=default)
+    if value:
+        return value
+    return context.cfg.get(fallback_key, default=default)
 
 
 def _remap_editor(app: str) -> str:
@@ -348,7 +360,32 @@ def default_history_browser() -> str:
 def history_browser(context) -> str:
     """Return the configured history browser"""
     default = default_history_browser()
-    return context.cfg.get(HISTORY_BROWSER, default=default)
+    return _config_with_override(
+        context,
+        OVERRIDE_HISTORY_BROWSER,
+        HISTORY_BROWSER,
+        default=default,
+    )
+
+
+def difftool(context) -> str:
+    """Return the configured diff tool"""
+    return _config_with_override(
+        context,
+        OVERRIDE_DIFFTOOL,
+        DIFFTOOL,
+        default=Defaults.difftool,
+    )
+
+
+def mergetool(context) -> str:
+    """Return the configured merge tool"""
+    return _config_with_override(
+        context,
+        OVERRIDE_MERGETOOL,
+        MERGETOOL,
+        default=Defaults.mergetool,
+    )
 
 
 def http_proxy(context) -> str:

--- a/cola/models/prefs.py
+++ b/cola/models/prefs.py
@@ -273,7 +273,9 @@ def display_untracked(context) -> bool:
 
 def editor(context) -> str:
     """Return the configured editor"""
-    app = _config_with_override(context, OVERRIDE_EDITOR, EDITOR, default=fallback_editor())
+    app = _config_with_override(
+        context, OVERRIDE_EDITOR, EDITOR, default=fallback_editor()
+    )
     return _remap_editor(app)
 
 
@@ -309,9 +311,11 @@ def fallback_editor() -> str:
     return Defaults.editor
 
 
-def _config_with_override(context, override_key: str, fallback_key: str, default='') -> str:
+def _config_with_override(
+    context, override_key: str, fallback_key: str, default=''
+) -> str:
     """Return a cola.* override when configured, else fall back to the git key."""
-    value = context.cfg.get(override_key, default=default)
+    value = context.cfg.get(override_key, default=None)
     if value:
         return value
     return context.cfg.get(fallback_key, default=default)

--- a/cola/widgets/prefs.py
+++ b/cola/widgets/prefs.py
@@ -301,6 +301,11 @@ class SettingsFormWidget(FormWidget):
         self.tabwidth = standard.SpinBox(maxi=42)
         self.textwidth = standard.SpinBox(maxi=150)
 
+        self.override_editor = QtWidgets.QLineEdit()
+        self.override_editor.setToolTip(
+            N_('Override the GUI editor setting when configured')
+        )
+
         self.editor = QtWidgets.QLineEdit()
         self.editor.setToolTip(N_('The main GUI editor that must block until it exits'))
 
@@ -310,8 +315,21 @@ class SettingsFormWidget(FormWidget):
         )
         self.historybrowser = QtWidgets.QLineEdit()
         self.blameviewer = QtWidgets.QLineEdit()
+        self.override_historybrowser = QtWidgets.QLineEdit()
+        self.override_historybrowser.setToolTip(
+            N_('Override the history browser setting when configured')
+        )
+
         self.difftool = QtWidgets.QLineEdit()
+        self.override_difftool = QtWidgets.QLineEdit()
+        self.override_difftool.setToolTip(
+            N_('Override the diff tool setting when configured')
+        )
         self.mergetool = QtWidgets.QLineEdit()
+        self.override_mergetool = QtWidgets.QLineEdit()
+        self.override_mergetool.setToolTip(
+            N_('Override the merge tool setting when configured')
+        )
 
         self.linebreak = qtutils.checkbox()
         self.mouse_zoom = qtutils.checkbox()
@@ -348,6 +366,11 @@ class SettingsFormWidget(FormWidget):
         self.add_row(N_('Insert Spaces Instead of Tabs'), self.expandtab)
         self.add_row(N_('Auto-Wrap Lines'), self.linebreak)
 
+        self.add_row('', QtWidgets.QLabel())
+        self.add_row(N_('Editor Override'), self.override_editor)
+        self.add_row(N_('History Browser Override'), self.override_historybrowser)
+        self.add_row(N_('Diff Tool Override'), self.override_difftool)
+        self.add_row(N_('Merge Tool Override'), self.override_mergetool)
         self.add_row('', QtWidgets.QLabel())
         self.add_row(N_('Editor'), self.editor)
         self.add_row(N_('Background Editor'), self.background_editor)
@@ -387,6 +410,13 @@ class SettingsFormWidget(FormWidget):
 
         self.set_config({
             prefs.ASPELL_ENABLED: (self.aspell_enabled, Defaults.aspell_enabled),
+            prefs.OVERRIDE_EDITOR: (self.override_editor, ''),
+            prefs.OVERRIDE_HISTORY_BROWSER: (
+                self.override_historybrowser,
+                '',
+            ),
+            prefs.OVERRIDE_DIFFTOOL: (self.override_difftool, ''),
+            prefs.OVERRIDE_MERGETOOL: (self.override_mergetool, ''),
             prefs.SAVEWINDOWSETTINGS: (
                 self.save_window_settings,
                 Defaults.save_window_settings,
@@ -405,15 +435,15 @@ class SettingsFormWidget(FormWidget):
                 Defaults.fixup_commit_count,
             ),
             prefs.SORT_BOOKMARKS: (self.sort_bookmarks, Defaults.sort_bookmarks),
-            prefs.DIFFTOOL: (self.difftool, Defaults.difftool),
-            prefs.EDITOR: (self.editor, fallback_editor()),
+            prefs.DIFFTOOL: (self.difftool, ''),
+            prefs.EDITOR: (self.editor, ''),
             prefs.BACKGROUND_EDITOR: (
                 self.background_editor,
                 Defaults.background_editor,
             ),
             prefs.HISTORY_BROWSER: (
                 self.historybrowser,
-                prefs.default_history_browser(),
+                '',
             ),
             prefs.BLAME_VIEWER: (self.blameviewer, Defaults.blame_viewer),
             prefs.CHECK_CONFLICTS: (self.check_conflicts, Defaults.check_conflicts),


### PR DESCRIPTION
Implement `cola.*` overrides for the editor, history browser, diff tool, and merge tool settings.

### Changes

- Add separate `cola.*` override settings for:
  - `cola.editor`
  - `cola.historybrowser`
  - `cola.difftool`
  - `cola.mergetool`
- Keep the existing `gui.*` / Git configuration keys as fallbacks.
- Make `cola.*` values take precedence when configured.
- Add a shared `_config_with_override()` helper to keep the fallback logic centralized.
- Pass the configured diff and merge tools explicitly when launching them.
- Keep the normal settings and their overrides as separate UI fields.

### Verification

Tested manually in a dedicated Git repository:

1. Removed both `cola.difftool` and `diff.tool`.
2. Configured only `diff.tool` to `vimdiff`.
3. Verified that `diff.tool` was used when `cola.difftool` was unset.
4. Configured `cola.difftool` with a different tool.
5. Verified that `cola.difftool` took precedence.
6. Removed `cola.difftool` and verified that the configured `diff.tool` was used again.

All tested cases passed.

Closes #1632