### PR TITLE
Improve SVG image rendering in the diff viewer

### DIFF
--- a/cola/widgets/diff.py
+++ b/cola/widgets/diff.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from qtpy import QtCore
 from qtpy import QtGui
+from qtpy import QtSvg
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt
 from qtpy.QtCore import Signal
@@ -714,6 +715,7 @@ class Viewer(QtWidgets.QFrame):
         self.model = model = context.model
         self.images = []
         self.pixmaps = []
+        self.sources = []
         italic_font = self.font()
         italic_font.setItalic(True)
 
@@ -954,26 +956,39 @@ class Viewer(QtWidgets.QFrame):
     def set_images(self, images):
         self.images = images
         self.pixmaps = []
+        self.sources = []
         if not images:
             self.reset()
             return False
 
-        # In order to comp, we first have to load all the images
-        all_pixmaps = [QtGui.QPixmap(image[0]) for image in images]
-        pixmaps = [pixmap for pixmap in all_pixmaps if not pixmap.isNull()]
-        if not pixmaps:
+        # In order to comp, we first have to load all the images. SVGs are kept
+        # as renderers so they can be re-rasterised crisply at display size.
+        sources = [load_image_source(image[0]) for image in images]
+        sources = [source for source in sources if source is not None]
+        if not sources:
             self.reset()
             return False
 
-        self.pixmaps = pixmaps
+        self.sources = sources
+        self.pixmaps = [
+            source for source in sources if isinstance(source, QtGui.QPixmap)
+        ]
         self.render()
         self.cleanup()
         return True
 
     def render(self):
         # Update images
-        if self.pixmaps:
-            mode = self.options.image_mode.currentIndex()
+        mode = self.options.image_mode.currentIndex()
+        if self.sources and any(is_svg_source(source) for source in self.sources):
+            # Vector sources: hand the view a re-rasterising callback so the
+            # image stays sharp at any zoom level or device-pixel-ratio.
+            sources = self.sources
+            logical = comp_logical_size(sources, mode)
+            self.image.set_image_source(
+                lambda scale: render_comp_image(sources, mode, scale), logical
+            )
+        elif self.pixmaps:
             if mode == self.options.SIDE_BY_SIDE:
                 image = self.render_side_by_side()
             elif mode == self.options.DIFF:
@@ -984,9 +999,9 @@ class Viewer(QtWidgets.QFrame):
                 image = self.render_pixel_xor()
             else:
                 image = self.render_side_by_side()
+            self.image.pixmap = image
         else:
-            image = QtGui.QPixmap()
-        self.image.pixmap = image
+            self.image.pixmap = QtGui.QPixmap()
 
         # Apply zoom
         zoom_mode = self.options.zoom_mode.currentIndex()
@@ -996,6 +1011,8 @@ class Viewer(QtWidgets.QFrame):
             self.image.scale(zoom_factor, zoom_factor)
             poly = self.image.mapToScene(self.image.viewport().rect())
             self.image.last_scene_roi = poly.boundingRect()
+        # Re-rasterise any vector source at the resulting fixed-zoom scale.
+        self.image.update_render_resolution()
 
     def render_side_by_side(self):
         # Side-by-side lineup comp
@@ -1058,6 +1075,112 @@ def create_painter(image):
     painter = QtGui.QPainter(image)
     painter.fillRect(image.rect(), Qt.transparent)
     return painter
+
+
+def _comp_mode(mode):
+    """Map an Options mode index to its QPainter composition mode, or None."""
+    return {
+        Options.DIFF: QtGui.QPainter.CompositionMode_Difference,
+        Options.XOR: QtGui.QPainter.CompositionMode_Xor,
+        Options.PIXEL_XOR: QtGui.QPainter.RasterOp_SourceXorDestination,
+    }.get(mode)
+
+
+def load_image_source(path):
+    """Load an image path as a re-rasterisable SVG renderer or a QPixmap.
+
+    Returns a ``QtSvg.QSvgRenderer`` for valid SVGs, a non-null ``QPixmap`` for
+    raster images, or ``None`` when the file cannot be loaded.
+    """
+    if imageview.looks_like_svg(path):
+        renderer = QtSvg.QSvgRenderer(path)
+        if renderer.isValid():
+            return renderer
+    pixmap = QtGui.QPixmap(path)
+    if pixmap.isNull():
+        return None
+    return pixmap
+
+
+def is_svg_source(source):
+    return isinstance(source, QtSvg.QSvgRenderer)
+
+
+def source_logical_size(source):
+    """Return the logical size of an image source in device-independent pixels."""
+    if is_svg_source(source):
+        size = source.defaultSize()
+        if size.isEmpty():
+            size = source.viewBox().size()
+        return size
+    return source.size()
+
+
+def comp_logical_size(sources, mode):
+    """Logical size of the composited image for the given sources and mode."""
+    sizes = [source_logical_size(source) for source in sources]
+    if mode == Options.SIDE_BY_SIDE:
+        width = sum(size.width() for size in sizes)
+        height = max(size.height() for size in sizes)
+    else:
+        width = max(size.width() for size in sizes)
+        height = max(size.height() for size in sizes)
+    return QtCore.QSize(width, height)
+
+
+def paint_source(painter, source, rect):
+    """Paint a single image source into ``rect`` (a device-pixel QRectF)."""
+    if is_svg_source(source):
+        source.render(painter, rect)
+    else:
+        painter.drawPixmap(rect, source, QtCore.QRectF(source.rect()))
+
+
+def render_comp_image(sources, mode, scale):
+    """Composite ``sources`` at ``scale`` device pixels per logical unit.
+
+    The returned pixmap carries a device-pixel-ratio of ``scale`` so it occupies
+    the logical composited size while painting at higher resolution. SVGs are
+    rasterised directly at the target size, so they stay crisp.
+    """
+    sizes = [source_logical_size(source) for source in sources]
+    logical = comp_logical_size(sources, mode)
+    image = create_image(
+        max(1, int(round(logical.width() * scale))),
+        max(1, int(round(logical.height() * scale))),
+    )
+    painter = create_painter(image)
+    painter.setRenderHint(QtGui.QPainter.Antialiasing, True)
+    painter.setRenderHint(QtGui.QPainter.SmoothPixmapTransform, True)
+
+    if mode == Options.SIDE_BY_SIDE:
+        x = 0.0
+        for source, size in zip(sources, sizes):
+            rect = QtCore.QRectF(
+                x * scale, 0.0, size.width() * scale, size.height() * scale
+            )
+            paint_source(painter, source, rect)
+            x += size.width()
+    else:
+        comp_mode = _comp_mode(mode)
+        if len(sources) == 1:
+            pairs = [(sources[0], sizes[0])]
+        else:
+            pairs = [(sources[0], sizes[0]), (sources[-1], sizes[-1])]
+        for source, size in pairs:
+            x = (logical.width() - size.width()) / 2.0
+            y = (logical.height() - size.height()) / 2.0
+            rect = QtCore.QRectF(
+                x * scale, y * scale, size.width() * scale, size.height() * scale
+            )
+            paint_source(painter, source, rect)
+            if comp_mode is not None:
+                painter.setCompositionMode(comp_mode)
+    painter.end()
+
+    pixmap = QtGui.QPixmap.fromImage(image)
+    pixmap.setDevicePixelRatio(scale)
+    return pixmap
 
 
 class Options(QtWidgets.QWidget):

--- a/cola/widgets/imageview.py
+++ b/cola/widgets/imageview.py
@@ -32,6 +32,7 @@ import sys
 
 from qtpy import QtCore
 from qtpy import QtGui
+from qtpy import QtSvg
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt
 from qtpy.QtCore import Signal
@@ -50,6 +51,41 @@ main_loop_type = 'qt'
 
 def clamp(x, lo, hi):
     return max(min(x, hi), lo)
+
+
+def looks_like_svg(path):
+    """Cheaply decide whether ``path`` is an SVG before invoking QSvgRenderer.
+
+    Gating on this avoids Qt logging a parse warning for every raster image.
+    """
+    _, ext = os.path.splitext(path)
+    if ext.lower() in ('.svg', '.svgz'):
+        return True
+    try:
+        with open(path, 'rb') as handle:
+            head = handle.read(1024)
+    except OSError:
+        return False
+    return b'<svg' in head.lower()
+
+
+def render_svg_to_pixmap(renderer, logical_size, scale):
+    """Rasterise a QSvgRenderer at ``scale`` device pixels per logical unit.
+
+    The returned pixmap has its device-pixel-ratio set to ``scale`` so it
+    occupies ``logical_size`` scene units while painting at higher resolution.
+    """
+    width = max(1, int(round(logical_size.width() * scale)))
+    height = max(1, int(round(logical_size.height() * scale)))
+    image = QtGui.QImage(width, height, QtGui.QImage.Format_ARGB32)
+    image.fill(Qt.transparent)
+    painter = QtGui.QPainter(image)
+    painter.setRenderHint(QtGui.QPainter.Antialiasing, True)
+    renderer.render(painter, QtCore.QRectF(0, 0, width, height))
+    painter.end()
+    pixmap = QtGui.QPixmap.fromImage(image)
+    pixmap.setDevicePixelRatio(scale)
+    return pixmap
 
 
 class ImageView(QtWidgets.QGraphicsView):
@@ -71,6 +107,14 @@ class ImageView(QtWidgets.QGraphicsView):
         self.start_drag = QtCore.QPoint()
         self.checkerboard = None
 
+        # Optional vector source. When set, the displayed pixmap is
+        # re-rasterised on resize/zoom so SVGs stay crisp at any scale.
+        self._render_fn = None
+        self._logical_size = QtCore.QSize(0, 0)
+        self._render_scale = 0.0
+        self._max_render_pixels = 4096
+        self._rendering = False
+
         CHECK_MEDIUM = 8
         CHECK_GRAY = 0x80
         CHECK_LIGHT = 0xCC
@@ -90,6 +134,20 @@ class ImageView(QtWidgets.QGraphicsView):
         self.check_brush = QtGui.QBrush(check_pattern)
 
     def load(self, filename):
+        if looks_like_svg(filename):
+            renderer = QtSvg.QSvgRenderer(filename)
+            if renderer.isValid():
+                logical_size = renderer.defaultSize()
+                if logical_size.isEmpty():
+                    logical_size = renderer.viewBox().size()
+                if not logical_size.isEmpty():
+                    self.set_image_source(
+                        lambda scale: render_svg_to_pixmap(
+                            renderer, logical_size, scale
+                        ),
+                        logical_size,
+                    )
+                    return True
         image = QtGui.QImage()
         image.load(filename)
         ok = not image.isNull()
@@ -103,6 +161,9 @@ class ImageView(QtWidgets.QGraphicsView):
 
     @pixmap.setter
     def pixmap(self, image, image_format=None):
+        # A directly-assigned pixmap is a fixed raster; drop any vector source
+        # so resize/zoom does not try to re-rasterise stale content.
+        self._render_fn = None
         pixmap = None
         if have_numpy and isinstance(image, np.ndarray):
             if image.ndim == 3:
@@ -139,21 +200,76 @@ class ImageView(QtWidgets.QGraphicsView):
         else:
             raise TypeError(image)
 
-        if pixmap.hasAlpha():
-            checkerboard = QtGui.QImage(
-                pixmap.width(), pixmap.height(), QtGui.QImage.Format_ARGB32
-            )
-            self.checkerboard = checkerboard
-            painter = QtGui.QPainter(checkerboard)
-            painter.fillRect(checkerboard.rect(), self.check_brush)
-            painter.drawPixmap(0, 0, pixmap)
-            pixmap = QtGui.QPixmap.fromImage(checkerboard)
+        pixmap = self._composite_checkerboard(pixmap)
 
         self.graphics_pixmap.setPixmap(pixmap)
         self.update_scene_rect()
         self.fitInView(self.image_scene_rect, flags=Qt.KeepAspectRatio)
         self.graphics_pixmap.update()
         self.image_changed.emit()
+
+    def _composite_checkerboard(self, pixmap):
+        """Paint the checkerboard behind a pixmap that has an alpha channel.
+
+        Works in device pixels and preserves the pixmap's device-pixel-ratio so
+        hi-DPI vector rasters keep their logical size.
+        """
+        if not pixmap.hasAlpha():
+            return pixmap
+        dpr = pixmap.devicePixelRatio() or 1.0
+        checkerboard = QtGui.QImage(
+            pixmap.width(), pixmap.height(), QtGui.QImage.Format_ARGB32
+        )
+        self.checkerboard = checkerboard
+        painter = QtGui.QPainter(checkerboard)
+        painter.fillRect(checkerboard.rect(), self.check_brush)
+        # Draw into the full device rect so the pixmap's dpr does not shrink it.
+        painter.drawPixmap(QtCore.QRect(0, 0, pixmap.width(), pixmap.height()), pixmap)
+        painter.end()
+        result = QtGui.QPixmap.fromImage(checkerboard)
+        result.setDevicePixelRatio(dpr)
+        return result
+
+    def set_image_source(self, render_fn, logical_size):
+        """Display a re-rasterisable source (e.g. an SVG).
+
+        ``render_fn(scale)`` returns a QPixmap rendered at ``scale`` device
+        pixels per logical unit with its device-pixel-ratio set to ``scale``.
+        The image is re-rasterised as the on-screen size changes.
+        """
+        self._render_fn = render_fn
+        self._logical_size = logical_size
+        self._render_scale = 1.0
+        pixmap = self._composite_checkerboard(render_fn(1.0))
+        self.graphics_pixmap.setPixmap(pixmap)
+        self.update_scene_rect()
+        # fitInView re-rasterises at the fitted resolution via its tail hook.
+        self.fitInView(self.image_scene_rect, flags=Qt.KeepAspectRatio)
+        self.graphics_pixmap.update()
+        self.image_changed.emit()
+
+    def update_render_resolution(self):
+        """Re-rasterise the vector source to match the current on-screen size."""
+        if self._render_fn is None or self._rendering:
+            return
+        logical_w = max(1.0, float(self._logical_size.width()))
+        logical_h = max(1.0, float(self._logical_size.height()))
+        view_scale = abs(self.transform().m11())
+        needed = view_scale * self.viewport().devicePixelRatioF()
+        cap = self._max_render_pixels / max(logical_w, logical_h)
+        needed = clamp(needed, 1.0, max(1.0, cap))
+        # Hysteresis: skip small changes so panning/zoom does not thrash.
+        if self._render_scale / 2.0 <= needed <= self._render_scale * 1.25:
+            return
+        self._rendering = True
+        try:
+            pixmap = self._composite_checkerboard(self._render_fn(needed))
+            self.graphics_pixmap.setPixmap(pixmap)
+            self._render_scale = needed
+            self.update_scene_rect()
+            self.graphics_pixmap.update()
+        finally:
+            self._rendering = False
 
     # image property alias
     @property
@@ -166,17 +282,20 @@ class ImageView(QtWidgets.QGraphicsView):
 
     def update_scene_rect(self):
         pixmap = self.pixmap
+        dpr = pixmap.devicePixelRatio() or 1.0
         self.setSceneRect(
             QtCore.QRectF(
-                QtCore.QPointF(0, 0), QtCore.QPointF(pixmap.width(), pixmap.height())
+                QtCore.QPointF(0, 0),
+                QtCore.QPointF(pixmap.width() / dpr, pixmap.height() / dpr),
             )
         )
 
     @property
     def image_scene_rect(self):
-        return QtCore.QRectF(
-            self.graphics_pixmap.pos(), QtCore.QSizeF(self.pixmap.size())
-        )
+        pixmap = self.pixmap
+        dpr = pixmap.devicePixelRatio() or 1.0
+        size = QtCore.QSizeF(pixmap.width() / dpr, pixmap.height() / dpr)
+        return QtCore.QRectF(self.graphics_pixmap.pos(), size)
 
     def resizeEvent(self, event):
         super().resizeEvent(event)
@@ -355,6 +474,7 @@ class ImageView(QtWidgets.QGraphicsView):
             xratio = yratio = max(xratio, yratio)
         self.scale(xratio, yratio)
         self.centerOn(rect.center())
+        self.update_render_resolution()
 
 
 class AppImageView(ImageView):

--- a/test/imageview_test.py
+++ b/test/imageview_test.py
@@ -1,0 +1,120 @@
+"""Tests for crisp SVG rendering in the image diff viewer.
+
+These exercise the pure module-level helpers only (no widget event flow), so
+they stay deterministic in the full suite.
+"""
+import sys
+
+import pytest
+
+from cola.widgets import imageview
+from cola.widgets.diff import Options
+from cola.widgets.diff import comp_logical_size
+from cola.widgets.diff import is_svg_source
+from cola.widgets.diff import load_image_source
+from cola.widgets.diff import render_comp_image
+from cola.widgets.diff import source_logical_size
+from qtpy import QtGui
+from qtpy import QtSvg
+from qtpy import QtWidgets
+
+# A minimal SVG whose intrinsic size comes from viewBox alone (no width/height),
+# reproducing the syncthing.svg case that rendered blurry.
+SVG_BYTES = b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 118 118">' b'<circle cx="59" cy="59" r="59" fill="#0891d1"/></svg>'
+
+
+@pytest.fixture(scope='module')
+def qapp():
+    """Provide a QApplication for the QImage/QPixmap/QPainter helpers."""
+    instance = QtWidgets.QApplication.instance()
+    if instance is None:
+        instance = QtWidgets.QApplication(
+            sys.argv[:1] if sys.argv else ['git-cola-test']
+        )
+    yield instance
+
+
+@pytest.fixture
+def svg_path(tmp_path):
+    path = tmp_path / 'logo.svg'
+    path.write_bytes(SVG_BYTES)
+    return str(path)
+
+
+@pytest.fixture
+def png_path(tmp_path, qapp):
+    path = tmp_path / 'logo.png'
+    image = QtGui.QImage(32, 24, QtGui.QImage.Format_ARGB32)
+    image.fill(0)
+    image.save(str(path))
+    return str(path)
+
+
+def test_looks_like_svg_by_extension_and_content(svg_path, png_path, tmp_path):
+    assert imageview.looks_like_svg(svg_path)
+    assert not imageview.looks_like_svg(png_path)
+    # Content sniff wins even without a .svg extension.
+    disguised = tmp_path / 'logo.txt'
+    disguised.write_bytes(SVG_BYTES)
+    assert imageview.looks_like_svg(str(disguised))
+    # An unreadable file with a non-SVG extension is not treated as SVG.
+    assert not imageview.looks_like_svg(str(tmp_path / 'missing.png'))
+
+
+def test_load_image_source_detects_svg_vs_raster(qapp, svg_path, png_path):
+    svg_source = load_image_source(svg_path)
+    assert is_svg_source(svg_source)
+    assert isinstance(svg_source, QtSvg.QSvgRenderer)
+
+    raster_source = load_image_source(png_path)
+    assert not is_svg_source(raster_source)
+    assert isinstance(raster_source, QtGui.QPixmap)
+
+
+def test_load_image_source_returns_none_for_garbage(qapp, tmp_path):
+    junk = tmp_path / 'junk.bin'
+    junk.write_bytes(b'not an image')
+    assert load_image_source(str(junk)) is None
+
+
+def test_source_logical_size_uses_viewbox(qapp, svg_path):
+    size = source_logical_size(load_image_source(svg_path))
+    assert size.width() == 118
+    assert size.height() == 118
+
+
+def test_comp_logical_size(qapp, svg_path):
+    source = load_image_source(svg_path)
+    single = comp_logical_size([source], Options.SIDE_BY_SIDE)
+    assert (single.width(), single.height()) == (118, 118)
+    # Side-by-side lays two images out horizontally.
+    pair = comp_logical_size([source, source], Options.SIDE_BY_SIDE)
+    assert (pair.width(), pair.height()) == (236, 118)
+    # Comp modes overlay, so the canvas is the max of each dimension.
+    overlay = comp_logical_size([source, source], Options.DIFF)
+    assert (overlay.width(), overlay.height()) == (118, 118)
+
+
+@pytest.mark.parametrize(
+    'mode',
+    [Options.SIDE_BY_SIDE, Options.DIFF, Options.XOR, Options.PIXEL_XOR],
+)
+def test_render_comp_image_rasterises_at_scale(qapp, svg_path, mode):
+    source = load_image_source(svg_path)
+    pixmap = render_comp_image([source], mode, 4.0)
+    assert not pixmap.isNull()
+    # A 118-unit SVG rendered at 4x yields a 472px raster carrying dpr 4, so the
+    # scene keeps its 118 logical units while painting at higher resolution.
+    assert pixmap.devicePixelRatio() == 4.0
+    assert pixmap.width() == 472
+    assert pixmap.height() == 472
+
+
+def test_render_svg_to_pixmap_scales(qapp, svg_path):
+    renderer = load_image_source(svg_path)
+    size = source_logical_size(renderer)
+    pixmap = imageview.render_svg_to_pixmap(renderer, size, 3.0)
+    assert not pixmap.isNull()
+    assert pixmap.devicePixelRatio() == 3.0
+    assert pixmap.width() == 354
+    assert pixmap.height() == 354


### PR DESCRIPTION
I was staging an SVG and noticed the SVGs came up blurry in the image diff pane, while the PNG sitting right next to them looked fine, and the same SVG looks perfectly fine opened anywhere else.

It bugged me enough to go digging, and it turns out to be a rasterisation-size quirk rather than anything wrong with the files. I learnt way more about both qt and SVGs!

Before:

<img width="1511" height="943" alt="before-svg" src="https://github.com/user-attachments/assets/56a24799-725e-4173-9cf0-e90bdd061ffc" />

After:

<img width="1511" height="943" alt="after-svg" src="https://github.com/user-attachments/assets/a7ef6e76-e512-46af-b55e-ae22e44a4836" />

Note, PNGs DO work:

<img width="1511" height="943" alt="png-example" src="https://github.com/user-attachments/assets/f5bff413-9766-4afa-9413-e8f9be521915" />

## What's happening

The image diff viewer loads every file with `QtGui.QPixmap(path)` (`Viewer.set_images` in `cola/widgets/diff.py`). That reads a raster at its real pixels, so a 512x512 PNG barely rescales to fit the pane and stays sharp. An SVG, though, gets rasterised through Qt's `qsvg` plugin at its intrinsic size: a logo whose only size hint is `viewBox="0 0 118 118"` becomes a 118x118 bitmap, which `QGraphicsView` then upscales ~5x to fill the pane. Nothing in the image path used `QSvgRenderer` or the device pixel ratio, so the vector never got a chance to render at display size -- which is exactly what makes it look fine everywhere else.

## The fix

The idea is to make `ImageView` re-rasterise from a vector source instead of a fixed bitmap. 

The scene rect stays in the image's logical units (118), but the SVG is rendered to a `QImage` of `logical_size * render_scale` device pixels, wrapped in a pixmap with `setDevicePixelRatio(render_scale)`. The `QGraphicsPixmapItem` then occupies the logical size while painting at higher resolution, so all the existing `fitInView`/zoom maths stays untouched. `render_scale` is `abs(transform().m11()) * viewport().devicePixelRatioF()`, recomputed at the tail of `fitInView` (which resize, wheel-zoom, pan and reset all route through) and re-rasterised past a small hysteresis band, capped at 4096px so wheel-zoom doesn't thrash or balloon memory. It falls out nicely for rasters too: they have a device pixel ratio of 1, so `size() / dpr == size()` and their path is unchanged.

IMHO the fixed 4096px cap is fine, but I'm happy to turn it into a `cola.*` setting if you'd rather -- no strong feelings either way.

## What I tweaked

- `cola/widgets/imageview.py` gains `looks_like_svg()` (a cheap extension/content sniff that gates `QSvgRenderer` so raster images do not trigger a Qt parse warning), `render_svg_to_pixmap()`, `ImageView.set_image_source()`, `update_render_resolution()`, and a shared `_composite_checkerboard()` helper. `update_scene_rect`/`image_scene_rect` now size the scene in logical units (`width() / devicePixelRatio()`). The standalone image viewer's `ImageView.load()` is SVG-aware too.
- `cola/widgets/diff.py` gains `load_image_source()` (an SVG renderer or a `QPixmap`), `source_logical_size()`, `comp_logical_size()`, `paint_source()` and a scale-aware `render_comp_image()` that composites the side-by-side / diff / xor modes at a given scale and returns a dpr-tagged pixmap. `Viewer.render()` installs a re-rasterising callback via `set_image_source` when any source is an SVG, and keeps the existing raster path unchanged otherwise.

Happy for this to be split into smaller pieces, or reworked entirely -- take whatever's useful (none, some, all, I really don't mind :-)).

## References

Here are some doc references I used (I have these docs cloned locally to ripgrep through, makes it SOO much easier when working with qt!!).

- [`QPixmap`](https://doc.qt.io/qt-6/qpixmap.html) -- the file-path constructor rasterises at the format's intrinsic size and is the source of the blur; the fix instead tags the rendered pixmap with [`setDevicePixelRatio()`](https://doc.qt.io/qt-6/qpixmap.html#setDevicePixelRatio).
- [`QSvgRenderer`](https://doc.qt.io/qt-6/qsvgrenderer.html) -- vector rendering: [`isValid()`](https://doc.qt.io/qt-6/qsvgrenderer.html#isValid), [`defaultSize`](https://doc.qt.io/qt-6/qsvgrenderer.html#defaultSize), [`viewBox`](https://doc.qt.io/qt-6/qsvgrenderer.html#viewBox-prop) and [`render()`](https://doc.qt.io/qt-6/qsvgrenderer.html#render). PyQt6 binding: [riverbankcomputing.com/.../qsvgrenderer.html](https://www.riverbankcomputing.com/static/Docs/PyQt6/api/qtsvg/qsvgrenderer.html).
- [High DPI Displays](https://doc.qt.io/qt-6/highdpi.html) and [`QPaintDevice::devicePixelRatioF()`](https://doc.qt.io/qt-6/qpaintdevice.html#devicePixelRatioF) -- the device-independent vs device pixel model the render scale is derived from.
- [`QGraphicsView::fitInView()`](https://doc.qt.io/qt-6/qgraphicsview.html#fitInView) and [`QTransform::m11()`](https://doc.qt.io/qt-6/qtransform.html#m11) -- how the view scales the scene, and the horizontal scale factor the re-rasterise resolution reads from.
- [`QGraphicsPixmapItem::setTransformationMode()`](https://doc.qt.io/qt-6/qgraphicspixmapitem.html#setTransformationMode) -- the item defaults to `Qt::FastTransformation` (nearest-neighbour), so an under-sized raster is scaled up without smoothing; rendering the vector at display resolution avoids relying on it.
- [`QPainter::RenderHint`](https://doc.qt.io/qt-6/qpainter.html#RenderHint-enum) -- `Antialiasing` and `SmoothPixmapTransform`, set on the compositing painter in `render_comp_image()`.
