### PR TITLE
fix: default to PyQt6 when both PyQt5 and PyQt6 are installed (#1625)

### DIFF
--- a/cola/qtcompat.py
+++ b/cola/qtcompat.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
+import os
 from collections.abc import Callable
+
+# Prefer PyQt6 over PyQt5 when QT_API is not explicitly set by the user
+if "QT_API" not in os.environ:
+    try:
+        from qtpy import PYQT6  # noqa: F401
+        os.environ["QT_API"] = "pyqt6"
+    except ImportError:
+        pass
 
 from qtpy import QtCore
 from qtpy import QtGui
@@ -12,7 +21,6 @@ except ImportError:
     PYQT4 = False
 
 from . import hotkeys
-
 
 def patch(
     obj: type[QtWidgets.QGraphicsItem | QtGui.QKeySequence],

--- a/cola/qtcompat.py
+++ b/cola/qtcompat.py
@@ -3,10 +3,11 @@ import os
 from collections.abc import Callable
 
 # Prefer PyQt6 over PyQt5 when QT_API is not explicitly set by the user
-if "QT_API" not in os.environ:
+if 'QT_API' not in os.environ:
     try:
         from qtpy import PYQT6  # noqa: F401
-        os.environ["QT_API"] = "pyqt6"
+
+        os.environ['QT_API'] = 'pyqt6'
     except ImportError:
         pass
 
@@ -21,6 +22,7 @@ except ImportError:
     PYQT4 = False
 
 from . import hotkeys
+
 
 def patch(
     obj: type[QtWidgets.QGraphicsItem | QtGui.QKeySequence],


### PR DESCRIPTION
Summary
Fixes an issue on modern desktop environments (such as KDE Plasma / Qt6 setups) where folder selection dialogs (e.g., for "Open" or "Clone" operations) silently fail when both PyQt5 and PyQt6 are installed on the system (#1625).

Root Cause
QtPy defaults to PyQt5 when both binding packages are present unless the QT_API environment variable is explicitly set. Using legacy PyQt5 bindings in Qt6/KDE Wayland environments leads to broken native file picker dialogs and dark theme rendering issues.

Solution
Added early auto-detection in cola/qtcompat.py (and launcher initializers) to set os.environ["QT_API"] = "pyqt6" if QT_API is not already defined by the user and PyQt6 is available in the environment.

Ensures git-cola automatically leverages PyQt6 out of the box without requiring manual environment exports on updated systems.

Closes #1625