### PR TITLE
qt: prefer PyQt6 when QT_API is unset and PyQt6 is installed (#1625)

### DIFF
--- a/cola/__init__.py
+++ b/cola/__init__.py
@@ -1,0 +1,19 @@
+"""Git Cola package initialization."""
+from __future__ import annotations
+import importlib.util
+import os
+
+
+def auto_select_qt_api() -> None:
+    """Default to PyQt6 when QT_API is unset and PyQt6 is installed.
+
+    QtPy defaults to PyQt5 when available, which causes regressions in modern
+    desktop environments (such as KDE Plasma 6 on Wayland) where Qt5 file portal
+    dialogs fail (#1625). If QT_API is not explicitly set by the user, prefer PyQt6.
+    """
+    if 'QT_API' not in os.environ:
+        if importlib.util.find_spec('PyQt6') is not None:
+            os.environ['QT_API'] = 'pyqt6'
+
+
+auto_select_qt_api()

--- a/test/qt_api_test.py
+++ b/test/qt_api_test.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+import importlib.machinery
+import os
+from unittest.mock import patch
+
+from cola import auto_select_qt_api
+
+
+def test_auto_select_qt_api_prefers_pyqt6(monkeypatch):
+    monkeypatch.delenv('QT_API', raising=False)
+    fake_spec = importlib.machinery.ModuleSpec('PyQt6', None)
+    with patch('importlib.util.find_spec', return_value=fake_spec):
+        auto_select_qt_api()
+    assert os.environ.get('QT_API') == 'pyqt6'
+
+
+def test_auto_select_qt_api_preserves_explicit_qt_api(monkeypatch):
+    monkeypatch.setenv('QT_API', 'pyqt5')
+    fake_spec = importlib.machinery.ModuleSpec('PyQt6', None)
+    with patch('importlib.util.find_spec', return_value=fake_spec):
+        auto_select_qt_api()
+    assert os.environ.get('QT_API') == 'pyqt5'
+
+
+def test_auto_select_qt_api_noop_when_pyqt6_missing(monkeypatch):
+    monkeypatch.delenv('QT_API', raising=False)
+    with patch('importlib.util.find_spec', return_value=None):
+        auto_select_qt_api()
+    assert 'QT_API' not in os.environ


### PR DESCRIPTION
QtPy defaults to PyQt5 when available. On modern Linux desktop environments such as KDE Plasma 6 (Wayland), running with Qt5 causes native portal folder dialogs (e.g. for 'Open Git Repository' or 'Clone') to silently fail to open or pick folders, as well as severe dark theme contrast issues (#1625).

Use importlib.util.find_spec() during package initialization in cola/__init__.py to detect PyQt6 presence without importing it, and default QT_API to 'pyqt6' if not already explicitly set in os.environ. If QT_API is already specified by the user or script, that setting is preserved.